### PR TITLE
remove reference to package plugin (step 4)

### DIFF
--- a/install-intro.md
+++ b/install-intro.md
@@ -11,7 +11,7 @@ The process of installing Tanzu Application Platform includes the following task
 |1.| Reviewing the prerequisites, ensure that you have set up everything you need before beginning the installation.|[Prerequisites](install-general.md#prereqs)|
 |2.| Verifying the Kubernetes Cluster configurations.|[Set and Verify the Kubernetes Cluster Configurations](install-general.md#set-and-verify)|
 |3.| Accepting the end user license agreements.|[Accept the EULAs](install-general.md#eulas)|
-|4.| Installing the Tanzu command line interface (CLI) and the package plugin for the Tanzu CLI.|[Install the Tanzu CLI and Package Plugin](install-general.md#cli-and-plugin)|
+|4.| Installing the Tanzu command line interface (CLI) and plugins for the Tanzu CLI.|[Install the Tanzu CLI and Plugins](install-general.md#cli-and-plugin)|
 |5.| Adding the Tanzu Application Platform package repository to the cluster.|[Add the Tanzu Application Platform Package Repository](install.md#add-package-repositories)|
 |6.| Installing each package to the cluster.|[Installing the Packages](install.md)|
 |7.| Verifying that the packages installed.|[Verify the Installed Packages](install.md#verify)|


### PR DESCRIPTION
the package plugin comes pre-installed so shouldn't be referenced directly in this copy.
there are other plugins that must be installed, so referring to them generally is appropriate.