### PR TITLE
scc: update role and rolebinding names

### DIFF
--- a/install-components.md
+++ b/install-components.md
@@ -2368,7 +2368,7 @@ run the following commands to add credentials and Role-Based Access Control (RBA
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
-      name: kapp-permissions
+      name: default
     rules:
     - apiGroups: [source.toolkit.fluxcd.io]
       resources: [gitrepositories]
@@ -2417,11 +2417,11 @@ run the following commands to add credentials and Role-Based Access Control (RBA
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
-      name: kapp-permissions
+      name: default
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: Role
-      name: kapp-permissions
+      name: default
     subjects:
       - kind: ServiceAccount
         name: default

--- a/scc/ootb-supply-chain-basic.md
+++ b/scc/ootb-supply-chain-basic.md
@@ -194,11 +194,11 @@ Then bind it to the ServiceAccount:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: kapp-permissions
+  name: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kapp-permissions
+  name: default
 subjects:
   - kind: ServiceAccount
     name: default


### PR DESCRIPTION
`kapp-permissions` used to make sense it those were permissions that
were indeed just intended for `kapp`, but now that we make use of it for
the supplychain to act in favor of the workload user, it makes sense to
not call it that.

Signed-off-by: Ciro S. Costa <ciroscosta@vmware.com>