### PR TITLE
Fix link to metadata store to not be hardcoded, remove '-ing' usage

### DIFF
--- a/install.md
+++ b/install.md
@@ -1181,7 +1181,7 @@ Ensure both are installed.
 To install Supply Chain Security Tools - Scan (Scan Controller):
 
 **Prerequisite**: Supply Chain Security Tools - Store installed on the cluster.
-See [Install Supply Chain Security Tools - Store](https://docs-staging.vmware.com/en/VMware-Tanzu-Application-Platform/0.2/tap-0-2/GUID-install.html#install-supply-chain-security-tools--store-15).
+See [Install Supply Chain Security Tools - Store](#install-scst-store).
 
 1. Follow the instructions in [Install Packages](#install-packages) above.
 

--- a/scst-scan/running-scans.md
+++ b/scst-scan/running-scans.md
@@ -73,7 +73,7 @@ For more information, refer to [Observing and Troubleshooting](observing.md).
 kubectl apply -f policy-enforcement-example.yaml
 ```
 
-### View the Results
+### View the Scan Results
 Once the scan has completed, perform:
 ```bash
 kubectl describe sourcescan policy-enforcement-example
@@ -205,7 +205,7 @@ For more information about setting up a watch, see [Observing and Troubleshootin
 kubectl apply -f image-policy-enforcement-example.yaml
 ```
 
-### View the Results
+### View the Scan Results
 ```bash
 kubectl describe imagescan image-policy-enforcement-example
 ```

--- a/scst-scan/samples/blob.md
+++ b/scst-scan/samples/blob.md
@@ -1,7 +1,7 @@
 # Running a Sample Public Source Scan of a Blob
 This example will perform a scan against a source code in a `.tar.gz` file. This can be helpful in a Supply Chain, where there can be a `GitRepository` step that handles cloning a repository and outputting the source code as a compressed archive.
 
-## Defining the Resources
+## Define the Resources
 Create `public-blob-source-example.yaml`:
 ```yaml
 ---
@@ -51,20 +51,20 @@ spec:
   scanTemplate: public-blob-source-scan-template
 ```
 
-## (Optional) Setting Up a Watch
-Before deploying, set up a watch in another terminal to see things process... it will be quick!
+## (Optional) Set Up a Watch
+Before deploying, set up a watch in another terminal to see things process which will be quick.
 ```bash
 watch kubectl get scantemplates,scanpolicies,sourcescans,imagescans,pods,jobs
 ```
 
 For more information, refer to [Observing and Troubleshooting](../observing.md).
 
-## Deploying the Resources
+## Deploy the Resources
 ```bash
 kubectl apply -f public-blob-source-example.yaml
 ```
 
-## Viewing the Scan Status
+## View the Scan Results
 Once the scan has completed, perform:
 ```bash
 kubectl describe sourcescan public-blob-source-example
@@ -73,10 +73,10 @@ and notice the `Status.Conditions` includes a `Reason: JobFinished` and `Message
 
 For more information, refer to [Viewing and Understanding Scan Status Conditions](../results.md).
 
-## Cleaning Up
+## Clean Up
 ```bash
 kubectl delete -f public-blob-source-example.yaml
 ```
 
-## Viewing Vulnerability Reports
+## View Vulnerability Reports
 See [Viewing Vulnerability Reports](../viewing-reports.md) section

--- a/scst-scan/samples/private-image.md
+++ b/scst-scan/samples/private-image.md
@@ -1,7 +1,7 @@
 # Running a Sample Private Image Scan
 This example will perform a scan against a private image of `spring-petclinic` located in the `dev.registry.pivotal.io` registry. The image is publicly available at [Docker Hub](https://hub.docker.com/r/arey/springboot-petclinic/) should you need to upload it to a private registry you have access to.
 
-## Defining the Resources
+## Define the Resources
 Create `private-image-example.yaml` and ensure you enter a valid docker config.json value in the secret:
 ```yaml
 ---
@@ -24,20 +24,20 @@ spec:
   scanTemplate: private-image-scan-template
 ```
 
-## (Optional) Setting Up a Watch
-Before deploying, set up a watch in another terminal to see things process... it will be quick!
+## (Optional) Set Up a Watch
+Before deploying, set up a watch in another terminal to see things process which will be quick.
 ```bash
 watch kubectl get scantemplates,scanpolicies,sourcescans,imagescans,pods,jobs
 ```
 
 For more information, refer to [Observing and Troubleshooting](../observing.md).
 
-## Deploying the Resources
+## Deploy the Resources
 ```bash
 kubectl apply -f private-image-example.yaml
 ```
 
-## Viewing the Scan Status
+## View the Scan Results
 Once the scan has completed, perform:
 ```bash
 kubectl describe imagescan private-image-example
@@ -46,10 +46,10 @@ and notice the `Status.Conditions` includes a `Reason: JobFinished` and `Message
 
 For more information, refer to [Viewing and Understanding Scan Status Conditions](../results.md).
 
-## Cleaning Up
+## Clean Up
 ```bash
 kubectl delete -f private-image-example.yaml
 ```
 
-## Viewing Vulnerability Reports
+## View Vulnerability Reports
 See [Viewing Vulnerability Reports](../viewing-reports.md) section

--- a/scst-scan/samples/private-source.md
+++ b/scst-scan/samples/private-source.md
@@ -1,6 +1,6 @@
 # Running a Sample Private Source Scan
 
-## Defining the Resources
+## Define the Resources
 Create `private-source-example.yaml` and ensure you enter a valid private ssh key value in the secret:
 ```yaml
 ---
@@ -29,20 +29,20 @@ spec:
   scanTemplate: private-source-scan-template
 ```
 
-## (Optional) Setting Up a Watch
-Before deploying, set up a watch in another terminal to see things process... it will be quick!
+## (Optional) Set Up a Watch
+Before deploying, set up a watch in another terminal to see things process which will be quick.
 ```bash
 watch kubectl get scantemplates,scanpolicies,sourcescans,imagescans,pods,jobs
 ```
 
 For more information, refer to [Observing and Troubleshooting](../observing.md).
 
-## Deploying the Resources
+## Deploy the Resources
 ```bash
 kubectl apply -f private-source-example.yaml
 ```
 
-## Viewing the Scan Status
+## View the Scan Status
 Once the scan has completed, perform:
 ```bash
 kubectl describe sourcescan private-source-example
@@ -51,10 +51,10 @@ and notice the `Status.Conditions` includes a `Reason: JobFinished` and `Message
 
 For more information, refer to [Viewing and Understanding Scan Status Conditions](../results.md).
 
-## Cleaning Up
+## Clean Up
 ```bash
 kubectl delete -f private-source-example.yaml
 ```
 
-## Viewing Vulnerability Reports
+## View Vulnerability Reports
 See [Viewing Vulnerability Reports](../viewing-reports.md) section


### PR DESCRIPTION
Summary:
* Following up https://github.com/pivotal/docs-tap/pull/231#issuecomment-936975321, do not hardcode using the "docs-staging", instead use the html id to go directly to the metadata store docs
* Use less "-ing" in verbs in the running-scans.md because https://docs-staging.vmware.com/en/VMware-Tanzu-Application-Platform/0.2/tap-0-2/GUID-install.html this page seems to use present tense without "-ing"