### PR TITLE
Add update to resource claim cluster role as is now required

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -1076,7 +1076,7 @@ service resources, in this case RabbitMQ clusters. See the following example.
     rules:
     - apiGroups: ["rabbitmq.com"]
       resources: ["rabbitmqclusters"]
-      verbs: ["get", "list", "watch"]
+      verbs: ["get", "list", "watch", "update"]
     ```
 
 1. Apply the YAML by running the following command.
@@ -1245,7 +1245,7 @@ controller to the Service resources, in this case RabbitMQ.
     rules:
     - apiGroups: ["rabbitmq.com"]
       resources: ["rabbitmqclusters"]
-      verbs: ["get", "list", "watch"]
+      verbs: ["get", "list", "watch", "update"]
     ```
 
 1. Apply the YAML file by running the following command.


### PR DESCRIPTION
This is required as part of the exclusive resource claims feature.

This is a feature for tap-beta4, it doesn't need to be ported back to previous versions.