### PR TITLE
Fix supply chain values file name

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -468,9 +468,9 @@ Now that Tekton is installed, you can install the **Out of the Box with Testing*
 ```bash
 tanzu package install ootb-supply-chain-testing \
   --package-name ootb-supply-chain-testing.tanzu.vmware.com \
-  --version 0.3.0 \
+  --version 0.3.0-build.3  \
   --namespace tap-install \
-  --values-file default-supply-chain-values.yaml
+  --values-file ootb-supply-chain-basic-values.yaml
 ```
 
 ### Example Tekton Pipeline Config
@@ -614,9 +614,9 @@ Next the Out of the Box Testing and Scanning supply chain can be installed.
 ```bash
 tanzu package install ootb-supply-chain-testing-scanning \
   --package-name ootb-supply-chain-testing-scanning.tanzu.vmware.com \
-  --version 0.3.0 \
+  --version 0.3.0-build.3  \
   --namespace tap-install \
-  --values-file default-supply-chain-values.yaml
+  --values-file ootb-supply-chain-basic-values.yaml
 ```
 
 ### Workload update


### PR DESCRIPTION
The install-components guide was updated to have a new values file name for the test and scan supply chains, but the getting started guide was not updated to reflect the change.  Change the file names + bump the version to the latest build version.  The build version will be removed once the final Beta 3 build is dropped.