### PR TITLE
Update API group for service offering and resource claims

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -1054,7 +1054,7 @@ Let’s start by playing the role of a Service Operator, who is responsible for 
     metadata:
       name: resource-claims-rmq
       labels:
-        services.vmware.tanzu.com/aggregate-to-resource-claims: "true"
+        services.apps.tanzu.vmware.com/aggregate-to-resource-claims: "true"
     rules:
     - apiGroups: ["rabbitmq.com"]
       resources: ["rabbitmqclusters"]
@@ -1160,7 +1160,7 @@ installed. RabbitMQ Cluster Operator is not installed on this cluster.
     metadata:
       name: resource-claims-rmq
       labels:
-        services.vmware.tanzu.com/aggregate-to-resource-claims: "true"
+        services.apps.tanzu.vmware.com/aggregate-to-resource-claims: "true"
     rules:
     - apiGroups: ["rabbitmq.com"]
       resources: ["rabbitmqclusters"]
@@ -1199,7 +1199,7 @@ installed. RabbitMQ Cluster Operator is not installed on this cluster.
 9. An Application Developer uses services available in the Workload Cluster. There is one service resource available in the example below.
 
     ```
-    kubectl --context=WORKLOAD_CONTEXT get clusterserviceresources
+    kubectl --context=WORKLOAD_CONTEXT get clusterresources.services.apps.tanzu.vmware.com
 
     NAME                           API KIND          API GROUP      DESCRIPTION
     rabbitmq.com-rabbitmqcluster   RabbitmqCluster   rabbitmq.com

--- a/install-components.md
+++ b/install-components.md
@@ -2267,7 +2267,7 @@ run the following commands to add credentials and Role-Based Access Control (RBA
         resources: ['servicebindings']
         verbs: ['*']
       - apiGroups:
-          - services.tanzu.vmware.com
+          - services.apps.tanzu.vmware.com
         resources: ['resourceclaims']
         verbs: ['*']
       - apiGroups:


### PR DESCRIPTION
This also includes renaming of clusterserviceresource to clusterresource.

Note that this is for a release of services toolkit that hasn't been cut yet and is being targetted for tap-beta4.