### PR TITLE
ootb: point at build.5; add notes about one supply chain in the cluster at a time

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -28,7 +28,9 @@ Before getting started, ensure the following prerequisites are in place:
 
 2. Default kubeconfig context is set to the target Kubernetes cluster
 
-3. A developer namespace has been setup to accommodate the developer's Workload.
+3. The Out of The Box Supply Chain Basic is installed: see [Install default Supply Chain](install-components.md#install-ootb-supply-chain-basic).
+
+4. A developer namespace has been setup to accommodate the developer's Workload.
    See [Set Up Developer Namespaces to Use Installed Packages](install-components.md#setup).
 
 
@@ -55,10 +57,9 @@ Follow these steps to get started with an accelerator called `Tanzu-Java-Web-App
     <img src="images/tanzu-java-web-app.png" alt="Screenshot of the Tanzu Java Web App within Application Accelerator. It includes empty text boxes for new project information." width="600">
 
 1. Replace the default value `dev.local` in the _"prefix for container image registry"_ field
-with the URL to your registry. The URL you enter must match the `REGISTRY_SERVER` value you
-provided when you installed the default Supply Chain.
-For more information, see
-[Install default Supply Chain](install-components.md#install-ootb-supply-chain-basic).
+with the URL to your registry. The URL you enter must match the registry server you want the default Supply Chain to push container images to.
+
+For more information, see [Install default Supply Chain](install-components.md#install-ootb-supply-chain-basic).
 
     >**Note:** This entry should not include the project ID or image name.
 
@@ -468,12 +469,22 @@ You can also view the Tekton
 [tutorial](https://github.com/tektoncd/pipeline/blob/main/docs/tutorial.md)
 and [getting started guide](https://tekton.dev/docs/getting-started/).
 
-Now that Tekton is installed, you can install the **Out of the Box with Testing** supply chain on your cluster. Run:
+Now that Tekton is installed, you can install the **Out of the Box with
+Testing** supply chain on your cluster. In this iteration of TAP, only one
+Supply Chain can be installed at a time, so before proceeding, make sure the
+Basic Supply Chain is not installed in the cluster:
+
+```bash
+tanzu package installed delete ootb-supply-chain-basic
+```
+
+Then, install the Out of the Box With Testing:
+
 
 ```bash
 tanzu package install ootb-supply-chain-testing \
   --package-name ootb-supply-chain-testing.tanzu.vmware.com \
-  --version 0.3.0-build.3  \
+  --version 0.3.0-build.5  \
   --namespace tap-install \
   --values-file ootb-supply-chain-basic-values.yaml
 ```
@@ -544,7 +555,7 @@ the workload must be updated to point at the your Tekton pipeline.
   tanzu apps workload create tanzu-java-web-app \
     --git-repo  https://github.com/sample-accelerators/tanzu-java-web-app \
     --git-branch main \
-    --type web-test \
+    --type web \
     --param tekton-pipeline-name=developer-defined-tekton-pipeline \
     --yes
   ```
@@ -660,11 +671,20 @@ EOF
 2. (Optional, but recommended) To persist and query the vulnerability results post-scan, [install Supply Chain Security Tools - Store](install-components.md#install-scst-store). Refer to the *Prerequisite* in [Supply Chain Security Tools - Scan](install-components.md#install-scst-scan) for more details.
 
 3. Install the Out of the Box Testing and Scanning supply chain by running:
+In the same way as in the Testing step, we have to first uninstall any
+previously installed Supply Chain:
+
+    ```bash
+    tanzu package installed delete ootb-supply-chain-basic
+    tanzu package installed delete ootb-supply-chain-testing
+    ```
+
+And then, move on with installing Out of the Box Testing and Scanning:
 
     ```bash
     tanzu package install ootb-supply-chain-testing-scanning \
       --package-name ootb-supply-chain-testing-scanning.tanzu.vmware.com \
-      --version 0.3.0-build.3  \
+      --version 0.3.0-build.5  \
       --namespace tap-install \
       --values-file ootb-supply-chain-basic-values.yaml
     ```
@@ -677,9 +697,9 @@ The workload can be updated using the Tanzu CLI as follows:
 
 ```bash
 tanzu apps workload create tanzu-java-web-app \
-  --git-repo  https://github.com/sample-accelerators/tanzu-java-web-app \
+  --git-repo https://github.com/sample-accelerators/tanzu-java-web-app \
   --git-branch main \
-  --type web-scan \
+  --type web \
   --param tekton-pipeline-name=developer-defined-tekton-pipeline \
   --yes
 ```

--- a/install-components.md
+++ b/install-components.md
@@ -775,7 +775,7 @@ To install Out of the Box Templates:
    ```bash
     tanzu package install ootb-templates \
       --package-name ootb-templates.tanzu.vmware.com \
-      --version 0.3.0-build.4 \
+      --version 0.3.0-build.5 \
       --namespace tap-install
     ```
    
@@ -787,13 +787,13 @@ Install the default Supply Chain, called Out of the Box Supply Chain Basic, by r
 1. Gather the values schema:
 
     ```bash
-    tanzu package available get ootb-supply-chain-basic.tanzu.vmware.com/0.3.0-build.4 --values-schema -n tap-install
+    tanzu package available get ootb-supply-chain-basic.tanzu.vmware.com/0.3.0-build.5 --values-schema -n tap-install
     ```
 
     For example:
 
    ```console
-   $ tanzu package available get ootb-supply-chain-basic.tanzu.vmware.com/0.3.0-build.4 --values-schema -n tap-install
+   $ tanzu package available get ootb-supply-chain-basic.tanzu.vmware.com/0.3.0-build.5 --values-schema -n tap-install
    | Retrieving package details for ootb-supply-chain-basic.tanzu.vmware.com/0.3.0...
 
     KEY                  DEFAULT          TYPE    DESCRIPTION
@@ -821,13 +821,15 @@ Install the default Supply Chain, called Out of the Box Supply Chain Basic, by r
      ```bash
     tanzu package install ootb-supply-chain-basic \
       --package-name ootb-supply-chain-basic.tanzu.vmware.com \
-      --version 0.3.0-build.4 \
+      --version 0.3.0-build.5 \
       --namespace tap-install \
       --values-file ootb-supply-chain-basic-values.yaml
     ```
 
 > **Note:** The `default` service account and required secrets are created in
 [Set Up Developer Namespaces to Use Installed Packages](#setup).
+
+> **Note:** Only one supply chain should be installed in the cluster at a time.
 
 ## <a id='install-developer-conventions'></a> Install Developer Conventions
 
@@ -2110,8 +2112,8 @@ Use the following procedure to verify that the packages are installed.
     grype-scanner            grype.scanning.apps.tanzu.vmware.com               1.0.0-beta.2     Reconcile succeeded
     image-policy-webhook     image-policy-webhook.signing.run.tanzu.vmware.com  1.0.0-beta.1     Reconcile succeeded
     metadata-store           scst-store.tanzu.vmware.com                        1.0.0-beta.1     Reconcile succeeded
-    ootb-supply-chain-basic  ootb-supply-chain-basic.tanzu.vmware.com           0.3.0-build.4    Reconcile succeeded
-    ootb-templates           ootb-templates.tanzu.vmware.com                    0.3.0-build.4    Reconcile succeeded
+    ootb-supply-chain-basic  ootb-supply-chain-basic.tanzu.vmware.com           0.3.0-build.5    Reconcile succeeded
+    ootb-templates           ootb-templates.tanzu.vmware.com                    0.3.0-build.5    Reconcile succeeded
     scan-controller          scanning.apps.tanzu.vmware.com                     1.0.0-beta.2     Reconcile succeeded
     service-bindings         service-bindings.labs.vmware.com                   0.5.0            Reconcile succeeded
     services-toolkit         services-toolkit.tanzu.vmware.com                  0.4.0            Reconcile succeeded

--- a/install.md
+++ b/install.md
@@ -408,11 +408,6 @@ install by changing the `profile` value.
       tanzunet_username: "<TANZUNET-USERNAME>"
       tanzunet_password: "<TANZUNET-PASSWORD>"
 
-    ootb_supply_chain_basic:
-      registry:
-        server: "<SERVER-NAME>"
-        repository: "<REPO-NAME>"
-
     learningcenter:
       ingressDomain: "<DOMAIN-NAME>"
 
@@ -423,8 +418,6 @@ install by changing the `profile` value.
 
     - `<PROFILE-VALUE>` is a value such as `full`, `dev-light`, `shared-tools`, or `operator-light`.
     - `<KP-DEFAULT-REPO>` has a value such as `us-east4-docker.pkg.dev/some-project-id/test-private-repo/apps`.
-    - `<SERVER-NAME>` has a value such as `us-east4-docker.pkg.dev`.
-    - `<REPO-NAME>` has a value such as `some-project-id/test-private-repo/apps`.
     - `<DOMAIN-NAME>` has a value such as `educates.example.com`.
 
     To view possible configuration settings for a package, run:

--- a/install.md
+++ b/install.md
@@ -198,37 +198,37 @@ The following table lists the packages contained in each profile:
   <tr>
    <td>Out of the Box Supply Chain - Basic
    </td>
-   <td>&check;
-   </td>
-   <td>&check;
+   <td>
    </td>
    <td>
    </td>
-   <td>&check;
+   <td>
+   </td>
+   <td>
    </td>
   </tr>
   <tr>
    <td>Out of the Box Supply Chain - Testing
    </td>
-   <td>&check;
-   </td>
-   <td>&check;
+   <td>
    </td>
    <td>
    </td>
-   <td>&check;
+   <td>
+   </td>
+   <td>
    </td>
   </tr>
   <tr>
    <td>Out of the Box Supply Chain - Testing and Scanning
    </td>
-   <td>&check;
-   </td>
-   <td>&check;
+   <td>
    </td>
    <td>
    </td>
-   <td>&check;
+   <td>
+   </td>
+   <td>
    </td>
   </tr>
   <tr>


### PR DESCRIPTION
hi folks,

with the updates brought in via 0.3.0-build.5 (see https://gitlab.eng.vmware.com/tap/tap-packages/-/merge_requests/146 - not merged yet), we had to update a couple things in the guides over here.

highlight: unfortunately, with the focus on the _developer_ experience of not having to target a specific supply chain (e.g., not having to specify `--type=web` vs `--type=web-test` but instead having cartographer "figuring out" which one to use under the hood, something to be implemented), we had to rollback support for having all 3 supply chains coming out of the box in the profiles and going back to documenting how operators should uninstall previous supply chains so the matching always works.

ps.: this should only be merged after build.5 is available (given the changes in `--type=` for `tanzu apps workload create` commands).

thank you!

/cc @jwntrs 