### PR TITLE
Application Live connector_namespaces must exist

### DIFF
--- a/install.md
+++ b/install.md
@@ -414,7 +414,7 @@ To install Application Live View:
     connector_namespaces: [foo, bar]
     server_namespace: tap-install
     ```
-    The server_namespace is the namespace to which the Application Live View server is deployed. Typically you should pick the namespace you created earlier, tap-install. The connector_namespaces should be a list of namespaces in which you want Application Live View to monitor your apps. To each of those namespace an instance of the Application Live View Connector will be deployed.
+    The server_namespace is the namespace to which the Application Live View server is deployed. Typically you should pick the namespace you created earlier, tap-install. The connector_namespaces should be a list of existing namespaces in which you want Application Live View to monitor your apps. To each of those namespace an instance of the Application Live View Connector will be deployed.
 
 5. Install the package by running:
 


### PR DESCRIPTION
If these namespaces do not exist, then the installation will fail.