### PR TITLE
add troubleshooting steps for mac CLI install

### DIFF
--- a/install-general.md
+++ b/install-general.md
@@ -124,19 +124,20 @@ The following prerequisites are required to install Tanzu Application Platform:
         ```
         kapp deploy --yes -a cert-manager -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
         ```
-        We have Qualified TAP repo bundle packages installation with cert-manager version v1.5.3.
+        We have verified the TAP repo bundle packages installation with cert-manager version v1.5.3.
         
         * Verify installed cert-manager version by running:
 
         ```
-        kubectl get deployment cert-manager -n cert-manager -o yaml | grep app.kubernetes.io/version
+        kubectl get deployment cert-manager -n cert-manager -o yaml | grep 'app.kubernetes.io/version: v'
         ```
 
         For example:
 
         ```
-        kubectl get deployment cert-manager -n cert-manager -o yaml | grep app.kubernetes.io/version
-        "app.kubernetes.io/version": v0.5.0
+        kubectl get deployment cert-manager -n cert-manager -o yaml | grep 'app.kubernetes.io/version: v'
+           app.kubernetes.io/version: v1.5.3
+              app.kubernetes.io/version: v1.5.3
         ```
 
 
@@ -323,7 +324,16 @@ To install the Tanzu CLI on a Mac operating system:
    ```
    tanzu version
    ```
+**If running `tanzu version` causes the following macOS warning to be displayed:** "tanzu" cannot be opened because the developer cannot be verified:
+  1. Click the Cancel button in the macOS prompt window.
+  2. Open the “Security & Privacy” control panel from System Preferences.
+  3. Click on the “General” tab.
+  4. Click “Allow Anyway” next to the warning message for the tanzu binary.
+  5. Enter your system username and password in the macOS prompt window to confirm the changes.
+  6. Execute the `tanzu version` command in the term window again.
+  7. Click “Open” in the macOS prompt window.
 
+After completing the steps above, there should be no more security issues while running Tanzu CLI commands.
 
 ### <a id='windows-cli'></a> Windows: Install the Tanzu CLI
 


### PR DESCRIPTION
Mac prevents users from running software downloaded via a browser.
I've added steps to follow to work around this limitation.

I also updated a typo in the verification steps for installing cert-manager