### PR TITLE
Update getting-started.md

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -438,9 +438,7 @@ Tekton pipeline.
 
 ### Install Out of the Box with Testing
 
-The first step is to install Tekton, which was not installed in the installation docs as
-it is only a requirement for the **Out of the Box Basic** supply chain.
-The next section walks you through installing Tekton on your cluster.
+The first step is to install Tekton, which was only installed if you added `install_tekton: true` to your `tap-values.yaml`. If you did not, this next section walks you through installing Tekton on your cluster.
 
 
 #### Install Tekton


### PR DESCRIPTION
Since we're documenting how to install the full profile in the installation docs, it makes more sense to add "install_tekton: true" to the tap-values.yaml and let it install automatically.