### PR TITLE
Remove scan note on scan policy changes

### DIFF
--- a/scst-scan/running-scans.md
+++ b/scst-scan/running-scans.md
@@ -106,8 +106,6 @@ spec:
 ...
 ```
 
-**NOTE:** The ScanPolicy CRD will not re-trigger a scan if it is updated. To re-trigger the scan, delete and re-apply the SourceScan CR.
-
 #### Delete the SourceScan CR:
 
 ```bash


### PR DESCRIPTION
It will no longer be necessary to delete and reapply scan CRs after a
ScanTemplate or ScanPolicy changes - a new scan will be triggered
automatically

Co-authored-by: Behrouz Soroushian <bsoroushian@vmware.com>