### PR TITLE
TANZUSC-455 Adds CNR namespace clarification

### DIFF
--- a/install.md
+++ b/install.md
@@ -268,6 +268,7 @@ To install Cloud Native Runtimes:
    then skip this step because namespace configuration is covered in
    [Set Up Developer Namespaces to Use Installed Packages](#setup) below.
 
+   **Note:** You must complete following steps for each namespace where you create Knative services.
 
    Service accounts which run workloads using Cloud Native Runtimes need to have access to the image pull secrets for the Tanzu package.
    This includes the `default` service account in a namespace, which is created automatically but not associated with any image pull secrets.


### PR DESCRIPTION
* the namespace is not identified for this step in the CNR docs
* users should do this for every namespace they intend to deploy
knative services

Co-authored-by: David Solomon <solomond@vmware.com>