### PR TITLE
Correct telemetry opt-out instructions

### DIFF
--- a/opting-out-telemetry.md
+++ b/opting-out-telemetry.md
@@ -16,7 +16,7 @@ To turn off telemetry collection on your Tanzu Application Platform installation
 2. Run the following `kubectl` command:
 
     ```
-    kubectl apply < <<EOF
+    kubectl apply -f - <<EOF
     apiVersion: v1
     kind: Namespace
     metadata:
@@ -30,6 +30,12 @@ To turn off telemetry collection on your Tanzu Application Platform installation
     data:
       level: disabled
     EOF
+    ```
+
+3. If you already have TAP installed, restart the telemetry collector to pick up the change:
+
+    ```
+    kubectl delete pods --namespace tap-telemetry --all
     ```
 
 


### PR DESCRIPTION
Discovered that the `kubectl` command was incorrect while testing this.

Also, added directions to restart the telemetry controllers to make sure that they don't use an incorrect cached value for a while.
