### PR TITLE
Add note for release notes that CVE print columns aren't getting populated

### DIFF
--- a/scst-scan/release-notes.md
+++ b/scst-scan/release-notes.md
@@ -33,6 +33,8 @@ Scans have an edge case where, when an error has occurred during scanning, the S
 not get updated to `Error` and instead remains in the `Scanning` phase.
 Read the scan Pod logs to verify there was an error.
 
+* **CVE print columns are not getting populated:**
+After running a scan and using `kubectl get` on the scan, the CVE print columns (CRITICAL, HIGH, MEDIUM, LOW, UNKNOWN, CVETOTAL) are not getting populated.
 
 ### Known limitations with Grype scanner
 


### PR DESCRIPTION
Following up from https://vmware.slack.com/archives/C02D60T1ZDJ/p1641234896490300, we have a known issue that the CVE print columns aren't getting populated.