### PR TITLE
Use a unique name for scc registry secret

### DIFF
--- a/scc/default-supply-chains.md
+++ b/scc/default-supply-chains.md
@@ -43,15 +43,15 @@ REGISTRY_PASSWORD=admin
 # placeholder secret can be found.
 #
 #
-tanzu imagepullsecret add registry-credentials \
+tanzu imagepullsecret add scc-registry-credentials \
   --export-to-all-namespaces \
   --registry $REGISTRY \
   --username $REGISTRY_USERNAME \
   --password $REGISTRY_PASSWORD
 ```
 ```console
-- Adding image pull secret 'registry-credentials'...
- Added image pull secret 'registry-credentials' into namespace 'default'
+- Adding image pull secret 'scc-registry-credentials'...
+ Added image pull secret 'scc-registry-credentials' into namespace 'default'
 ```
 
 _ps.: note that the REGISTRY here _must_ be the same as the one set in the
@@ -89,7 +89,7 @@ source-to-url     Ready   2m20s   apps.tanzu.vmware.com/workload-type=web
 apiVersion: v1
 kind: Secret
 metadata:
-  name: registry-credentials
+  name: scc-registry-credentials
   annotations:
     secretgen.carvel.dev/image-pull-secret: ""
 type: kubernetes.io/dockerconfigjson
@@ -103,9 +103,9 @@ metadata:
   name: service-account   # must match the name configured in the supply chain
                           # for source-to-url, must be "service-account"
 secrets:
-  - name: registry-credentials
+  - name: scc-registry-credentials
 imagePullSecrets:
-  - name: registry-credentials
+  - name: scc-registry-credentials
 ```
 
 3. create the workload
@@ -163,7 +163,7 @@ source-test-to-url   Ready   2m20s   apps.tanzu.vmware.com/workload-type=web
 apiVersion: v1
 kind: Secret
 metadata:
-  name: registry-credentials
+  name: scc-registry-credentials
   annotations:
     secretgen.carvel.dev/image-pull-secret: ""
 type: kubernetes.io/dockerconfigjson
@@ -177,9 +177,9 @@ metadata:
   name: service-account   # must match the name configured in the supply chain
                   # installation (defaults to `service-account`)
 secrets:
-  - name: registry-credentials
+  - name: scc-registry-credentials
 imagePullSecrets:
-  - name: registry-credentials
+  - name: scc-registry-credentials
 ```
 
 2. configure a Tekton pipeline for running the tests


### PR DESCRIPTION
- avoids generic naming conflict with other components

Fixes #218

Co-authored-by: Todd Ritchie <tritchie@vmware.com>