### PR TITLE
Updating fluxcd source-controller documentation

### DIFF
--- a/install-components.md
+++ b/install-components.md
@@ -67,26 +67,78 @@ cert_manager and FluxCD Source Controller are installed as part of all profiles.
 * **FluxCD source-controller**:
     Install FluxCD source-controller using the following procedure.
 
-     1. Create the namespace `flux-system`.
+    1. List version information for the package by running:
 
         ```
-        kubectl create namespace flux-system
+        tanzu package available list fluxcd.source.controller.tanzu.vmware.com -n tap-install
         ```
 
-     2. Create the `clusterrolebinding` by running:
-        ```
-        kubectl create clusterrolebinding default-admin \
-        --clusterrole=cluster-admin \
-        --serviceaccount=flux-system:default
-        ```
-     3. Install FluxCD Source Controller by running:
-        ```
-        kapp deploy -y -a flux-source-controller -n flux-system \
-        -f https://github.com/fluxcd/source-controller/releases/download/v0.15.4/source-controller.crds.yaml \
-        -f https://github.com/fluxcd/source-controller/releases/download/v0.15.4/source-controller.deployment.yaml
-        ```
-        We have verified the Tanzu Application Platform repo bundle packages installation with FluxCD source-controller version v0.15.4.
+         For example:
 
+        ```
+        $ tanzu package available list fluxcd.source.controller.tanzu.vmware.com -n tap-install
+            \ Retrieving package versions for fluxcd.source.controller.tanzu.vmware.com...
+              NAME                                       VERSION  RELEASED-AT
+              fluxcd.source.controller.tanzu.vmware.com  0.16.0   2021-10-27 19:00:00 -0500 -05
+        ```
+
+     2. Install the package by running:
+
+        ```
+        tanzu package install fluxcd-source-controller -p fluxcd.source.controller.tanzu.vmware.com -v VERSION-NUMBER -n tap-install
+        ```
+
+        Where:
+
+        - `VERSION-NUMBER` is the version of the package listed in step 1 above.
+
+        For example:
+        ```
+        tanzu package install fluxcd-source-controller -p fluxcd.source.controller.tanzu.vmware.com -v 0.16.0 -n tap-install
+        \ Installing package 'fluxcd.source.controller.tanzu.vmware.com'
+        | Getting package metadata for 'fluxcd.source.controller.tanzu.vmware.com'
+        | Creating service account 'fluxcd-source-controller-tap-install-sa'
+        | Creating cluster admin role 'fluxcd-source-controller-tap-install-cluster-role'
+        | Creating cluster role binding 'fluxcd-source-controller-tap-install-cluster-rolebinding'
+        | Creating package resource
+        - Waiting for 'PackageInstall' reconciliation for 'fluxcd-source-controller'
+        | 'PackageInstall' resource install status: Reconciling
+
+         Added installed package 'fluxcd-source-controller'
+        ```
+
+    3. Verify the package install by running:
+
+        ```
+        tanzu package installed get fluxcd-source-controller -n tap-install
+        ```
+        For example:
+        ```
+        tanzu package installed get fluxcd-source-controller -n tap-install
+        \ Retrieving installation details for fluxcd-source-controller...
+        NAME:                    fluxcd-source-controller
+        PACKAGE-NAME:            fluxcd.source.controller.tanzu.vmware.com
+        PACKAGE-VERSION:         0.16.0
+        STATUS:                  Reconcile succeeded
+        CONDITIONS:              [{ReconcileSucceeded True  }]
+        USEFUL-ERROR-MESSAGE:
+        ```
+
+        STATUS should be 'Reconcile succeeded.'
+
+        ```
+        kubectl get pods -n flux-system
+        ```
+
+        For example:
+
+        ```
+        $ kubectl get pods -n flux-system
+        NAME                                 READY   STATUS    RESTARTS   AGE
+        source-controller-69859f545d-ll8fj   1/1     Running   0          3m38s
+        ```
+
+        STATUS should be 'Running.'
 
 ## <a id='install-cnr'></a> Install Cloud Native Runtimes
 


### PR DESCRIPTION
- Updating documentation so it can use the TAP fluxcd.source.controller.tanzu.vmware.com package instead of the manual installation