### PR TITLE
ootb: update components documentation

### DIFF
--- a/install-components.md
+++ b/install-components.md
@@ -17,10 +17,11 @@ For information, see [Installing part I: Prerequisites, EULA, and CLI](install-g
 + [Install Application Accelerator](#install-app-accelerator)
 + [Install Tanzu Build Service](#install-tbs)
 + [Install Supply Chain Choreographer](#install-scc)
++ [Install Out of the Delivery Basic](#install-ootb- delivery-basic)
 + [Install Out of the Box Templates](#install-ootb-templates)
 + [Install Out of The Box Supply Chain Basic](#install-ootb-supply-chain-basic)
 + [Install Out of The Box Supply Chain with Testing](#install-ootb-supply-chain-testing)
-+ [Install Out of The Box Supply Chain with Testing and Scanning](#install-ootb-sc-test-scan)
++ [Install Out of The Box Supply Chain with Testing and Scanning](#install-ootb-supply-chain-testing-scanning)
 + [Install Developer Conventions](#install-developer-conventions)
 + [Install Spring Boot Conventions](#install-spring-boot-convention)
 + [Install Application Live View](#install-app-live-view)
@@ -807,17 +808,6 @@ To install Tanzu Build Service using the Tanzu CLI:
 
 ## <a id='install-scc'></a> Install Supply Chain Choreographer
 
-[cartographer]: https://github.com/vmware-tanzu/cartographer
-[cert-manager]: https://github.com/jetstack/cert-manager
-[convention-controller]: https://github.com/vmware-tanzu/convention-controller
-[kapp-controller]: https://github.com/vmware-tanzu/carvel-kapp-controller
-[knative-serving]: https://knative.dev/docs/serving/
-[kpack]: https://github.com/pivotal/kpack
-[secretgen-controller]: https://github.com/vmware-tanzu/carvel-secretgen-controller
-[source-controller]: https://github.com/fluxcd/source-controller
-[tanzu cli]: https://github.com/vmware-tanzu/tanzu-framework/tree/main/cmd/cli#installation
-[tekton]: https://github.com/tektoncd/pipeline
-
 Supply Chain Choreographer provides the custom resource definitions that the supply chain uses.
 Each pre-approved supply chain creates a paved road to production and orchestrates supply chain resources. You can test, build, scan, and deploy. Developers can focus on delivering value to
 users. App Operators can have peace of mind that all code in production has passed
@@ -827,29 +817,97 @@ For example, Supply Chain Choreographer passes the results of fetching source co
 that knows how to build a container image from of it and then passes the container image
 to a component that knows how to deploy the image.
 
-1. Install v0.0.7 of the `cartographer.tanzu.vmware.com` package, naming the installation `cartographer`.
+1. Install v0.1.0-rc.1 of the `cartographer.tanzu.vmware.com` package, naming the installation `cartographer`.
 
     ```
     tanzu package install cartographer \
       --namespace tap-install \
       --package-name cartographer.tanzu.vmware.com \
-      --version 0.0.7
+      --version 0.1.0-rc.1
     ```
 
     Example output:
 
     ```
     | Installing package 'cartographer.tanzu.vmware.com'
-    | Getting namespace 'default'
+    | Getting namespace 'tap-install'
     | Getting package metadata for 'cartographer.tanzu.vmware.com'
-    | Creating service account 'cartographer-default-sa'
-    | Creating cluster admin role 'cartographer-default-cluster-role'
-    | Creating cluster role binding 'cartographer-default-cluster-rolebinding'
+    | Creating service account 'cartographer-tap-install-sa'
+    | Creating cluster admin role 'cartographer-tap-install-cluster-role'
+    | Creating cluster role binding 'cartographer-tap-install-cluster-rolebinding'
     - Creating package resource
     \ Package install status: Reconciling
-    
-    Added installed package 'cartographer' in namespace 'default'
+
+    Added installed package 'cartographer' in namespace 'tap-install'
     ```
+
+
+## <a id='install-ootb-delivery-basic'></a> Install Out of the Box Delivery Basic
+
+The Out of the Box Delivery Basic package is used by all the Out of the Box
+Supply Chains to deliver to a Kubernetes environment the objects that have been
+produced by the them.
+
+
+### Prerequisites
+
+- Cartographer
+
+
+### Install
+
+1. Familiarize yourself with the set of values of the package that can be
+   configured by running:
+
+    ```
+    tanzu package available get ootb-delivery-basic.tanzu.vmware.com/0.5.0-build.1 \
+      --values-schema \
+      -n tap-install
+    ```
+
+    For example:
+
+    ```
+    KEY                  DEFAULT  TYPE    DESCRIPTION
+    service_account      default  string  Name of the service account in the
+                                          namespace where the Deliverable is
+                                          submitted to.
+    ```
+
+1. Create a file named `ootb-delivery-basic-values.yaml` that specifies the
+   corresponding values to the properties you want to tweak. For example:
+
+    ```
+    service_account: default
+    ```
+
+1. With the configuration ready, install the package by running:
+
+
+    ```
+    tanzu package install ootb-delivery-basic \
+      --package-name ootb-delivery-basic.tanzu.vmware.com \
+      --version 0.5.0-build.1 \
+      --namespace tap-install \
+      --values-file ootb-delivery-basic-values.yaml
+    ```
+
+    Example output:
+
+    ```
+    \ Installing package 'ootb-delivery-basic.tanzu.vmware.com'
+    | Getting package metadata for 'ootb-delivery-basic.tanzu.vmware.com'
+    | Creating service account 'ootb-delivery-basic-tap-install-sa'
+    | Creating cluster admin role 'ootb-delivery-basic-tap-install-cluster-role'
+    | Creating cluster role binding 'ootb-delivery-basic-tap-install-cluster-rolebinding'
+    | Creating secret 'ootb-delivery-basic-tap-install-values'
+    | Creating package resource
+    - Waiting for 'PackageInstall' reconciliation for 'ootb-delivery-basic'
+    / 'PackageInstall' resource install status: Reconciling
+
+     Added installed package 'ootb-delivery-basic' in namespace 'tap-install'
+    ```
+
 
 ## <a id='install-ootb-templates'></a> Install Out of the Box Templates
 
@@ -873,15 +931,15 @@ install it is the following command:
 ```
 tanzu package install ootb-templates \
   --package-name ootb-templates.tanzu.vmware.com \
-  --version 0.4.0-build.1 \
+  --version 0.5.0-build.1 \
   --namespace tap-install
 ```
 ```
 \ Installing package 'ootb-templates.tanzu.vmware.com'
 | Getting package metadata for 'ootb-templates.tanzu.vmware.com'
-| Creating service account 'ootb-templates-default-sa'
-| Creating cluster admin role 'ootb-templates-default-cluster-role'
-| Creating cluster role binding 'ootb-templates-default-cluster-rolebinding'
+| Creating service account 'ootb-templates-tap-install-sa'
+| Creating cluster admin role 'ootb-templates-tap-install-cluster-role'
+| Creating cluster role binding 'ootb-templates-tap-install-cluster-rolebinding'
 | Creating package resource
 / Waiting for 'PackageInstall' reconciliation for 'ootb-templates'
 / 'PackageInstall' resource install status: Reconciling
@@ -905,10 +963,11 @@ Cartographer
 
 ### Install
 
-1. Familiarize yourself with the set of values of the package that can be configured by running:
+1. Familiarize yourself with the set of values of the package that can be
+   configured by running:
 
     ```
-    tanzu package available get ootb-supply-chain-basic.tanzu.vmware.com/0.4.0-build.1 \
+    tanzu package available get ootb-supply-chain-basic.tanzu.vmware.com/0.5.0-build.1 \
       --values-schema \
       -n tap-install
     ```
@@ -916,31 +975,64 @@ Cartographer
     For example:
 
     ```
-    KEY                  TYPE    DESCRIPTION
+    KEY                       DESCRIPTION
 
-    registry.repository  string  Name of the repository in the image registry server where
-                                 the application images from the workload be pushed to
-                                 (required).
+    registry.repository       Name of the repository in the image registry server where
+                              the application images from he workloould be pushed to
+                              (required).
 
-    registry.server      string  Name of the registry server where application images should
-                                 be pushed to (required).
+    registry.server           Name of the registry server where application images should
+                              be pushed to (required).
 
-    cluster_builder      string  Name of the Tanzu Build Service (TBS) ClusterBuilder to
-                                 use by default on image objects managed by the supply chain.
 
-    service_account      string  Name of the service account in the namespace where the Workload
-                                 is submitted to utilize for providing registry credentials to
-                                 Tanzu Build Service (TBS) Image objects as well as deploying the
-                                 application.
+
+    gitops.username           Default user name to be used for the commits produced by the
+                              supply chain.
+
+    gitops.branch             Default branch to use for pushing Kubernetes configuration files
+                              produced by the supply chain.
+
+    gitops.commit_message     Default git commit message to write when publishing Kubernetes
+                              configuration files produces by the supply chain to git.
+
+    gitops.email              Default user email to be used for the commits produced by the
+                              supply chain.
+
+    gitops.repository_prefix  Default prefix to be used for forming Git SSH URLs for pushing
+                              Kubernetes configuration produced by the supply chain.
+
+    gitops.ssh_secret         Name of the default Secret containing SSH credentials to lookup
+                              in the developer namespace for the supply chain to fetch source
+                              code from and push configuration to.
+
+
+
+    cluster_builder           Name of the Tanzu Build Service (TBS) ClusterBuilder to
+                              use by default on image objects managed by the supply chain.
+
+    service_account           Name of the service account in the namespace where the Workload
+                              is submitted to utilize for providing registry credentials to
+                              Tanzu Build Service (TBS) Image objects as well as deploying the
+                              application.
     ```
 
-1. Create a file named `ootb-supply-chain-basic-values.yaml` that specifies the corresponding values
-to the properties you want to tweak. For example:
+1. Create a file named `ootb-supply-chain-basic-values.yaml` that specifies the
+   corresponding values to the properties you want to tweak. For example:
 
     ```
     registry:
       server: REGISTRY-SERVER
       repository: REGISTRY-REPOSITORY
+
+    gitops:
+      repository_prefix: git@github.com:vmware-tanzu/
+      branch: main
+      user_name: supplychain
+      user_email: supplychain
+      commit_message: supplychain@cluster.local
+      ssh_secret: git-ssh
+
+    cluster_builder: default
     service_account: default
     ```
 
@@ -949,19 +1041,20 @@ to the properties you want to tweak. For example:
     ```
     tanzu package install ootb-supply-chain-basic \
       --package-name ootb-supply-chain-basic.tanzu.vmware.com \
-      --version 0.4.0-build.1 \
+      --version 0.5.0-build.1 \
       --namespace tap-install \
       --values-file ootb-supply-chain-basic-values.yaml
     ```
+
     Example output:
 
     ```
     \ Installing package 'ootb-supply-chain-basic.tanzu.vmware.com'
     | Getting package metadata for 'ootb-supply-chain-basic.tanzu.vmware.com'
-    | Creating service account 'ootb-supply-chain-basic-default-sa'
-    | Creating cluster admin role 'ootb-supply-chain-basic-default-cluster-role'
-    | Creating cluster role binding 'ootb-supply-chain-basic-default-cluster-rolebinding'
-    | Creating secret 'ootb-supply-chain-basic-default-values'
+    | Creating service account 'ootb-supply-chain-basic-tap-install-sa'
+    | Creating cluster admin role 'ootb-supply-chain-basic-tap-install-cluster-role'
+    | Creating cluster role binding 'ootb-supply-chain-basic-tap-install-cluster-rolebinding'
+    | Creating secret 'ootb-supply-chain-basic-tap-install-values'
     | Creating package resource
     - Waiting for 'PackageInstall' reconciliation for 'ootb-supply-chain-basic'
     / 'PackageInstall' resource install status: Reconciling
@@ -986,6 +1079,7 @@ You must have installed:
 - Cartographer
 - Out of The Box Delivery Basic (`ootb-delivery-basic.tanzu.vmware.com`)
 - Out of The Box Templates (`ootb-templates.tanzu.vmware.com`)
+
 
 ### Install
 
@@ -1024,10 +1118,10 @@ Install by following these steps:
         | Uninstalling package 'ootb-supply-chain-testing-scanning' from namespace 'tap-install'
         \ Getting package install for 'ootb-supply-chain-testing-scanning'
         - Deleting package install 'ootb-supply-chain-testing-scanning' from namespace 'tap-install'
-        | Deleting admin role 'ootb-supply-chain-testing-scanning-default-cluster-role'
-        | Deleting role binding 'ootb-supply-chain-testing-scanning-default-cluster-rolebinding'
-        | Deleting secret 'ootb-supply-chain-testing-scanning-default-values'
-        | Deleting service account 'ootb-supply-chain-testing-scanning-default-sa'
+        | Deleting admin role 'ootb-supply-chain-testing-scanning-tap-install-cluster-role'
+        | Deleting role binding 'ootb-supply-chain-testing-scanning-tap-install-cluster-rolebinding'
+        | Deleting secret 'ootb-supply-chain-testing-scanning-tap-install-values'
+        | Deleting service account 'ootb-supply-chain-testing-scanning-tap-install-sa'
      
          Uninstalled package 'ootb-supply-chain-testing-scanning' from namespace 'tap-install'
         ```
@@ -1035,48 +1129,77 @@ Install by following these steps:
 1. Check the values of the package that can be configured by running:
 
     ```
-    tanzu package available get ootb-supply-chain-testing.tanzu.vmware.com/0.4.0-build.1 \
-      --values-schema \
-      -n tap-install
+    KEY                       DESCRIPTION
+
+    registry.repository       Name of the repository in the image registry server where
+                              the application images from he workloould be pushed to
+                              (required).
+
+    registry.server           Name of the registry server where application images should
+                              be pushed to (required).
+
+
+
+    gitops.username           Default user name to be used for the commits produced by the
+                              supply chain.
+
+    gitops.branch             Default branch to use for pushing Kubernetes configuration files
+                              produced by the supply chain.
+
+    gitops.commit_message     Default git commit message to write when publishing Kubernetes
+                              configuration files produces by the supply chain to git.
+
+    gitops.email              Default user email to be used for the commits produced by the
+                              supply chain.
+
+    gitops.repository_prefix  Default prefix to be used for forming Git SSH URLs for pushing
+                              Kubernetes configuration produced by the supply chain.
+
+    gitops.ssh_secret         Name of the default Secret containing SSH credentials to lookup
+                              in the developer namespace for the supply chain to fetch source
+                              code from and push configuration to.
+
+
+
+    cluster_builder           Name of the Tanzu Build Service (TBS) ClusterBuilder to
+                              use by default on image objects managed by the supply chain.
+
+    service_account           Name of the service account in the namespace where the Workload
+                              is submitted to utilize for providing registry credentials to
+                              Tanzu Build Service (TBS) Image objects as well as deploying the
+                              application.
     ```
 
-    Example output:
-
-    ```
-    KEY                  TYPE    DESCRIPTION
-
-    registry.repository  string  Name of the repository in the image registry server where
-                                 the application images from the workload be pushed to
-                                 (required).
-
-    registry.server      string  Name of the registry server where application images should
-                                 be pushed to (required).
-
-    cluster_builder      string  Name of the Tanzu Build Service (TBS) ClusterBuilder to
-                                 use by default on image objects managed by the supply chain.
-
-    service_account      string  Name of the service account in the namespace where the Workload
-                                 is submitted to utilize for providing registry credentials to
-                                 Tanzu Build Service (TBS) Image objects as well as deploying the
-                                 application.
-    ```
-
-1. Create a file named `ootb-supply-chain-testing-values.yaml` that specifies the corresponding
-values to the properties you want to tweak. For example:
+1. Create a file named `ootb-supply-chain-testing-values.yaml` that specifies the
+   corresponding values to the properties you want to tweak. For example:
 
     ```
     registry:
       server: REGISTRY-SERVER
       repository: REGISTRY-REPOSITORY
+
+    gitops:
+      repository_prefix: git@github.com:vmware-tanzu/
+      branch: main
+      user_name: supplychain
+      user_email: supplychain
+      commit_message: supplychain@cluster.local
+      ssh_secret: git-ssh
+
+    cluster_builder: default
     service_account: default
     ```
+
+    >**Note:** it's **required** that the `gitops.repository_prefix` field ends
+    > with a `/`.
+
 
 1. With the configuration ready, install the package by running:
 
     ```
     tanzu package install ootb-supply-chain-testing \
       --package-name ootb-supply-chain-testing.tanzu.vmware.com \
-      --version 0.4.0-build.1 \
+      --version 0.5.0-build.1 \
       --namespace tap-install \
       --values-file ootb-supply-chain-testing-values.yaml
     ```
@@ -1086,10 +1209,10 @@ values to the properties you want to tweak. For example:
     ```
     \ Installing package 'ootb-supply-chain-testing.tanzu.vmware.com'
     | Getting package metadata for 'ootb-supply-chain-testing.tanzu.vmware.com'
-    | Creating service account 'ootb-supply-chain-testing-default-sa'
-    | Creating cluster admin role 'ootb-supply-chain-testing-default-cluster-role'
-    | Creating cluster role binding 'ootb-supply-chain-testing-default-cluster-rolebinding'
-    | Creating secret 'ootb-supply-chain-testing-default-values'
+    | Creating service account 'ootb-supply-chain-testing-tap-install-sa'
+    | Creating cluster admin role 'ootb-supply-chain-testing-tap-install-cluster-role'
+    | Creating cluster role binding 'ootb-supply-chain-testing-tap-install-cluster-rolebinding'
+    | Creating secret 'ootb-supply-chain-testing-tap-install-values'
     | Creating package resource
     - Waiting for 'PackageInstall' reconciliation for 'ootb-supply-chain-testing'
     \ 'PackageInstall' resource install status: Reconciling
@@ -1098,7 +1221,7 @@ values to the properties you want to tweak. For example:
     ```
 
 
-## <a id='install-ootb-sc-test-scan'></a> Install Out of The Box Supply Chain with Testing and Scanning
+## <a id='install-ootb-supply-chain-testing-scanning'></a> Install Out of The Box Supply Chain with Testing and Scanning
 
 The Out of the Box Supply Chain with Testing and Scanning package provides a
 ClusterSupplyChain that brings an application from source code to a deployed
@@ -1106,11 +1229,13 @@ instance of it running in a Kubernetes environment performing validations not
 only in terms of running application tests, but also scanning the source code
 and image for vulnerabilities.
 
+
 ### Prerequisites
 
 - Cartographer
 - Out of The Box Delivery Basic (`ootb-delivery-basic.tanzu.vmware.com`)
 - Out of The Box Templates (`ootb-templates.tanzu.vmware.com`)
+
 
 ### Install
 
@@ -1147,10 +1272,10 @@ and image for vulnerabilities.
         | Uninstalling package 'ootb-supply-chain-testing' from namespace 'tap-install'
         \ Getting package install for 'ootb-supply-chain-testing'
         - Deleting package install 'ootb-supply-chain-testing' from namespace 'tap-install'
-        | Deleting admin role 'ootb-supply-chain-testing-default-cluster-role'
-        | Deleting role binding 'ootb-supply-chain-testing-default-cluster-rolebinding'
-        | Deleting secret 'ootb-supply-chain-testing-default-values'
-        | Deleting service account 'ootb-supply-chain-testing-default-sa'
+        | Deleting admin role 'ootb-supply-chain-testing-tap-install-cluster-role'
+        | Deleting role binding 'ootb-supply-chain-testing-tap-install-cluster-rolebinding'
+        | Deleting secret 'ootb-supply-chain-testing-tap-install-values'
+        | Deleting service account 'ootb-supply-chain-testing-tap-install-sa'
      
          Uninstalled package 'ootb-supply-chain-testing' from namespace 'tap-install'
         ```
@@ -1158,48 +1283,85 @@ and image for vulnerabilities.
 1. Check the values of the package that can be configured by running:
 
     ```
-    tanzu package available get ootb-supply-chain-testing-scanning.tanzu.vmware.com/0.4.0-build.1 \
+    tanzu package available get ootb-supply-chain-testing-scanning.tanzu.vmware.com/0.5.0-build.1 \
       --values-schema \
       -n tap-install
     ```
 
-    Example output:
+    For example:
 
     ```
-    KEY                  TYPE    DESCRIPTION
+    KEY                       DESCRIPTION
 
-    registry.repository  string  Name of the repository in the image registry server where
-                                 the application images from the workload be pushed to
-                                 (required).
+    registry.repository       Name of the repository in the image registry server where
+                              the application images from he workloould be pushed to
+                              (required).
 
-    registry.server      string  Name of the registry server where application images should
-                                 be pushed to (required).
+    registry.server           Name of the registry server where application images should
+                              be pushed to (required).
 
-    cluster_builder      string  Name of the Tanzu Build Service (TBS) ClusterBuilder to
-                                 use by default on image objects managed by the supply chain.
 
-    service_account      string  Name of the service account in the namespace where the Workload
-                                 is submitted to utilize for providing registry credentials to
-                                 Tanzu Build Service (TBS) Image objects as well as deploying the
-                                 application.
+    gitops.username           Default user name to be used for the commits produced by the
+                              supply chain.
+
+    gitops.branch             Default branch to use for pushing Kubernetes configuration files
+                              produced by the supply chain.
+
+    gitops.commit_message     Default git commit message to write when publishing Kubernetes
+                              configuration files produces by the supply chain to git.
+
+    gitops.email              Default user email to be used for the commits produced by the
+                              supply chain.
+
+    gitops.repository_prefix  Default prefix to be used for forming Git SSH URLs for pushing
+                              Kubernetes configuration produced by the supply chain.
+
+    gitops.ssh_secret         Name of the default Secret containing SSH credentials to lookup
+                              for the supply chain to push configuration to.
+
+
+    cluster_builder           Name of the Tanzu Build Service (TBS) ClusterBuilder to
+                              use by default on image objects managed by the supply chain.
+
+    service_account           Name of the service account in the namespace where the Workload
+                              is submitted to utilize for providing registry credentials to
+                              Tanzu Build Service (TBS) Image objects as well as deploying the
+                              application.
+
+    cluster_builder           Name of the Tanzu Build Service (TBS) ClusterBuilder to use by
+                              default on image objects managed by the supply chain.
     ```
 
-1. Create a file named `ootb-supply-chain-testing-scanning-values.yaml` that specifies the
-corresponding values to the properties you want to tweak. For example:
+1. Create a file named `ootb-supply-chain-testing-values.yaml` that specifies
+   the corresponding values to the properties you want to tweak. For example:
 
     ```
     registry:
       server: REGISTRY-SERVER
       repository: REGISTRY-REPOSITORY
+
+    gitops:
+      repository_prefix: git@github.com:vmware-tanzu/
+      branch: main
+      user_name: supplychain
+      user_email: supplychain
+      commit_message: supplychain@cluster.local
+      ssh_secret: git-ssh
+
+    cluster_builder: default
     service_account: default
     ```
 
+    >**Note:** it's **required** that the `gitops.repository_prefix` field ends
+    > with a `/`.
+
 1. With the configuration ready, install the package by running:
+
 
     ```
     tanzu package install ootb-supply-chain-testing-scanning \
       --package-name ootb-supply-chain-testing-scanning.tanzu.vmware.com \
-      --version 0.4.0-build.1 \
+      --version 0.5.0-build.1 \
       --namespace tap-install \
       --values-file ootb-supply-chain-testing-scanning-values.yaml
     ```
@@ -1209,16 +1371,17 @@ corresponding values to the properties you want to tweak. For example:
     ```
     \ Installing package 'ootb-supply-chain-testing-scanning.tanzu.vmware.com'
     | Getting package metadata for 'ootb-supply-chain-testing-scanning.tanzu.vmware.com'
-    | Creating service account 'ootb-supply-chain-testing-scanning-default-sa'
-    | Creating cluster admin role 'ootb-supply-chain-testing-scanning-default-cluster-role'
-    | Creating cluster role binding 'ootb-supply-chain-testing-scanning-default-cluster-rolebinding'
-    | Creating secret 'ootb-supply-chain-testing-scanning-default-values'
+    | Creating service account 'ootb-supply-chain-testing-scanning-tap-install-sa'
+    | Creating cluster admin role 'ootb-supply-chain-testing-scanning-tap-install-cluster-role'
+    | Creating cluster role binding 'ootb-supply-chain-testing-scanning-tap-install-cluster-rolebinding'
+    | Creating secret 'ootb-supply-chain-testing-scanning-tap-install-values'
     | Creating package resource
     - Waiting for 'PackageInstall' reconciliation for 'ootb-supply-chain-testing-scanning'
     \ 'PackageInstall' resource install status: Reconciling
     
     Added installed package 'ootb-supply-chain-testing-scanning' in namespace 'tap-install'
     ```
+
 
 ## <a id='install-developer-conventions'></a> Install Developer Conventions
 

--- a/scc/ootb-delivery-basic.md
+++ b/scc/ootb-delivery-basic.md
@@ -1,7 +1,4 @@
----
-title: Out of The Box Delivery Basic (ootb-delivery-basic)
-weight: 2
----
+# Out of The Box Delivery Basic (ootb-delivery-basic)
 
 This package provides a reusable ClusterDelivery object that is responsible for
 delivering to an environment the Kubernetes configuration that has been

--- a/scc/ootb-supply-chain-testing-scanning.md
+++ b/scc/ootb-supply-chain-testing-scanning.md
@@ -1,4 +1,4 @@
-# Out of The Box Supply Chain with Testing and Scanning
+# Out of The Box Supply Chain with Testing and Scanning (ootb-supply-chain-testing-scanning)
 
 This Cartographer Supply Chain ties a series of Kubernetes resources which,
 when working together, drives a developer-provided Workload from source code
@@ -72,8 +72,7 @@ As mentioned in the prerequisites section, this example builds on the previous
 Out of The Box Supply Chain examples, so only additions are included here.
 
 To make sure you have configured the namespace correctly, it's important that
-the namespace has the following objects in it (including the ones marked with
-'_new_' whose explanation and details are provided below):
+the namespace has the objects we configured in the other supply chain setups:
 
 - **image secret**: A Kubernetes secret of type `kubernetes.io/dockerconfigjson` filled with
 credentials for pushing the container images built by the supply chain. For more information, see
@@ -96,6 +95,9 @@ For more information, see [Supply Chain Basic](ootb-supply-chain-basic.md).
 - **tekton pipeline**: A pipeline to be ran whenever the supply chain hits the stage of testing the
 source code. For more information, see [Supply Chain with Testing](ootb-supply-chain-testing.md).
 
+
+And the new ones we create here:
+
 - **scan policy**: Defines what to do with the results taken from scanning the source code and
 image produced. For more information, see [ScanPolicy section](#scan-policy).
 
@@ -104,6 +106,9 @@ code. For more information, see [ScanTemplate section](#scan-template).
 
 - **image scan template**: A template of how jobs are created for scanning the image
 produced by the supply chain. For more information, see [ScanTemplate section](#scan-template).
+
+Below you'll find details about the new objects (compared to Out of The Box
+Supply Chain With Testing).
 
 
 ### Updates to the developer namespace
@@ -207,82 +212,24 @@ to the properties you want to tweak. For example:
 >[About Source and Image Scans](scst-scan/explanation.md#about-source-and-image-scans).
 
 
-### Developer Workload
+## Developer Workload
 
 With the ScanPolicy and ScanTemplate objects, with the required names set,
 submitted to the same namespace where the Workload will be submitted
 to, we're ready to submit our Workload.
 
-We can configure the Workload with two scenarios in mind:
+Regardless of the workflow being targgeted (local development or gitops), the
+Workload configuration details are the same as in Out of The Box Supply Chain
+Basic, except that we mark the Workload as having tests enabled.
 
-- local iteration: takes source code from the filesystem and
-  drives is through the supply chain making no use of external git repositories
-
-- local iteration with code from git: takes source code from a git repository
-  and drives it through the supply chain without persisting the final
-configuration in git
-
-- gitops: source code is provided by an external git repository (public _or_
-  private), and the final kubernetes configuration to deploy the application is
-  persisted in a repository
-
-
-#### Local iteration
-
-For local iteration, all we need is the source code (in the example below,
-assuming the current directory `.` as the location of the source code we want
-to send through the supply chain), and a container image registry to use as the
-mean for making the source code available inside the Kubernetes cluster.
-
-
-```
-tanzu apps workload create tanzu-java-web-app \
-  --local-path . \
-  --source-image $REGISTRY/source \
-  --label apps.tanzu.vmware.com/has-tests=true \
-  --type web
-```
-```
-Create workload:
-      1 + |---
-      2 + |apiVersion: carto.run/v1alpha1
-      3 + |kind: Workload
-      4 + |metadata:
-      5 + |  labels:
-      6 + |    apps.tanzu.vmware.com/has-tests: "true"
-      7 + |    apps.tanzu.vmware.com/workload-type: web
-      8 + |  name: tanzu-java-web-app
-      9 + |  namespace: default
-     10 + |spec:
-     11 + |  source:
-     12 + |    image: 10.188.0.3:5000/source:latest@sha256:1cb23472fcdcce276c316d9bed6055625fbc4ac3e50a971f8f8004b1e245981e
-
-? Do you want to create this workload? Yes
-Created workload "tanzu-java-web-app"
-```
-
-With the Workload submitted, we should be able to keep track of the resulting
-series of Kubernetes objects created to drive the source code all the way to a
-deployed application by making use of the `tail` command:
-
-```
-tanzu apps workload tail tanzu-java-web-app
-```
-
-
-#### Local iteration with code from git
-
-Similar to local iteration with local code, here we make use of the same type
-(`web`), but instead of pointing at source code that we have locally, we can
-make use of a git repository to feed the supply chain with new changes as they
-are pushed to a branch.
-
+For instance:
 
 ```
 tanzu apps workload create tanzu-java-web-app \
   --git-branch main \
-  --git-repo https://github.com/sample-accelerators/tanzu-java-web-app \
+  --git-repo https://github.com/sample-accelerators/tanzu-java-web-app
   --label apps.tanzu.vmware.com/has-tests=true \
+  --label app.kubernetes.io/part-of=tanzu-java-web-app \
   --type web
 ```
 ```
@@ -292,222 +239,15 @@ Create workload:
       3 + |kind: Workload
       4 + |metadata:
       5 + |  labels:
-      6 + |    apps.tanzu.vmware.com/has-tests: "true"
-      7 + |    apps.tanzu.vmware.com/workload-type: web
-      8 + |  name: tanzu-java-web-app
-      9 + |  namespace: default
-     10 + |spec:
-     11 + |  source:
-     12 + |    git:
-     13 + |      ref:
-     14 + |        branch: main
-     15 + |      url: https://github.com/sample-accelerators/tanzu-java-web-app
+      6 + |    apps.tanzu.vmware.com/workload-type: web
+      7 + |    apps.tanzu.vmware.com/has-tests: "true"
+      8 + |    app.kubernetes.io/part-of: tanzu-java-web-app
+      9 + |  name: tanzu-java-web-app
+     10 + |  namespace: default
+     11 + |spec:
+     12 + |  source:
+     13 + |    git:
+     14 + |      ref:
+     15 + |        branch: main
+     16 + |      url: https://github.com/sample-accelerators/tanzu-java-web-app
 ```
-
-In the example above, we make use of a public repository, but, if you want to
-make use of a private repository instead, make sure you create a Secret in the
-same namespace as the one where the Workload is being submitted to, and add the
-`--param source_git_ssh_secret=<>` parameter to the set of parameters above.
-
-```
-tanzu apps workload create tanzu-java-web-app \
-  --git-branch main \
-  --git-repo git@github.com:sample-accelerators/tanzu-java-web-app.git \
-  --param source_git_ssh_secret=git-ssh \
-  --label apps.tanzu.vmware.com/has-tests=true \
-  --type web
-```
-```
-Create workload:
-      1 + |---
-      2 + |apiVersion: carto.run/v1alpha1
-      3 + |kind: Workload
-      4 + |metadata:
-      5 + |  labels:
-      6 + |    apps.tanzu.vmware.com/has-tests: "true"
-      7 + |    apps.tanzu.vmware.com/workload-type: web
-      8 + |  name: tanzu-java-web-app
-      9 + |  namespace: default
-     10 + |spec:
-     11 + |  params:
-     12 + |  - name: source_git_ssh_secret
-     13 + |    value: git-ssh
-     14 + |  source:
-     15 + |    git:
-     16 + |      ref:
-     17 + |        branch: main
-     18 + |      url: git@github.com:sample-accelerators/tanzu-java-web-app.git
-```
-
-For more information of how to set up that secret, check out this section on
-Out of The Box Supply Chain Basic.
-
-
-
-#### gitops
-
-Differently from local iteration, the GitOps approach requires a secret
-containing credentials to a git provider (e.g., GitHub) to be exist in the same
-namespace as the Workload, and a couple parameters to be set with details about
-the commit to be pushed to the repository where Kubernetes configuration is
-delivered to.
-
-Before proceeding, make sure you have a secret with following shape fields and
-annotations set:
-
-```
-apiVersion: v1
-kind: Secret
-metadata:
-  name: git-ssh
-  annotations:
-    tekton.dev/git-0: github.com  # git server host
-type: kubernetes.io/ssh-auth
-stringData:
-  ssh-privatekey: string          # private key with push-permissions
-  known_hosts: string             # git server public keys
-  identity:                       # private key with pull permissions
-  identity.pub:                   # public of the `identity` private key
-```
-
-With the Secret created, we can move on to the Workload:
-
-
-```
-tanzu apps workload create tanzu-java-web-app \
-  --git-repo git@github.com:sample-accelerators/tanzu-java-web-app.git \
-  --git-branch main \
-  --param "delivery_git_branch=main" \
-  --param "delivery_git_commit_message=bump" \
-  --param "delivery_git_repository=git@github.com:my-team/staging-repository.git" \
-  --param "delivery_git_user_email=team@team.com" \
-  --param "delivery_git_user_name=team" \
-  --param "delivery_git_ssh_secret=git-ssh" \
-  --param "source_git_ssh_secret=git-ssh" \
-  --label apps.tanzu.vmware.com/has-tests=true \
-  --type web
-```
-```
-Create workload:
-      1 + |---
-      2 + |apiVersion: carto.run/v1alpha1
-      3 + |kind: Workload
-      4 + |metadata:
-      5 + |  labels:
-      6 + |    apps.tanzu.vmware.com/has-tests: "true"
-      7 + |    apps.tanzu.vmware.com/workload-type: web
-      8 + |  name: tanzu-java-web-app
-      9 + |  namespace: default
-     10 + |spec:
-     11 + |  params:
-     12 + |  - name: delivery_git_branch
-     13 + |    value: main
-     14 + |  - name: delivery_git_commit_message
-     15 + |    value: bump
-     16 + |  - name: delivery_git_repository
-     17 + |    value: git@github.com:my-team/staging-repository.git
-     18 + |  - name: delivery_git_user_email
-     19 + |    value: team@team.com
-     20 + |  - name: delivery_git_user_name
-     21 + |    value: team
-     22 + |  - name: delivery_git_ssh_secret
-     23 + |    value: git-ssh
-     24 + |  - name: source_git_ssh_secret
-     25 + |    value: git-ssh
-     26 + |  source:
-     27 + |    git:
-     28 + |      ref:
-     29 + |        branch: main
-     30 + |      url: git@github.com:sample-accelerators/tanzu-java-web-app.git
-
-? Do you want to create this workload? Yes
-Created workload "tanzu-java-web-app"
-```
-
-Where:
-
--  `delivery_git_ssh_secret` (required): name of the secret in the same
-   namespace as the Workload where SSH credentials exist for pushing the
-   configuration produced by the supply chain to a git repository.
-   e.g.: "ssh-secret"
-
--  `delivery_git_repository` (required): SSH url of the git repository to push
-   the Kubernetes configuration produced by the supply chain to.
-   e.g.: "ssh://git@foo.com/staging.git"
-
--  `delivery_git_branch`: name of the branch to push the configuration to.
-   e.g.: "main"
-
--  `delivery_git_commit_message`: message to write as the body of the commits
-   produced for pushing configuration to the git repository.
-   e.g.: "ci bump"
-
--  `delivery_git_user_name`: user name to use in the commits.
-   e.g.: "Alice Lee"
-
--  `delivery_git_user_email`: user email to use for the commits.
-   e.g.: "foo@example.com"
-
--  `source_git_ssh_secret` (required, if source is private): name of the secret
-   in the same namespace as the Workload where SSH credentials exist for
-   fetching the source code of `workload.spec.source.git`.
-
-
-### Known Issues
-
-#### Scanning logs
-
-At the moment, `tanzu apps workload tail` _will not_ provide the logs of the
-Jobs created for source and image scanning. In order to get those, make use of
-`kubectl tree` to find the Pods created as children resources and use `kubectl
-logs` to visualize them.
-
-For instance, assuming we want to discover the logs of an ImageScan, we can
-look at the tree of child objects:
-
-```
-kubectl tree workload tanzu-java-web-app
-```
-```
-NAMESPACE     NAME
-default       Workload/workload
-default       ├─ConfigMap/workload
-default       ├─Deliverable/workload
-default       │ ├─App/workload
-default       │ └─ImageRepository/workload-delivery
-default       ├─Image/workload
-default       │ ├─Build/workload-build-1
-default       │ │ └─Pod/workload-build-1-build-pod
-default       │ ├─PersistentVolumeClaim/workload-cache
-default       │ └─SourceResolver/workload-source
-default       ├─ImageRepository/workload
-default       ├─ImageScan/workload											<< !!
-default       │ └─Job/scan-workloadw96rc                << !!
-default       │   └─Pod/scan-workloadw96rc-6724n        << !!
-default       ├─PodIntent/workload
-default       ├─Runnable/workload
-default       │ └─PipelineRun/workload-hrllc
-default       │   └─TaskRun/workload-hrllc-test
-default       │     └─Pod/workload-hrllc-test-pod
-default       ├─Runnable/workload-image-writer
-default       │ └─TaskRun/workload-image-writer-tghr9
-default       │   └─Pod/workload-image-writer-tghr9-pod
-default       └─SourceScan/workload
-```
-
-And then use `kubectl logs` to look at the logs of that pod:
-
-
-```
-kubectl logs scan-workloadw96rc-6724n
-```
-```
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.2" xmlns:v="http://cyclonedx.o...
-  <metadata>
-    <timestamp>2021-11-30T17:05:34Z</timestamp>
-    <tools>
-...
-```
-
-[Grype]: https://github.com/anchore/grype

--- a/scc/ootb-supply-chain-testing.md
+++ b/scc/ootb-supply-chain-testing.md
@@ -1,7 +1,4 @@
----
-title: Out of The Box Supply Chain with Testing (ootb-supply-chain-testing)
-weight: 2
----
+# Out of The Box Supply Chain with Testing (ootb-supply-chain-testing)
 
 This Cartographer Supply Chain ties a series of Kubernetes resources which,
 when working together, drives a developer-provided Workload from source code
@@ -35,7 +32,7 @@ adds on top testing with Tekton:
 - Deploying the application to the same cluster
 
 
-### Prerequisites
+## Prerequisites
 
 To make use this supply chain, it's required that:
 
@@ -65,7 +62,7 @@ _source-test-to-url_.
 
 
 
-#### Developer namespace
+## Developer namespace
 
 As mentioned in the prerequisites section, this supply chain builds on the
 previous Out of The Box Supply Chain, so only additions are included here.
@@ -88,6 +85,11 @@ supplychain is responsible for (see Supply Chain Basic for details)
 - **rolebinding**: binds the role to the service account, i.e., grants the
   capabilities to the identity (see Supply Chain Basic for details)
 
+- (optional) **git credentials secret**: when using GitOps for managing the
+  delivery of applications (or a private git source), provides the required
+  credentials for interacting with the git repository (see Supply Chain Basic 
+  for details).
+
 - **Tekton pipeline** (_new_): a pipeline to be ran whenever the supply chain
   hits the stage of testing the source code
 
@@ -96,7 +98,7 @@ Below you'll find details about the new objects compared to Out of The Box
 Supply Chain Basic.
 
 
-#### Updates to the developer namespace
+### Updates to the developer namespace
 
 In order for source code testing to be present in the supply chain, a Tekton
 Pipeline must exist in the same namespace as the Workload so that, at the right
@@ -110,7 +112,7 @@ Chain Basic section, we need to include one more:
   source code that has been found by earlier resources in the Supply Chain.
 
 
-##### Tekton/Pipeline
+#### Tekton/Pipeline
 
 Despite the full liberty around tasks to run, the Tekton or pipeline object
 **must** be labelled with `apps.tanzu.vmware.com/pipeline: test`, and define
@@ -154,84 +156,31 @@ spec:
               ./mvnw test
 ```
 
-ps.: at this point, changes to the developer-provided Tekton or pipeline _will
-not_ automatically trigger a re-run of the pipeline (i.e., a new
-[tekton/PipelineRun] will not be automatically created if a field in the
-tekton/Pipeline object is changed). As a workaround, the latest
-tekton/PipelineRun created can be deleted, which will trigger a re-run.
+ps.: at this point, changes to the developer-provided Tekton Pipeline _will
+not_ automatically trigger a re-run of the pipeline (i.e., a new Tekton
+PipelineRun will not be automatically created if a field in the Pipeline object
+is changed). As a workaround, the latest PipelineRun created can be deleted,
+which will trigger a re-run.
 
 
-##### Developer workload
+## Developer workload
 
-With the Tekton or pipeline object, following the label and parameter requirements
-mentioned above, submitted to the same namespace where the Workload
-is submitted to, we're ready to submit our Workload.
+With the Tekton Pipeline object (following the label and parameter requirements
+mentioned above) submitted to the same namespace as the one where the Workload
+will be submitted to, we're ready to submit our Workload.
 
-We can configure the Workload with two scenarios in mind:
+Regardless of the workflow being targgeted (local development or gitops), the
+Workload configuration details are the same as in Out of The Box Supply Chain
+Basic, except that we mark the Workload as having tests enabled.
 
-- local iteration: takes source code from the filesystem and makes no use of
-  external git repositories,
-
-- gitops: source code is provided by an external git repository (public _or_
-  private), and the final Kubernetes configuration to deploy the application is
-  persisted in a repository.
-
-
-###### Local iteration with local code
-
-For local iteration, all we need is the source code (in the example below,
-assuming the current directory `.` as the location of the source code we want
-to send through the supply chain), and a container image registry to use as the
-mean for making the source code available inside the Kubernetes cluster.
-
-
-```
-tanzu apps workload create tanzu-java-web-app \
-  --local-path . \
-  --source-image $REGISTRY/source \
-  --label apps.tanzu.vmware.com/has-tests=true \
-  --type web
-```
-```
-Create workload:
-      1 + |---
-      2 + |apiVersion: carto.run/v1alpha1
-      3 + |kind: Workload
-      4 + |metadata:
-      5 + |  labels:
-      6 + |    apps.tanzu.vmware.com/has-tests: "true"
-      7 + |    apps.tanzu.vmware.com/workload-type: web
-      8 + |  name: tanzu-java-web-app
-      9 + |  namespace: default
-     10 + |spec:
-     11 + |  source:
-     12 + |    image: 10.188.0.3:5000/source:latest@sha256:1cb23472fcdcce276c316d9bed6055625fbc4ac3e50a971f8f8004b1e245981e
-
-? Do you want to create this workload? Yes
-Created workload "tanzu-java-web-app"
-```
-
-With the Workload submitted, we should be able to keep track of the resulting
-series of Kubernetes objects created to drive the source code all the way to a
-deployed application by making use of the `tail` command:
-
-```
-tanzu apps workload tail tanzu-java-web-app
-```
-
-###### Local iteration with code from git
-
-Similar to local iteration with local code, here we make use of the same type
-(`web`), but instead of pointing at source code that we have locally, we can
-make use of a git repository to feed the supply chain with new changes as they
-are pushed to a branch.
-
+For instance:
 
 ```
 tanzu apps workload create tanzu-java-web-app \
   --git-branch main \
-  --git-repo https://github.com/sample-accelerators/tanzu-java-web-app \
+  --git-repo https://github.com/sample-accelerators/tanzu-java-web-app
   --label apps.tanzu.vmware.com/has-tests=true \
+  --label app.kubernetes.io/part-of=tanzu-java-web-app \
   --type web
 ```
 ```
@@ -241,221 +190,15 @@ Create workload:
       3 + |kind: Workload
       4 + |metadata:
       5 + |  labels:
-      6 + |    apps.tanzu.vmware.com/has-tests: "true"
-      7 + |    apps.tanzu.vmware.com/workload-type: web
-      8 + |  name: tanzu-java-web-app
-      9 + |  namespace: default
-     10 + |spec:
-     11 + |  source:
-     12 + |    git:
-     13 + |      ref:
-     14 + |        branch: main
-     15 + |      url: https://github.com/sample-accelerators/tanzu-java-web-app
+      6 + |    apps.tanzu.vmware.com/workload-type: web
+      7 + |    apps.tanzu.vmware.com/has-tests: "true"
+      8 + |    app.kubernetes.io/part-of: tanzu-java-web-app
+      9 + |  name: tanzu-java-web-app
+     10 + |  namespace: default
+     11 + |spec:
+     12 + |  source:
+     13 + |    git:
+     14 + |      ref:
+     15 + |        branch: main
+     16 + |      url: https://github.com/sample-accelerators/tanzu-java-web-app
 ```
-
-In the example above, we make use of a public repository, but, if you want to
-make use of a private repository instead, make sure you create a Secret in the
-same namespace as the one where the Workload is being submitted to, and add the
-`--param source_git_ssh_secret=<>` parameter to the set of parameters above.
-
-```
-tanzu apps workload create tanzu-java-web-app \
-  --git-branch main \
-  --git-repo git@github.com:sample-accelerators/tanzu-java-web-app.git \
-  --param source_git_ssh_secret=git-ssh \
-  --label apps.tanzu.vmware.com/has-tests=true \
-  --type web
-```
-```
-Create workload:
-      1 + |---
-      2 + |apiVersion: carto.run/v1alpha1
-      3 + |kind: Workload
-      4 + |metadata:
-      5 + |  labels:
-      6 + |    apps.tanzu.vmware.com/has-tests: "true"
-      7 + |    apps.tanzu.vmware.com/workload-type: web
-      8 + |  name: tanzu-java-web-app
-      9 + |  namespace: default
-     10 + |spec:
-     11 + |  params:
-     12 + |  - name: source_git_ssh_secret
-     13 + |    value: git-ssh
-     14 + |  source:
-     15 + |    git:
-     16 + |      ref:
-     17 + |        branch: main
-     18 + |      url: git@github.com:sample-accelerators/tanzu-java-web-app.git
-```
-
-For more information of how to set up that secret, check out this section on
-Out of The Box Supply Chain Basic.
-
-
-###### GitOps
-
-Differently from local iteration, the GitOps approach requires a secret
-containing credentials to a git provider (e.g., GitHub) to be exist in the same
-namespace as the Workload, and a couple parameters to be set with details about
-the commit to be pushed to the repository where Kubernetes configuration is
-delivered to.
-
-Before proceeding, make sure you have a secret with following shape fields and
-annotations set:
-
-```
-apiVersion: v1
-kind: Secret
-metadata:
-  name: git-ssh
-  annotations:
-    tekton.dev/git-0: github.com  # git server host
-type: kubernetes.io/ssh-auth
-stringData:
-  ssh-privatekey: string          # private key with push-permissions
-  known_hosts: string             # git server public keys
-  identity: string                # private key with pull permissions
-  identity.pub: string            # public of the `identity` private key
-```
-
-With the Secret created, we can move on to the Workload:
-
-
-```
-tanzu apps workload create tanzu-java-web-app \
-  --git-repo git@github.com:sample-accelerators/tanzu-java-web-app.git \
-  --git-branch main \
-  --param "delivery_git_branch=main" \
-  --param "delivery_git_commit_message=bump" \
-  --param "delivery_git_repository=git@github.com:my-team/staging-repository.git" \
-  --param "delivery_git_user_email=team@team.com" \
-  --param "delivery_git_user_name=team" \
-  --param "delivery_git_ssh_secret=git-ssh" \
-  --param "source_git_ssh_secret=git-ssh" \
-  --label apps.tanzu.vmware.com/has-tests=true \
-  --type web
-```
-```
-Create workload:
-      1 + |---
-      2 + |apiVersion: carto.run/v1alpha1
-      3 + |kind: Workload
-      4 + |metadata:
-      5 + |  labels:
-      6 + |    apps.tanzu.vmware.com/has-tests: "true"
-      7 + |    apps.tanzu.vmware.com/workload-type: web
-      8 + |  name: tanzu-java-web-app
-      9 + |  namespace: default
-     10 + |spec:
-     11 + |  params:
-     12 + |  - name: delivery_git_branch
-     13 + |    value: main
-     14 + |  - name: delivery_git_commit_message
-     15 + |    value: bump
-     16 + |  - name: delivery_git_repository
-     17 + |    value: git@github.com:my-team/staging-repository.git
-     18 + |  - name: delivery_git_user_email
-     19 + |    value: team@team.com
-     20 + |  - name: delivery_git_user_name
-     21 + |    value: team
-     22 + |  - name: delivery_git_ssh_secret
-     23 + |    value: git-ssh
-     24 + |  - name: source_git_ssh_secret
-     25 + |    value: git-ssh
-     26 + |  source:
-     27 + |    git:
-     28 + |      ref:
-     29 + |        branch: main
-     30 + |      url: git@github.com:sample-accelerators/tanzu-java-web-app.git
-
-? Do you want to create this workload? Yes
-Created workload "tanzu-java-web-app"
-```
-
-where:
-
--  `delivery_git_ssh_secret` (required): name of the secret in the same
-   namespace as the Workload where SSH credentials exist for pushing the
-   configuration produced by the supply chain to a git repository.
-   e.g.: "ssh-secret"
-
--  `delivery_git_repository` (required): SSH url of the git repository to push
-   the Kubernetes configuration produced by the supply chain to.
-   e.g.: "ssh://git@foo.com/staging.git"
-
--  `delivery_git_branch`: name of the branch to push the configuration to.
-   e.g.: "main"
-
--  `delivery_git_commit_message`: message to write as the body of the commits
-   produced for pushing configuration to the git repository.
-   e.g.: "ci bump"
-
--  `delivery_git_user_name`: user name to use in the commits.
-   e.g.: "Alice Lee"
-
--  `delivery_git_user_email`: user email to use for the commits.
-   e.g.: "foo@example.com"
-
--  `source_git_ssh_secret` (required, if source is private): name of the secret
-   in the same namespace as the Workload where SSH credentials exist for
-   fetching the source code of `workload.spec.source.git`.
-
-
-### Known issues
-
-#### Scanning logs
-
-At the moment, `tanzu apps workload tail` _will not_ provide the logs of the
-Jobs created for source and image scanning. In order to get those, make use of
-`kubectl tree` to find the Pods created as children resources and use `kubectl
-logs` to visualize them.
-
-For instance, assuming we want to discover the logs of an ImageScan, we can
-look at the tree of child objects:
-
-```
-kubectl tree workload tanzu-java-web-app
-```
-```
-NAMESPACE     NAME
-default       Workload/workload
-default       ├─ConfigMap/workload
-default       ├─Deliverable/workload
-default       │ ├─App/workload
-default       │ └─ImageRepository/workload-delivery
-default       ├─Image/workload
-default       │ ├─Build/workload-build-1
-default       │ │ └─Pod/workload-build-1-build-pod
-default       │ ├─PersistentVolumeClaim/workload-cache
-default       │ └─SourceResolver/workload-source
-default       ├─ImageRepository/workload
-default       ├─ImageScan/workload											<< !!
-default       │ └─Job/scan-workloadw96rc                << !!
-default       │   └─Pod/scan-workloadw96rc-6724n        << !!
-default       ├─PodIntent/workload
-default       ├─Runnable/workload
-default       │ └─PipelineRun/workload-hrllc
-default       │   └─TaskRun/workload-hrllc-test
-default       │     └─Pod/workload-hrllc-test-pod
-default       ├─Runnable/workload-image-writer
-default       │ └─TaskRun/workload-image-writer-tghr9
-default       │   └─Pod/workload-image-writer-tghr9-pod
-default       └─SourceScan/workload
-```
-
-And then use `kubectl logs` to look at the logs of that pod:
-
-
-```
-kubectl logs scan-workloadw96rc-6724n
-```
-```
-<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.2" xmlns:v="http://cyclonedx.o...
-  <metadata>
-    <timestamp>2021-11-30T17:05:34Z</timestamp>
-    <tools>
-...
-```
-
-[Grype]: https://github.com/anchore/grype

--- a/scc/ootb-templates.md
+++ b/scc/ootb-templates.md
@@ -1,8 +1,3 @@
----
-title: Out of The Box Supply Chain with Testing and Scanning (ootb-supply-chain-testing)
-weight: 2
----
-
 # Out of The Box Templates (ootb-templates)
 
 In Cartographer, a supply chain is defined as a directed acyclic graph of


### PR DESCRIPTION
hi folks!

here I update install-components and `scc/`-specific documentation to account for the changes that we brought in with beta5.

the biggest changes are:

- **install-components**: new params (`gitops.*`) for the `ootb-supply-chain-*` packages
- **install-components**: add ootb-delivery-basic (it was missing before)
-**install-components**: bump cartographer and all ootb- versions
- **scc**: up-to-date documentation on how to make use of the gitops params that an operator sets / gets overwritten by a developer