### PR TITLE
Surround username and password with quotes

### DIFF
--- a/install.md
+++ b/install.md
@@ -24,7 +24,7 @@ To add the Tanzu Application Platform package repository:
 
     ```bash
     tanzu secret registry add tap-registry \
-      --username TANZU-NET-USER --password TANZU-NET-PASSWORD \
+      --username "TANZU-NET-USER" --password "TANZU-NET-PASSWORD" \
       --server registry.tanzu.vmware.com \
       --export-to-all-namespaces --yes --namespace tap-install
     ```


### PR DESCRIPTION
This to remind the reader to put the username and password in quotation marks, since if a value contains certain characters, the error message is not very helpful:

Error: accepts 1 arg(s), received 2
Error: exit status 1