### PR TITLE
default supply chain: update value schema

### DIFF
--- a/install.md
+++ b/install.md
@@ -667,9 +667,13 @@ Added installed package 'cartographer' in namespace 'default'
    ```console
    $ tanzu package available get default-supply-chain.tanzu.vmware.com/0.2.0 --values-schema -n tap-install
    | Retrieving package details for default-supply-chain.tanzu.vmware.com/0.2.0...
-     KEY                  DEFAULT                  TYPE    DESCRIPTION
-     registry.repository  sample-repo              string  Registry repository
-     registry.server      https://yourregistry.io  string  registry hostname
+
+    KEY                  DEFAULT          TYPE    DESCRIPTION
+    registry.repository  <nil>            string  Name of the repository in the image registry server where the application images from the workloads should be pushed to (required).
+    registry.server      index.docker.io  string  Name of the registry server where application images should be pushed to.
+    service_account      default          string  Name of the service account in the namespace where the Workload is submitted to utilize for providing registry credentials to Tanzu Build Service (TBS) Image objects as well as deploying the application.
+    templates_namespace  tap-install      string  Name of the namespace where shared templates are installed to. This variable should point to the namespace where this package is being installed into.
+    cluster_builder      default          string  Name of the Tanzu Build Service (TBS) ClusterBuilder to use by default on image objects managed by the supply chain.
    ```
 
 1. Gather the values schema.
@@ -683,6 +687,7 @@ Added installed package 'cartographer' in namespace 'default'
      server: REGISTRY_SERVER
      repository: REGISTRY_REPOSITORY
    service_account: service-account
+   templates_namespace: tap-install
    ```
 
 1. Create a secret called `registry-credentials` with the credentials for the registry that you want the supply chain to use.


### PR DESCRIPTION
we recently updates the values schema to account for two things:

1. providing detailed information about each field (like,
   `service_account and templates_namespace`)
2. introducing `templates_namespace` for configuring where
   carto.run/Pipeline should look for a RunTemplate so that it works
   regardless of the namespace where its submitted to.

ps.: `tempaltes_namespace` is only available in the latest version (as
of .. right now :sweat_smile:) of the package:

- registry.tanzu.vmware.com/default-supply-chain-testing/source-test-to-url@sha256:9558ebbb8423ef3c2ce0600c82c496ece3efcf58fdfb911be304784e189bb479

Signed-off-by: Ciro S. Costa <ciroscosta@vmware.com>