### PR TITLE
make file delete more exact for CLI removal

### DIFF
--- a/uninstall.md
+++ b/uninstall.md
@@ -90,7 +90,7 @@ To completely remove the Tanzu CLI, plug-ins, and associated files, run the scri
 
     ```
     #!/bin/zsh
-    rm -rf $HOME/tanzu/           # Remove tanzu storage folder
+    rm -rf $HOME/tanzu/cli        # Remove previously downloaded cli files
     sudo rm /usr/local/bin/tanzu  # Remove CLI binary (executable)
     rm -rf ~/.config/tanzu/       # current location # Remove config directory
     rm -rf ~/.tanzu/              # old location # Remove config directory


### PR DESCRIPTION
folks may be storing other TAP-experimentation-related files in $HOME/tanzu --- so the current delete would remove all of those (potentially making people sad/upset). Updating so it deleted $HOME/tanzu/cli and below should help address that.