### PR TITLE
Update remaining top level occurences of Services Control Plane Toolkit

### DIFF
--- a/install.md
+++ b/install.md
@@ -292,7 +292,7 @@ This table lists the packages that are contained in each profile:
    </td>
   </tr>
   <tr>
-   <td>Services Control Plane Toolkit
+   <td>Services Toolkit
    </td>
    <td>&check;
    </td>

--- a/release-notes.md
+++ b/release-notes.md
@@ -30,7 +30,7 @@ Tanzu Packages:
   - Image Source Controller v
   - Developer Conventions v
 - API Portal for VMware Tanzu v
-- Service Control Plane Toolkit v
+- Services Toolkit v
 - Service Bindings for Kubernetes v
 - Tanzu Application Platform GUI v0.3.0
   - Workload Visibility Plugin v1.0.0


### PR DESCRIPTION
I wasn't sure about adding in the version for Services Toolkit in release-notes.md as it hasn't technically been added in although we are pretty certain that it will be v0.4.0.