### PR TITLE
TANZUSC-455 Update CNR install step

### DIFF
--- a/install.md
+++ b/install.md
@@ -266,9 +266,7 @@ To install Cloud Native Runtimes:
    **Note:** This step covers configuring a namespace to run Knative services.
    If you rely on a SupplyChain to deploy Knative services into your cluster,
    then skip this step because namespace configuration is covered in
-   [Set Up Developer Namespaces to Use Installed Packages](#setup) below.
-
-   **Note:** You must complete following steps for each namespace where you create Knative services.
+   [Set Up Developer Namespaces to Use Installed Packages](#setup) below. Otherwise, you must complete following steps for each namespace where you create Knative services.
 
    Service accounts which run workloads using Cloud Native Runtimes need to have access to the image pull secrets for the Tanzu package.
    This includes the `default` service account in a namespace, which is created automatically but not associated with any image pull secrets.


### PR DESCRIPTION
* combining these two sentences with "Otherwise" makes it
more clear that users either skip this step or (exclusive or)
complete it for every namespace knative services will be created