### PR TITLE
rm references to self-signed cert workaround for convention service

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -24,7 +24,7 @@ The following components have been updated in Tanzu Application Platform v1.0:
 
 This release has the following issues:
 
-- **Convention Service:** Convention Service uses a workaround for supporting a self-signed certificate for the private registry. For more information, see Convention Service self-signed registry workaround.
+- **Convention Service:** Convention Service does not currently support self-signed certificates for integrating with a private registry. Support for self-signed certs will be available shortly.
 
 - **Installing Tanzu Application Platform on Google Kubernetes Engine (GKE):** When installing Tanzu Application Platform on GKE, Kubernetes control plane may be unavailable for several minutes during the install. Package installs can enter the ReconcileFailed state. When API server becomes available, packages try to reconcile to completion. This can happen on newly provisioned clusters which have not gone through GKE API server autoscaling. When GKE scales up an API server, the current Tanzu Application install continues, and any subsequent installs succeed without interruption.
 
@@ -89,9 +89,7 @@ Workload Visibility Plugin is renamed Runtime Visibility Plugin.
 
 This release has the following issues:
 
-- **Convention Service:** Convention Service uses a workaround for supporting a self-signed certificate for the private
-registry.
-For more information, see [Convention Service self-signed registry workaround](convention-service/self-signed-registry-workaround.md).
+- **Convention Service:** Convention Service does not currently support self-signed certificates for integrating with a private registry. Support for self-signed certs will be available shortly.
 - **Installing Tanzu Application Platform on Google Kubernetes Engine (GKE):** When installing Tanzu Application Platform on GKE, Kubernetes control plane may be unavailable for several minutes during the install. Package installs can enter the ReconcileFailed state. When API server becomes available, packages try to reconcile to completion.
   - This can happen on newly provisioned clusters which have not gone through GKE API server autoscaling. When GKE scales up an API server, the current Tanzu Application install continues, and any subsequent installs succeed without interruption.
 - **Supply Chain Security Tools - Sign:** If all webhook nodes or Pods are evicted by the cluster or scaled down,


### PR DESCRIPTION
the workaround doesn't work as expected so the references to it need to be removed.

Which other branches should this be merged with (if any)?
