### PR TITLE
Move TBS install docs before Supply Chain Choreographer

### DIFF
--- a/install.md
+++ b/install.md
@@ -473,6 +473,104 @@ To install Source Controller:
 
     STATUS should be `Running`.
 
+## <a id='install-tbs'></a> Install Tanzu Build Service
+
+This section provides a quick-start guide for installing Tanzu Build Service as part of Tanzu Application Platform using the Tanzu CLI.
+
+**Note**: This procedure might not include some configurations required for your specific environment. For more advanced details on installing Tanzu Build Service, see [Installing Tanzu Build Service](https://docs.pivotal.io/build-service/installing.html).
+
+
+### Prerequisites
+
+* You have access to a Docker registry that Tanzu Build Service can use to create Builder images. Approximately 5GB of registry space is required.
+* Your Docker registry is accesible with username and password credentials.
+
+
+### Install Tanzu Build Service Using the Tanzu CLI
+
+To install Tanzu Build Service using the Tanzu CLI:
+
+1. Follow the instructions in [Install Packages](#install-packages) above.
+
+1. Gather values schema.
+
+    ```bash
+    tanzu package available get buildservice.tanzu.vmware.com/1.3.0 --values-schema --namespace tap-install
+    ```
+
+    For example:
+
+    ```bash
+    $ tanzu package available get buildservice.tanzu.vmware.com/1.3.0 --values-schema --namespace tap-install
+    | Retrieving package details for buildservice.tanzu.vmware.com/1.3.0...
+      KEY                             DEFAULT  TYPE    DESCRIPTION
+      kp_default_repository           <nil>    string  docker repository
+      kp_default_repository_password  <nil>    string  registry password
+      kp_default_repository_username  <nil>    string  registry username
+      tanzunet_username               <nil>    string  tanzunet registry username required for dependency updater feature
+      tanzunet_password               <nil>    string  tanzunet registry password required for dependency updater feature
+      ca_cert_data                    <nil>    string  tbs registry ca certificate
+    ```
+
+1. Create a `tbs-values.yaml` file.
+
+    ```yaml
+    ---
+    kp_default_repository: EXAMPLE-REGISTRY/PATH-TO-INSTALL
+    kp_default_repository_username: REGISTRY-USERNAME
+    kp_default_repository_password: REGISTRY-PASSWORD
+    tanzunet_username: TANZUNET-USERNAME
+    tanzunet_password: TANZUNET-PASSWORD
+    ```
+    Where:
+        * `EXAMPLE-REGISTRY` is the URL of the Docker registry.
+        * `PATH-TO-INSTALL` is the path to the registry install location. `kp_default_repository` is the registry location where all Tanzu Build Services dependencies and builder images are written.
+        * `REGISTRY-USERNAME` and `REGISTRY-PASSWORD` are the username and password for the registry. The install requires a `kp_default_repository_username` and `kp_default_repository_password` in order to write to the repository location.
+        * `TANZUNET-USERNAME` and `TANZUNET-PASSWORD` are the email address and password that you use to log in to Tanzu Network. The Tanzu Network credentials allow for configuration of the Dependencies Updater.  This resource accesses and installs the build dependencies (buildpacks and stacks) Tanzu Build Service needs on your Cluster.  It also keeps these dependencies up-to-date as new versions are released on Tanzu Network.
+        * **Optional values**: There are optional values not included in this sample file that provide additional configuration for production use cases. For more information, see [Installing Tanzu Build Service](https://docs.pivotal.io/build-service/installing.html).
+
+1. Install the package by running:
+
+    ```bash
+    tanzu package install tbs -p buildservice.tanzu.vmware.com -v 1.3.0 -n tap-install -f tbs-values.yaml --poll-timeout 30m
+    ```
+
+    **Note**: Installing the `buildservice.tanzu.vmware.com` package with Tanzu Net credentials automatically relocates buildpack dependencies to your cluster. This install process can take some time.  The command provided above increases the timeout duration to account for this.  If the command still times out, periodically run the installation verification step provided below because image relocation will continue in the background.   
+
+    For example:
+
+    ```bash
+    $ tanzu package install tbs -p buildservice.tanzu.vmware.com -v 1.3.0 -n tap-install -f tbs-values.yaml
+    | Installing package 'buildservice.tanzu.vmware.com'
+    | Getting namespace 'tap-install'
+    | Getting package metadata for 'buildservice.tanzu.vmware.com'
+    | Creating service account 'tbs-tap-install-sa'
+    | Creating cluster admin role 'tbs-tap-install-cluster-role'
+    | Creating cluster role binding 'tbs-tap-install-cluster-rolebinding'
+    | Creating secret 'tbs-tap-install-values'
+    - Creating package resource
+    - Package install status: Reconciling
+
+     Added installed package 'tbs' in namespace 'tap-install'
+    ```
+
+1. (Optional) Run the following command to verify the clusterbuilders created by the Tanzu Build Service install:
+
+    ```bash
+    kubectl get clusterbuilders
+    ```
+
+    For example:
+
+    ```bash
+    $ kubectl get clusterbuilders
+
+    NAME      LATESTIMAGE                                                                                      READY
+    base      my-registry.com/tbs@sha256:8732fadb92d8afa40bcef2d885e9730b372484a39b4a7f718291f574645f4bf2      True
+    default   my-registry.com/tbs@sha256:8732fadb92d8afa40bcef2d885e9730b372484a39b4a7f718291f574645f4bf2      True
+    full      my-registry.com/tbs@sha256:f7cdac8b2d97790276821ee3f54c497fba4ec71752eec9a87d22905344471ed8      True
+    tiny      my-registry.com/tbs@sha256:b9c5348da4c1527c356d2d8b9d48462ea9bf97a98eb379e925bec69c6dd918a5      True
+    ```
 
 ## <a id='install-scc'></a> Install Supply Chain Choreographer
 
@@ -886,107 +984,6 @@ To install Application Live View:
     manager-6d85fffbcd-j4gvs   1/1     Running   0          22s
     ```
     STATUS should be `Running`.
-
-
-## <a id='install-tbs'></a> Install Tanzu Build Service
-
-This section provides a quick-start guide for installing Tanzu Build Service as part of Tanzu Application Platform using the Tanzu CLI.
-
-**Note**: This procedure might not include some configurations required for your specific environment. For more advanced details on installing Tanzu Build Service, see [Installing Tanzu Build Service](https://docs.pivotal.io/build-service/installing.html).
-
-
-### Prerequisites
-
-* You have access to a Docker registry that Tanzu Build Service can use to create Builder images. Approximately 5GB of registry space is required.
-* Your Docker registry is accesible with username and password credentials.
-
-
-### Install Tanzu Build Service Using the Tanzu CLI
-
-To install Tanzu Build Service using the Tanzu CLI:
-
-1. Follow the instructions in [Install Packages](#install-packages) above.
-
-1. Gather values schema.
-
-    ```bash
-    tanzu package available get buildservice.tanzu.vmware.com/1.3.0 --values-schema --namespace tap-install
-    ```
-
-    For example:
-
-    ```bash
-    $ tanzu package available get buildservice.tanzu.vmware.com/1.3.0 --values-schema --namespace tap-install
-    | Retrieving package details for buildservice.tanzu.vmware.com/1.3.0...
-      KEY                             DEFAULT  TYPE    DESCRIPTION
-      kp_default_repository           <nil>    string  docker repository
-      kp_default_repository_password  <nil>    string  registry password
-      kp_default_repository_username  <nil>    string  registry username
-      tanzunet_username               <nil>    string  tanzunet registry username required for dependency updater feature
-      tanzunet_password               <nil>    string  tanzunet registry password required for dependency updater feature
-      ca_cert_data                    <nil>    string  tbs registry ca certificate
-    ```
-
-1. Create a `tbs-values.yaml` file.
-
-    ```yaml
-    ---
-    kp_default_repository: EXAMPLE-REGISTRY/PATH-TO-INSTALL
-    kp_default_repository_username: REGISTRY-USERNAME
-    kp_default_repository_password: REGISTRY-PASSWORD
-    tanzunet_username: TANZUNET-USERNAME
-    tanzunet_password: TANZUNET-PASSWORD
-    ```
-    Where:
-        * `EXAMPLE-REGISTRY` is the URL of the Docker registry.
-        * `PATH-TO-INSTALL` is the path to the registry install location. `kp_default_repository` is the registry location where all Tanzu Build Services dependencies and builder images are written.
-        * `REGISTRY-USERNAME` and `REGISTRY-PASSWORD` are the username and password for the registry. The install requires a `kp_default_repository_username` and `kp_default_repository_password` in order to write to the repository location.
-        * `TANZUNET-USERNAME` and `TANZUNET-PASSWORD` are the email address and password that you use to log in to Tanzu Network. The Tanzu Network credentials allow for configuration of the Dependencies Updater.  This resource accesses and installs the build dependencies (buildpacks and stacks) Tanzu Build Service needs on your Cluster.  It also keeps these dependencies up-to-date as new versions are released on Tanzu Network.
-        * **Optional values**: There are optional values not included in this sample file that provide additional configuration for production use cases. For more information, see [Installing Tanzu Build Service](https://docs.pivotal.io/build-service/installing.html).
-
-1. Install the package by running:
-
-    ```bash
-    tanzu package install tbs -p buildservice.tanzu.vmware.com -v 1.3.0 -n tap-install -f tbs-values.yaml --poll-timeout 30m
-    ```
-
-    **Note**: Installing the `buildservice.tanzu.vmware.com` package with Tanzu Net credentials automatically relocates buildpack dependencies to your cluster. This install process can take some time.  The command provided above increases the timeout duration to account for this.  If the command still times out, periodically run the installation verification step provided below because image relocation will continue in the background.   
-
-    For example:
-
-    ```bash
-    $ tanzu package install tbs -p buildservice.tanzu.vmware.com -v 1.3.0 -n tap-install -f tbs-values.yaml
-    | Installing package 'buildservice.tanzu.vmware.com'
-    | Getting namespace 'tap-install'
-    | Getting package metadata for 'buildservice.tanzu.vmware.com'
-    | Creating service account 'tbs-tap-install-sa'
-    | Creating cluster admin role 'tbs-tap-install-cluster-role'
-    | Creating cluster role binding 'tbs-tap-install-cluster-rolebinding'
-    | Creating secret 'tbs-tap-install-values'
-    - Creating package resource
-    - Package install status: Reconciling
-
-     Added installed package 'tbs' in namespace 'tap-install'
-    ```
-
-1. (Optional) Run the following command to verify the clusterbuilders created by the Tanzu Build Service install:
-
-    ```bash
-    kubectl get clusterbuilders
-    ```
-
-    For example:
-
-    ```bash
-    $ kubectl get clusterbuilders
-
-    NAME      LATESTIMAGE                                                                                      READY
-    base      my-registry.com/tbs@sha256:8732fadb92d8afa40bcef2d885e9730b372484a39b4a7f718291f574645f4bf2      True
-    default   my-registry.com/tbs@sha256:8732fadb92d8afa40bcef2d885e9730b372484a39b4a7f718291f574645f4bf2      True
-    full      my-registry.com/tbs@sha256:f7cdac8b2d97790276821ee3f54c497fba4ec71752eec9a87d22905344471ed8      True
-    tiny      my-registry.com/tbs@sha256:b9c5348da4c1527c356d2d8b9d48462ea9bf97a98eb379e925bec69c6dd918a5      True
-    ```
-
 
 ## <a id='install-scst-store'></a> Install Supply Chain Security Tools - Store
 


### PR DESCRIPTION
Place TBS docs before cartographer since the default-supply-chain relies on tbs and cartographer lists tbs as a prereq.