### PR TITLE
fix: typo in installing cnr sample yaml

### DIFF
--- a/install.md
+++ b/install.md
@@ -440,7 +440,7 @@ To install Cloud Native Runtimes:
      internal:
        namespace:    
 
-    Local_dns:
+    local_dns:
     ```
 
     In TKG environments, Contour addons that are already be present might conflict


### PR DESCRIPTION
* Local_dns does not need to be capitalized as the
rest of the fields are all lowercase