### PR TITLE
TANZUSC-456 Update CNR install example

### DIFF
--- a/install.md
+++ b/install.md
@@ -286,13 +286,13 @@ To install Cloud Native Runtimes:
    run the following command to add the secret to the service account:
 
    ```console
-   kubectl patch serviceaccount SERVICEACCOUNT -p '{"imagePullSecrets": [{"name": "pull-secret"}]}'
+   kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "pull-secret"}]}'
    ```
 
    You can verify that a service account is correctly configured by running:
 
    ```console
-   kubectl describe serviceaccount SERVICEACCOUNT
+   kubectl describe serviceaccount default
    ```
 
    For example:


### PR DESCRIPTION
* In this step of CNR installation, using `default`
for the service account is the straight forward
way to complete the installation

Co-authored-by: David Solomon <solomond@vmware.com>