### PR TITLE
scc: fix group used for scan objects

### DIFF
--- a/scc/ootb-supply-chain-testing-scanning.md
+++ b/scc/ootb-supply-chain-testing-scanning.md
@@ -132,7 +132,7 @@ When a ImageScan or SourceScan is created to run a scan, those reference a
 policy whose name **must** match the one below (`scan-policy`):
  
 ```yaml
-apiVersion: scanning.apps.tanzu.vmware.com/v1alpha1
+apiVersion: scst-scan.apps.tanzu.vmware.com/v1alpha1
 kind: ScanPolicy
 metadata:
   name: scan-policy
@@ -175,7 +175,7 @@ below:
 - source scanning (`blob-source-scan-template`):
 
 ```yaml
-apiVersion: scanning.apps.tanzu.vmware.com/v1alpha1
+apiVersion: scst-scan.apps.tanzu.vmware.com/v1alpha1
 kind: ScanTemplate
 metadata:
   name: blob-source-scan-template
@@ -225,7 +225,7 @@ spec:
 
 
 ```yaml
-apiVersion: scanning.apps.tanzu.vmware.com/v1alpha1
+apiVersion: scst-scan.apps.tanzu.vmware.com/v1alpha1
 kind: ScanTemplate
 metadata:
   name: private-image-scan-template


### PR DESCRIPTION
hi folks,

`scst` recently updated the `group` used for their custom resources, so we must have them updates in the references over here too.

notice that the `scst-scan/` is already using the up-to-date group, so we really just need the bump _here_.

thank you!

/cc @nedenwalker 