### PR TITLE
Fix Broken link, fix list, and address comment for metadata store cert

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -743,7 +743,7 @@ For a complete guide on how to query the store, see [Querying Supply Chain Secur
 #### Example Supply Chain including Source and Image Scans
 
 One of the out-of-the-box supply chains we are working on for a future release will include image and source code vulnerability scanning and metadata storage into a preset Tanzu Application Platform supply chain. Until then, you can use this example to see how to try this out:
-[Example Supply Chain including Source and Image Scans](https://docs-staging.vmware.com/en/VMware-Tanzu-Application-Platform/0.2/tap-0-2/GUID-scst-scan-cartographer.html).
+[Example Supply Chain including Source and Image Scans](https://docs-staging.vmware.com/en/VMware-Tanzu-Application-Platform/0.2/tap-0-2/GUID-scst-scan-choreographer.html).
 
 **Next Steps and Further Information**
 

--- a/install.md
+++ b/install.md
@@ -1212,7 +1212,7 @@ To install Supply Chain Security Tools - Scan (Scan Controller):
       xargs kubectl -n metadata-store get -o jsonpath='{.spec.ports[].name}{"://"}{.metadata.name}{"."}{.metadata.namespace}{".svc.cluster.local:"}{.spec.ports[].port}'
     ```
 
-    The `metadataStoreCa` value can be determined by (when pasting, ensure the certificate is indented by two spaces):
+    The `metadataStoreCa` value can be determined by (when pasting this output into the `scst-scan-controller-values.yaml`, ensure the certificate is indented by two spaces as shown in the `scst-scan-controller-values.yaml` sample above):
 
     ```bash
     kubectl get secret app-tls-cert -n metadata-store -o json | jq -r '.data."ca.crt"' | base64 -d

--- a/install.md
+++ b/install.md
@@ -1187,6 +1187,8 @@ To install Supply Chain Security Tools - Scan (Scan Controller):
 1. Gather the values schema.
 1. Create a `scst-scan-controller-values.yaml` using the following sample as a guide:
 
+    Ensure the certificate is indented by two spaces as shown in the sample below.
+
     Sample `scst-scan-controller-values.yaml` for Scan Controller:
 
     ```yaml
@@ -1212,7 +1214,7 @@ To install Supply Chain Security Tools - Scan (Scan Controller):
       xargs kubectl -n metadata-store get -o jsonpath='{.spec.ports[].name}{"://"}{.metadata.name}{"."}{.metadata.namespace}{".svc.cluster.local:"}{.spec.ports[].port}'
     ```
 
-    The `metadataStoreCa` value can be determined by (when pasting this output into the `scst-scan-controller-values.yaml`, ensure the certificate is indented by two spaces as shown in the `scst-scan-controller-values.yaml` sample above):
+    The `metadataStoreCa` value can be determined by:
 
     ```bash
     kubectl get secret app-tls-cert -n metadata-store -o json | jq -r '.data."ca.crt"' | base64 -d

--- a/scst-scan/choreographer.md
+++ b/scst-scan/choreographer.md
@@ -7,6 +7,7 @@ This example takes every source code commit, scans the source code for vulnerabi
 Follow the steps listed in [Installing Part I: Prerequisites, Cluster Configurations, EULA, and CLI](https://github.com/pivotal/docs-tap/blob/main/install-general.md).
 
 Next, in [Installing Part II: Packages](https://github.com/pivotal/docs-tap/blob/main/install.md), ensure the following packages and their dependencies are installed:
+
 - [Supply Chain Choreographer](https://github.com/pivotal/docs-tap/blob/main/install.md#-install-supply-chain-choreographer)
 - [Tanzu Build Service](https://github.com/pivotal/docs-tap/blob/main/install.md#install-tbs)
 - [Supply Chain Security Tools - Store](https://github.com/pivotal/docs-tap/blob/main/install.md#install-scst-store)


### PR DESCRIPTION
Summary:
* FIxing listing of https://docs-staging.vmware.com/en/VMware-Tanzu-Application-Platform/0.2/tap-0-2/GUID-scst-scan-choreographer.html
* Fix link on this page https://docs-staging.vmware.com/en/VMware-Tanzu-Application-Platform/0.2/tap-0-2/GUID-getting-started.html#scan--store-introducing-vulnerability-scanning--metadata-storage-to-your-supply-chain-15 where it says "Example Supply Chain including Source and Image Scans"
* Address https://github.com/pivotal/docs-tap/pull/207#issuecomment-934896602 comment here.