### PR TITLE
Clarify local_dns.domain usage from kapp package

### DIFF
--- a/install-components.md
+++ b/install-components.md
@@ -129,7 +129,7 @@ To install Cloud Native Runtimes:
       ingress.external.namespace  <nil>    string   Optional: Only valid if a Contour instance already present in the cluster. Specify a namespace where an existing Contour is installed on your cluster (for external services) if you want CNR to use your Contour instance.
       ingress.internal.namespace  <nil>    string   Optional: Only valid if a Contour instance already present in the cluster. Specify a namespace where an existing Contour is installed on your cluster (for internal services) if you want CNR to use your Contour instance.
       ingress.reuse_crds          false    boolean  Optional: Only valid if a Contour instance already present in the cluster. Set to "true" if you want CNR to re-use the cluster's existing Contour CRDs.
-      local_dns.domain            <nil>    string   Optional: Set a custom domain for the Knative services.
+      local_dns.domain            <nil>    string   Optional: Set a custom domain for CoreDNS. Only applicable when "local_dns.enable" is set to "true", "provider" is set to "local" and running on Kind.
       local_dns.enable            false    boolean  Optional: Only for when "provider" is set to "local" and running on Kind. Set to true to enable local DNS.
       pdb.enable                  true     boolean  Optional: Set to true to enable Pod Disruption Budget. If provider local is set to "local", the PDB will be disabled automatically.
       provider                    <nil>    string   Optional: Kubernetes cluster provider. To be specified if deploying CNR on a local Kubernetes cluster provider.


### PR DESCRIPTION
Updating the documentation for `local_dns.domain` based on updated package documentation here: https://gitlab.eng.vmware.com/daisy/tanzu-serverless/-/blob/main/config/kapp/package/package.yaml#L47
