### PR TITLE
Update to approved agg role label and finalizer key

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -1072,7 +1072,7 @@ service resources, in this case RabbitMQ clusters. See the following example.
     metadata:
       name: resource-claims-rmq
       labels:
-        services.apps.tanzu.vmware.com/aggregate-to-resource-claims: "true"
+        resourceclaims.services.apps.tanzu.vmware.com/controller: "true"
     rules:
     - apiGroups: ["rabbitmq.com"]
       resources: ["rabbitmqclusters"]
@@ -1241,7 +1241,7 @@ controller to the Service resources, in this case RabbitMQ.
     metadata:
       name: resource-claims-rmq
       labels:
-        services.apps.tanzu.vmware.com/aggregate-to-resource-claims: "true"
+        resourceclaims.services.apps.tanzu.vmware.com/controller: "true"
     rules:
     - apiGroups: ["rabbitmq.com"]
       resources: ["rabbitmqclusters"]


### PR DESCRIPTION
For the beta 4 release.  Any place with  services.apps.tanzu.vmware.com/aggregate-to-resource-claims: "true" should be replaced with resourceclaims.services.apps.tanzu.vmware.com/controller: "true"
