### PR TITLE
Update dependencies for default supply chain

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -342,7 +342,13 @@ Tekton pipeline.
 <li>Convention Service
 
 <li>Cloud Native Runtimes
-</li>
+<li>If using Service References:
+   </li>   
+<ul>
+<li>Service Bindings
+<li>Services Toolkit
+   </li>
+   </ul>
 </ul>
    </td>
   </tr>


### PR DESCRIPTION
Add note that you will also need service bindings and services toolkit if using service references as part of a workload declaration.

Please reformat if needed.