### PR TITLE
ootb/scanning: improve scantemplate instructions

### DIFF
--- a/scc/ootb-supply-chain-testing-scanning.md
+++ b/scc/ootb-supply-chain-testing-scanning.md
@@ -39,7 +39,7 @@ Testing, but adds on top source and image scanning using Grype:
 - Deploying the application to the same cluster
 
 
-### Prerequisites
+## Prerequisites
 
 To make use this supply chain, it's required that:
 
@@ -70,7 +70,7 @@ _source-test-scan-to-url_.
 
 
 
-#### Developer namespace
+## Developer namespace
 
 As mentioned in the prerequisites section, this example builds on the previous
 Out of The Box Supply Chain examples, so only additions are included here.
@@ -93,6 +93,11 @@ supplychain is responsible for (see Supply Chain Basic for details)
 - **rolebinding**: binds the role to the service account, i.e., grants the
   capabilities to the identity (see Supply Chain Basic for details)
 
+- (optional) **git credentials secret**: when using GitOps for managing the
+  delivery of applications (or a private git source), provides the required
+  credentials for interacting with the git repository (see Supply Chain Basic
+  for details).
+
 - **tekton pipeline**: a pipeline to be ran whenever the supply chain hits the
   stage of testing the source code (see Supply Chain With Testing for details)
 
@@ -109,21 +114,22 @@ Below you'll find details about the new objects (compared to Out of The Box
 Supply Chain With Testing).
 
 
-#### Updates to the developer namespace
+### Updates to the developer namespace
 
 In order for source and image scans to happen, scan templates and scan policies
 must exist in the same namespace as the Workload. These define:
 
 - `ScanTemplate`: how to run a scan, allowing one to tweak details about the
   execution of the scan (either for images or source code)
+
 - `ScanPolicy`: how to evaluate whether the artifacts scanned are compliant,
   e.g., allowing one to be either very strict, or restrictive about particular
-  vulnerabilities found.
+vulnerabilities found.
 
 Note that the names of the objects **must** match the ones in the example.
 
 
-##### ScanPolicy
+#### ScanPolicy
 
 The ScanPolicy defines a set of rules to evaluate for a particular scan to
 consider the artifacts (image or source code) either compliant or not.
@@ -163,118 +169,53 @@ spec:
     isCompliant = isSafe(input.currentVulnerability)
 ```
 
+See [Writing Policy Templates](scst-scan/policies.md) for more details]).
 
-##### ScanTemplate
+
+#### ScanTemplate
 
 A ScanTemplate defines the PodTemplateSpec to be used by a Job to run a
-particular scan (image or source). When an ImageScan our SourceScan is
+particular scan (image or source). When an ImageScan or SourceScan is
 instantiated by the supply chain, they reference these templates which must
 live in the same namespace as the Workload with the names matching the ones
 below:
 
-- source scanning (`blob-source-scan-template`):
+- source scanning (`blob-source-scan-template`)
+- image scanning (`private-image-scan-template`)
 
-```
-apiVersion: scanning.apps.tanzu.vmware.com/v1beta1
-kind: ScanTemplate
-metadata:
-  name: blob-source-scan-template
-spec:
-  template:
-    containers:
-    - args:
-      - -c
-      - ./source/scan-source.sh /workspace/source scan.xml
-      command:
-      - /bin/bash
-      image: registry.tanzu.vmware.com/supply-chain-security-tools/grype-templates-image@sha256:36d947257ffd5d962d09e61dc9083f5d0db57dbbde5f5d7c7cd91caa323a2c43
-      imagePullPolicy: IfNotPresent
-      name: scanner
-      resources:
-        limits:
-          cpu: 1000m
-        requests:
-          cpu: 250m
-          memory: 128Mi
-      volumeMounts:
-      - mountPath: /workspace
-        name: workspace
-        readOnly: false
-    imagePullSecrets:
-    - name: image-secret
-    initContainers:
-    - args:
-      - -c
-      - ./source/untar-gitrepository.sh $REPOSITORY /workspace
-      command:
-      - /bin/bash
-      image: registry.tanzu.vmware.com/supply-chain-security-tools/grype-templates-image@sha256:36d947257ffd5d962d09e61dc9083f5d0db57dbbde5f5d7c7cd91caa323a2c43
-      imagePullPolicy: IfNotPresent
-      name: repo
-      volumeMounts:
-      - mountPath: /workspace
-        name: workspace
-        readOnly: false
-    restartPolicy: Never
-    volumes:
-    - emptyDir: {}
-      name: workspace
-```
-
-- image scanning (`private-image-scan-template`):
+If you're targetting a namespace that doesn't match the one configured in the
+TAP Profiles (i.e, `grype.namespace` is not the same as the one you're writing
+the Workload to) these can be installed in such namespace by making use of the
+`tanzu package install` command as described in [Install Supply Chain Security
+Tools - Scan](install-components.md#install-scst-scan) ():
 
 
-```
-apiVersion: scanning.apps.tanzu.vmware.com/v1beta1
-kind: ScanTemplate
-metadata:
-  name: private-image-scan-template
-spec:
-  template:
-    containers:
-    - args:
-      - -c
-      - ./image/copy-docker-config.sh /secret-data && ./image/scan-image.sh /workspace
-        scan.xml true
-      command:
-      - /bin/bash
-      image: registry.tanzu.vmware.com/supply-chain-security-tools/grype-templates-image@sha256:36d947257ffd5d962d09e61dc9083f5d0db57dbbde5f5d7c7cd91caa323a2c43
-      imagePullPolicy: IfNotPresent
-      name: scanner
-      resources:
-        limits:
-          cpu: 1000m
-        requests:
-          cpu: 250m
-          memory: 128Mi
-      volumeMounts:
-      - mountPath: /.docker
-        name: docker
-        readOnly: false
-      - mountPath: /workspace
-        name: workspace
-        readOnly: false
-      - mountPath: /secret-data
-        name: registry-cred
-        readOnly: true
-    imagePullSecrets:
-    - name: image-secret
-    restartPolicy: Never
-    volumes:
-    - emptyDir: {}
-      name: docker
-    - emptyDir: {}
-      name: workspace
-    - name: registry-cred
-      secret:
-        secretName: image-secret
-```
+-  Create a file named `ootb-supply-chain-basic-values.yaml` that specifies the
+   corresponding values to the properties you want to tweak. For example:
 
-Although they can be customized, we recommend sticking with the examples
-above.
+    ```
+    grype:
+      namespace: my-dev-namespace
+      targetImagePullSecret: registry-credentials
+    ```
+
+- With the configuration ready, install the templates:
+
+    ```
+    tanzu package install grype-scanner \
+      --package-name grype.scanning.apps.tanzu.vmware.com \
+      --version 1.0.0 \
+      --namespace my-dev-namespace
+    ```
 
 
-##### Developer Workload
+**note**: Although the templates can be customized, we recommend sticking with
+what's provided by the instalation of `grype.scanning.apps.tanzu.vmware.com`
+(created in the same namespace as configured via `grype.namespace` in either
+TAP profiles or individual component installation as in the example above). See
+[Creating a ScanTemplate](scst-scan/create-scan-template.md) for more details.
+
+### Developer Workload
 
 With the ScanPolicy and ScanTemplate objects, with the required names set,
 submitted to the same namespace where the Workload will be submitted
@@ -294,7 +235,7 @@ configuration in git
   persisted in a repository
 
 
-###### Local iteration
+#### Local iteration
 
 For local iteration, all we need is the source code (in the example below,
 assuming the current directory `.` as the location of the source code we want
@@ -337,7 +278,7 @@ tanzu apps workload tail tanzu-java-web-app
 ```
 
 
-###### Local iteration with code from git
+#### Local iteration with code from git
 
 Similar to local iteration with local code, here we make use of the same type
 (`web`), but instead of pointing at source code that we have locally, we can
@@ -411,7 +352,7 @@ Out of The Box Supply Chain Basic.
 
 
 
-###### gitops
+#### gitops
 
 Differently from local iteration, the GitOps approach requires a secret
 containing credentials to a git provider (e.g., GitHub) to be exist in the same

--- a/scc/ootb-supply-chain-testing-scanning.md
+++ b/scc/ootb-supply-chain-testing-scanning.md
@@ -210,7 +210,7 @@ Tools - Scan](install-components.md#install-scst-scan) ():
 
 
 **note**: Although the templates can be customized, we recommend sticking with
-what's provided by the instalation of `grype.scanning.apps.tanzu.vmware.com`
+what's provided by the installation of `grype.scanning.apps.tanzu.vmware.com`
 (created in the same namespace as configured via `grype.namespace` in either
 TAP profiles or individual component installation as in the example above). See
 [Creating a ScanTemplate](scst-scan/create-scan-template.md) for more details.

--- a/scc/ootb-supply-chain-testing-scanning.md
+++ b/scc/ootb-supply-chain-testing-scanning.md
@@ -212,8 +212,11 @@ Tools - Scan](install-components.md#install-scst-scan) ():
 **note**: Although the templates can be customized, we recommend sticking with
 what's provided by the installation of `grype.scanning.apps.tanzu.vmware.com`
 (created in the same namespace as configured via `grype.namespace` in either
-TAP profiles or individual component installation as in the example above). See
-[Creating a ScanTemplate](scst-scan/create-scan-template.md) for more details.
+TAP profiles or individual component installation as in the example above) if
+you're just following the Getting Started guide. See [About Source and Image
+Scans](/scst-scan/explanation.md#about-source-and-image-scans) to know more
+about them.
+
 
 ### Developer Workload
 


### PR DESCRIPTION
hi folks,

here in this PR I propose that  rather than having the template inlined in our documentation, we refer people to installation w/ `tanzu package install` instead and point at the documentation that the scst team maintains so that instead of having to keep that up to date in two places, we can link to the best source of truth for that.

wdyt @xtreme-conor-nosal @nedenwalker?

thank you!

---

marking as a draft so we can gather insights from other folks beforehand. 
