### PR TITLE
updating links to point directly to next step

### DIFF
--- a/install-general.md
+++ b/install-general.md
@@ -554,5 +554,5 @@ operating system is Linux, download the `tanzu-framework-linux-amd64.tar` bundle
     ```
 
  1. You may now proceed with installing TAP on TCE or TKG:
-    * **[Installing on a Tanzu Community Edition v0.9.1 Cluster](install-tce.md)**
-    * **[Installing on a Tanzu Kubernetes Grid v1.4 Cluster](install-tkg.md)
+    * **[Installing TAP on a Tanzu Community Edition v0.9.1 Cluster](install-tce.html#install-tap)**
+    * **[Installing TAP on a Tanzu Kubernetes Grid v1.4 Cluster](install-tkg.html#install-tap)**


### PR DESCRIPTION
once the TKG/TCE-specific instructions for the Tanzu CLI have been followed, the next step is to use the CLI to install TAP on TKG/TCE.
This change updates the pointers to deep-link directly to that part of the installing TAP on TCE/TKG pages.

## PLEASE
make sure these updated links will work properly on docs.vmware.com and if not, update accordingly -- thanks so much~!