### PR TITLE
Removing "Cartographer" from namespace section

### DIFF
--- a/install.md
+++ b/install.md
@@ -1481,7 +1481,7 @@ Use the following procedure to verify that the packages are installed.
 
 ## <a id='setup'></a> Set Up Developer Namespaces to Use Installed Packages
 
-To create a Cartographer `Workload` for your application that uses the registry credentials specified in the steps above,
+To create a `Workload` for your application that uses the registry credentials specified in the steps above,
 run the following commands to add credentials and Role-Based Access Control (RBAC) rules to the namespace that you plan to create the `Workload` in:
 
 


### PR DESCRIPTION
Cartographer shouldn't be referenced in the commercial docs. Removing it from the namespace section. All other instances of "Cartographer" that appear are in commands or command outputs and must remain.