### PR TITLE
VSCode Tanzu IDE Extension no longer relies on Spring.

### DIFF
--- a/developer-conventions/about.md
+++ b/developer-conventions/about.md
@@ -11,7 +11,7 @@ and debugging:
 
 - Scales the workload to one Pod
 - Extends HTTP-based timeouts
-- Enables live-update by using JAVA_TOOL_OPTIONS and spring-boot-devtools
+- Enables live-update for Java apps
 - Enables debugging by using the Java debug buildpack
 
 ## Features

--- a/vscode-extension/about.md
+++ b/vscode-extension/about.md
@@ -10,7 +10,7 @@ weight: 1
 
 Tanzu Developer Tools for VSCode is VMware Tanzu’s official IDE extension for VSCode to help you develop with the Tanzu Application Platform.
 
-> Note: This extension currently only supports Java Spring apps with spring-boot-devtools.
+> Note: This extension currently only supports Java apps.
 
 ---
 


### PR DESCRIPTION
Authored-by: Harsha Nandiwada <hnandiwada@vmware.com>