### PR TITLE
Streamline Services Toolkit Advanced Use Cases

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -1010,14 +1010,12 @@ One of the out of the box supply chains we are working on for a future release w
 
 * [Observing and Troubleshooting](scst-scan/observing.md)
 
-
-
 ## Section 5: Advanced Use Cases - Services Journey
 
 ### Overview
 
 Tanzu Application Platform makes it easy to discover, curate, consume, and manage services in a
-single- or multi-cluster environment to enable app developers to focus on consuming services
+single or multi-cluster environment to enable app developers to focus on consuming services
 without having to worry about provisioning, configuration, and operations of the services
 themselves.
 
@@ -1026,13 +1024,12 @@ Services Toolkit comprises a number of Kubernetes-native components that support
 lifecycle, discoverability, and connectivity of Service Resources on Kubernetes, such as databases,
 message queues, DNS records, and so on. These components are:
 
-* Service API Projection
-* Service Resource Replication
 * Service Offering
 * Service Resource Claims
+* Service API Projection
+* Service Resource Replication
 
-Each component has value on its own, however you can unlock the most powerful and
-valuable use cases by combining them.
+Each component has value on its own, however the most powerful and valuable use cases are unlocked by combining them together.
 
 For example, the APIs can enable the separation of application workloads and service resources into
 separate Kubernetes clusters. This allows, for example, a developer to create services from the
@@ -1042,50 +1039,10 @@ same cluster that their app is running in, while underlying resources that compr
 This allows Service Operators, who are responsible for the lifecycle and management of the  
 services, greater control and flexibility in the services they provide.
 
-#### Component Overview
+For detailed information on each of the Services Toolkit components, including the use cases they unlock, as well as API reference guides,
+please refer to the [Services Toolkit component documentation](https://docs.vmware.com/en/Services-Toolkit/0.4/services-toolkit-0-4/GUID-overview.html).
 
-1. Service API Projection
-
-Enables Service Operators to _project_ Custom Kubernetes APIs from one cluster into another
-cluster. For example, from a Services Cluster into a Workload cluster.
-API Projection makes use of Kubernetes API Aggregation to proxy requests from one
-cluster to another.
-Setup and configuration of the proxy and API Aggregation machinery is automated, leading to a less
-manual and error-prone user experience.
-
-When might you want to make use of API Projection?
-Imagine that a Service Operator has installed the
-[RabbitMQ Cluster Operator for Kubernetes](https://www.rabbitmq.com/kubernetes/operator/operator-overview.html) on to a cluster that is highly tuned and configured to the running of
-RabbitMQ clusters.
-They want to make the `rabbitmq.com` Custom Kubernetes API that ships with the operator available to
-developers so that they can provision RabbitMQ Clusters themselves.
-However, they do not want developers to have direct access to the Service cluster.
-They also do not want application workloads running in the same cluster as the RabbitMQ cluster
-Operator.
-In this case they can make use of API Projection to project the `rabbitmq.com` API from the Service
-cluster into an Application Workload cluster, where developers can interact with it like they
-interact with any other Kubernetes API.
-
-2. Service Resource Replication
-
-Service Resource Replication automates the replication of core Kubernetes resources -- namely
-Secrets -- across clusters securely. This is mainly used to help support API Projection of Service
-Resource Lifecycle APIs, such as the `rabbitmq.com` API mentioned above.
-
-Typically, when creating service resources, such as `RabbitmqCluster`, on such APIs, credentials to
-access the service resource are stored in Secrets.
-If using API Projection then the Secrets containing such credentials are created on the Service
-clusters, and are therefore not available for apps to consume in application workload clusters.
-Resource Replication is used to replicate such Secrets from Service Clusters into
-Application Workload clusters so that they can be consumed.
-
-3. Service Offering
-
-Service Offering APIs help to make services discoverable and understandable by enabling Service Operators to provide contextual metadata about the services they are providing.
-
-4. Resources Claims (coming soon!)
-
-Enables developers to declare and consume services on demand without worrying about provisioning, binding or maintenance of the services themselves.
+Following are a number of use cases enabled by the Services Toolkit as part of Tanzu Application Platform.
 
 ### <a id='use-case-1'></a> Use Case 1 - **Binding an App Workload to a Service Resource on a single cluster**
 


### PR DESCRIPTION
Hello! This PR replaces the "Component Overview" section of the Services Toolkit Advanced Use Case with a link to our own component docs.

Note: I have used a link to a URL that doesn't currently exist (https://docs.vmware.com/en/Services-Toolkit/0.4/services-toolkit-0-4/GUID-overview.html), but that will exist once the linked documentation goes live. Is this the preferred approach when linking to docs in PRs? Or would you prefer if I were to link to the docs on the staging site?

Thanks!
Ed