### PR TITLE
** BETA5+ ONLY ** - update Tanzu CLI/Plugin install to reflect v0.10.0

### DIFF
--- a/install-general.md
+++ b/install-general.md
@@ -244,7 +244,7 @@ To install the Tanzu CLI on a Linux operating system:
 
 3. Navigate to [Tanzu Application Platform](https://network.tanzu.vmware.com/products/tanzu-application-platform/) on Tanzu Network.
 
-4. Click the `tanzu-cli-0.12.0` folder.
+4. Click the `tanzu-cli-0.10.0` folder.
 
 5. Download `tanzu-framework-bundle-linux` and unpack the TAR file into the `tanzu` directory:
     ```
@@ -254,14 +254,14 @@ To install the Tanzu CLI on a Linux operating system:
 6. Install the CLI core:
     ```
     cd $HOME/tanzu
-    sudo install cli/core/v0.12.0/tanzu-core-linux_amd64 /usr/local/bin/tanzu
+    sudo install cli/core/v0.10.0/tanzu-core-linux_amd64 /usr/local/bin/tanzu
     ```
 
 7. Confirm installation of the CLI core:
    ```
    tanzu version
    ```
-   Expect `version: v0.12.0`
+   Expect `version: v0.10.0`
 
 8. Proceed to [Instructions for a clean install of Tanzu CLI Plugins](#cli-plugin-clean-install).
 
@@ -279,7 +279,7 @@ To install the Tanzu CLI on a Mac operating system:
 
 3. Navigate to [Tanzu Application Platform](https://network.tanzu.vmware.com/products/tanzu-application-platform/) on Tanzu Network.
 
-4. Click the `tanzu-cli-0.12.0` folder.
+4. Click the `tanzu-cli-0.10.0` folder.
 
 5. Download `tanzu-framework-bundle-mac` and unpack the TAR file into the `tanzu` directory:
     ```
@@ -289,14 +289,14 @@ To install the Tanzu CLI on a Mac operating system:
 6.  Install the CLI core:
     ```
     cd $HOME/tanzu
-    install cli/core/v0.12.0/tanzu-core-darwin_amd64 /usr/local/bin/tanzu
+    install cli/core/v0.10.0/tanzu-core-darwin_amd64 /usr/local/bin/tanzu
     ```
 
 7. Confirm installation of the CLI core:
    ```
    tanzu version
    ```
-   Expect `version: v0.12.0`
+   Expect `version: v0.10.0`
 
    If you see the following warning when running `Tanzu version` on macOS:
    ```
@@ -332,13 +332,13 @@ To install the Tanzu CLI on a Windows operating system:
 
   3. Navigate to [Tanzu Application Platform](https://network.tanzu.vmware.com/products/tanzu-application-platform/) on Tanzu Network.
 
-  4. Click the `tanzu-cli-0.12.0` folder.
+  4. Click the `tanzu-cli-0.10.0` folder.
 
   5. Download `tanzu-framework-bundle-windows` and unpack the TAR files into the `tanzu-bundle` directory.
 
   6. Create a new `Program Files\tanzu` folder.
 
-  7. In the unpacked CLI folder tanzu-bundle, locate and copy the `core/v0.12.0/tanzu-core-windows_amd64.exe`
+  7. In the unpacked CLI folder tanzu-bundle, locate and copy the `core/v0.10.0/tanzu-core-windows_amd64.exe`
      into the new `Program Files\tanzu` folder.
 
   8. Rename `tanzu-core-windows_amd64.exe` to `tanzu.exe`.
@@ -358,7 +358,7 @@ To install the Tanzu CLI on a Windows operating system:
       ```
       tanzu version
       ```
-      Expect `version: v0.12.0`
+      Expect `version: v0.10.0`
 
   15. Proceed to [Clean Install Tanzu CLI Plugins](#cli-plugin-clean-install)
 
@@ -390,16 +390,16 @@ To perform a clean installation of the Tanzu CLI plugins:
     ```
     tanzu plugin list
     NAME                LATEST VERSION  DESCRIPTION                                                        REPOSITORY  VERSION  STATUS
-    accelerator                         Manage accelerators in a Kubernetes cluster                                    v0.5.0   installed
-    apps                                Applications on Kubernetes                                                     v0.3.0   installed
-    cluster             v0.12.0         Kubernetes cluster operations                                      core        v0.12.0  installed
-    kubernetes-release  v0.12.0         Kubernetes release operations                                      core        v0.12.0  installed
-    login               v0.12.0         Login to the platform                                              core        v0.12.0  installed
-    management-cluster  v0.12.0         Kubernetes management cluster operations                           core        v0.12.0  installed
-    package             v0.12.0         Tanzu package management                                           core        v0.12.0  installed
-    pinniped-auth       v0.12.0         Pinniped authentication operations (usually not directly invoked)  core        v0.12.0  installed
-    secret              v0.12.0         Tanzu secret management                                            core        v0.12.0  installed
-    services                            Discover Service Types and manage Service Instances (ALPHA)                    v0.1.0   installed
+    accelerator                         Manage accelerators in a Kubernetes cluster                                    v1.0.0   installed
+    apps                                Applications on Kubernetes                                                     v0.4.0   installed
+    cluster             v0.13.1         Kubernetes cluster operations                                      core        v0.10.0  installed
+    kubernetes-release  v0.13.1         Kubernetes release operations                                      core        v0.10.0  installed
+    login               v0.13.1         Login to the platform                                              core        v0.10.0  installed
+    management-cluster  v0.13.1         Kubernetes management cluster operations                           core        v0.10.0  installed
+    package             v0.13.1         Tanzu package management                                           core        v0.10.0  installed
+    pinniped-auth       v0.13.1         Pinniped authentication operations (usually not directly invoked)  core        v0.10.0  installed
+    secret              v0.13.1         Tanzu secret management                                            core        v0.10.0  installed
+    services                            Discover Service Types and manage Service Instances (ALPHA)                    v0.1.1   installed
     ```
 
     Ensure that you have the `package`, `secret`, `accelerator`, `services`, and `apps` plugins.
@@ -416,8 +416,9 @@ You can now proceed with installing Tanzu Application Platform. For more informa
 
 ## <a id='udpate-previous-tap-tanzu-cli'></a>Instructions for updating Tanzu CLI that was installed for a previous release of Tanzu Application Platform
 
-If you have an earlier version of the Tanzu CLI on your local machine,
-then follow this procedure instead of the preceeding clean install procedure:
+* **If your Tanzu CLI version is >= `v0.11.0`**, you must [delete your existing Tanzu CLI, plug-ins, and associated files](uninstall.md#remove-tanzu-cli) and then do a [clean install](#tanzu-cli-clean-install)
+* **If your Tanzu CLI version = `v0.10.0`**, skip to step 12 below
+* **If your Tanzu CLI version is < `v0.10.0`**, proceed to step 1 below
 
   1. If a directory called `tanzu` does not exist, create one:
 
@@ -430,7 +431,7 @@ then follow this procedure instead of the preceeding clean install procedure:
   3. Navigate to [Tanzu Application Platform](https://network.tanzu.vmware.com/products/tanzu-application-platform/)
 on Tanzu Network.
 
-  4. Click the **tanzu-cli-0.12.0** directory.
+  4. Click the **tanzu-cli-0.10.0** directory.
 
   5. Download the CLI bundle corresponding with your operating system. For example, if your client
 operating system is Linux, download the `tanzu-framework-linux-amd64.tar` bundle.
@@ -458,35 +459,7 @@ operating system is Linux, download the `tanzu-framework-linux-amd64.tar` bundle
      export TANZU_CLI_NO_INIT=true
      ```
 
-  10. List the plugins to see if the `imagepullsecret` plugin was previously installed.
-      If installed, delete it:
-
-      ```
-      tanzu plugin list
-      tanzu plugin delete imagepullsecret
-      ```
-
-  11. Remove previously installed plugin binaries:
-
-      ```
-      rm -rf ~/Library/Application\ Support/tanzu-cli/*
-      ```
-
-  12. Check to see what version of the Tanzu CLI core is currently installed:
-
-      ```
-      tanzu version
-      ```
-
-  13. If the version returned is `v0.10.0` or later,
-      disable the **context-aware CLI for plugins** feature so the downloaded CLI core
-      and plugins can be installed without errors:
-
-      ```
-      tanzu config set features.global.context-aware-cli-for-plugins false
-      ```
-
-  14. Update the core CLI:
+  10. Update the core CLI:
 
       ```
       tanzu update --local ./cli
@@ -494,28 +467,33 @@ operating system is Linux, download the `tanzu-framework-linux-amd64.tar` bundle
       Expect to see a user prompt - submit "y"
 
 
-  15. Check installation status for the core CLI:
+  11. Check installation status for the core CLI:
 
       ```
       tanzu version
       ```
-      Expect `version: v0.12.0`
-
-
-  16. If the version returned in step 12 above is earlier than `v0.10.0`,
-      disable the **context-aware CLI for plugins** feature so that the downloaded plugins
-      can be installed without errors:
+      Expect `version: v0.10.0`
+      
+  12. List the plugins to see if the `imagepullsecret` plugin was previously installed.
+      If installed, delete it:
 
       ```
-      tanzu config set features.global.context-aware-cli-for-plugins false
+      tanzu plugin list
+      tanzu plugin delete imagepullsecret
       ```
 
-  17. Install new plugin versions:
+  13. Remove previously installed plugin binaries:
+
+      ```
+      rm -rf ~/Library/Application\ Support/tanzu-cli/*
+      ```
+
+  14. Install new plugin versions:
       ```
       tanzu plugin install --local cli all
       ```
 
-  18. Check installation status for plugins:
+  15. Check installation status for plugins:
 
       ```
       tanzu plugin list
@@ -525,16 +503,16 @@ operating system is Linux, download the `tanzu-framework-linux-amd64.tar` bundle
       ```
       tanzu plugin list
       NAME                LATEST VERSION  DESCRIPTION                                                        REPOSITORY  VERSION  STATUS
-      accelerator                         Manage accelerators in a Kubernetes cluster                                    v0.5.0   installed
-      apps                                Applications on Kubernetes                                                     v0.3.0   installed
-      cluster             v0.12.0         Kubernetes cluster operations                                      core        v0.12.0  installed
-      kubernetes-release  v0.12.0         Kubernetes release operations                                      core        v0.12.0  installed
-      login               v0.12.0         Login to the platform                                              core        v0.12.0  installed
-      management-cluster  v0.12.0         Kubernetes management cluster operations                           core        v0.12.0  installed
-      package             v0.12.0         Tanzu package management                                           core        v0.12.0  installed
-      pinniped-auth       v0.12.0         Pinniped authentication operations (usually not directly invoked)  core        v0.12.0  installed
-      secret              v0.12.0         Tanzu secret management                                            core        v0.12.0  installed
-      services                            Discover Service Types and manage Service Instances (ALPHA)                    v0.1.0   installed
+      accelerator                         Manage accelerators in a Kubernetes cluster                                    v1.0.0   installed
+      apps                                Applications on Kubernetes                                                     v0.4.0   installed
+      cluster             v0.13.1         Kubernetes cluster operations                                      core        v0.10.0  installed
+      kubernetes-release  v0.13.1         Kubernetes release operations                                      core        v0.10.0  installed
+      login               v0.13.1         Login to the platform                                              core        v0.10.0  installed
+      management-cluster  v0.13.1         Kubernetes management cluster operations                           core        v0.10.0  installed
+      package             v0.13.1         Tanzu package management                                           core        v0.10.0  installed
+      pinniped-auth       v0.13.1         Pinniped authentication operations (usually not directly invoked)  core        v0.10.0  installed
+      secret              v0.13.1         Tanzu secret management                                            core        v0.10.0  installed
+      services                            Discover Service Types and manage Service Instances (ALPHA)                    v0.1.1   installed
       ```
 
 You can now install Tanzu Application Platform.
@@ -543,8 +521,8 @@ See **[Installing part II: Profiles](install.md)**.
 
 ## <a id='udpate-tkg-tce-tanzu-cli'></a>Instructions for updating Tanzu CLI previously installed for Tanzu Kubernetes Grid or Tanzu Community Edition
 
-If you want to maintain the Tanzu CLI and plugins you installed previously
-for interacting with Tanzu Kubernetes Grid or Tanzu Community Edition, you only need to update/add the Tanzu Application Platform specific plugins as follows:
+* **If your Tanzu CLI version is >= `v0.11.0`**, you must [delete your existing Tanzu CLI, plug-ins, and associated files](uninstall.md#remove-tanzu-cli) and then do a [clean install](#tanzu-cli-clean-install)
+* **If your Tanzu CLI version <= `v0.10.0`**, proceed to step 1 below
 
   1. Create a directory named `tanzu`:
 
@@ -558,7 +536,7 @@ for interacting with Tanzu Kubernetes Grid or Tanzu Community Edition, you only 
   3. Navigate to [Tanzu Application Platform](https://network.tanzu.vmware.com/products/tanzu-application-platform/)
 on Tanzu Network.
 
-  4. Click the **tanzu-cli-0.12.0** directory.
+  4. Click the **tanzu-cli-0.10.0** directory.
 
   5. Download the CLI bundle corresponding to your operating system. For example, if your client
 operating system is Linux, download the `tanzu-framework-linux-amd64.tar` bundle.
@@ -599,53 +577,39 @@ operating system is Linux, download the `tanzu-framework-linux-amd64.tar` bundle
      tanzu plugin delete package
      ```
 
-  10. Check to see what version of the Tanzu CLI core is installed:
-
-      ```
-      tanzu version
-      ```
-
-  11. If the version returned is `v0.11.0` or later,
-      disable the **context-aware CLI for plugins** feature so that the downloaded plugins
-      can be installed without errors:
-
-      ```
-      tanzu config set features.global.context-aware-cli-for-plugins false
-      ```
-
-  12. Install the `secret` plugin by running:
+  10. Install the `secret` plugin by running:
 
       ```
       tanzu plugin install secret --local ./cli
       ```
 
-  13. Install the `accelerator` plugin by running:
+  11. Install the `accelerator` plugin by running:
 
       ```
       tanzu plugin install accelerator --local ./cli
       ```
 
-  14. Install the `apps` plugin by running:
+  12. Install the `apps` plugin by running:
 
       ```
       tanzu plugin install apps --local ./cli
       ```
 
-  15. Install the updated `package` plugin by running:
+  13. Install the updated `package` plugin by running:
 
       ```
       tanzu plugin install package --local ./cli
       ```
 
 
-  16. Install the `services` plugin by running:
+  14. Install the `services` plugin by running:
 
       ```
       tanzu plugin install services --local ./cli
       ```
 
 
-  17. Verify that the Tanzu Application Platform plugins are present:
+  15. Verify that the Tanzu Application Platform plugins are present:
 
       ```
       tanzu plugin list
@@ -655,11 +619,11 @@ operating system is Linux, download the `tanzu-framework-linux-amd64.tar` bundle
       ```
       tanzu plugin list
       NAME                LATEST VERSION  DESCRIPTION                                                        REPOSITORY  VERSION  STATUS
-      accelerator                         Manage accelerators in a Kubernetes cluster                                    v0.5.0   installed
-      apps                                Applications on Kubernetes                                                     v0.3.0   installed
-      package             v0.12.0         Tanzu package management                                           core        v0.12.0  installed
-      secret              v0.12.0         Tanzu secret management                                            core        v0.12.0  installed
-      services                            Discover Service Types and manage Service Instances (ALPHA)                    v0.1.0   installed
+      accelerator                         Manage accelerators in a Kubernetes cluster                                    v1.0.0   installed
+      apps                                Applications on Kubernetes                                                     v0.4.0   installed
+      package             v0.13.1         Tanzu package management                                           core        v0.10.0  installed
+      secret              v0.13.1         Tanzu secret management                                            core        v0.10.0  installed
+      services                            Discover Service Types and manage Service Instances (ALPHA)                    v0.1.1   installed
       ```
 
 You can now install Tanzu Application Platform on Tanzu Kubernetes Grid or Tanzu Community Edition.


### PR DESCRIPTION
## These changes should ONLY be applied to Beta5 / GA docs (leave beta1-4 as-is).
 
We've reverted back to Tanzu CLI core v0.10.0 for TAP beta5/GA (beta4 had v0.12.0).
This was required because the v0.11.0+ include a feature that's incompatible with the Tanzu CLI plugins that are required for TAP (accelerator, apps, services).

Which other branches should this be merged with (if any)?
