### PR TITLE
[SCST Scan] Add note where to see full CVE results

### DIFF
--- a/scst-scan/release-notes.md
+++ b/scst-scan/release-notes.md
@@ -34,7 +34,7 @@ not get updated to `Error` and instead remains in the `Scanning` phase.
 Read the scan Pod logs to verify there was an error.
 
 * **CVE print columns are not getting populated:**
-After running a scan and using `kubectl get` on the scan, the CVE print columns (CRITICAL, HIGH, MEDIUM, LOW, UNKNOWN, CVETOTAL) are not getting populated.
+After running a scan and using `kubectl get` on the scan, the CVE print columns (CRITICAL, HIGH, MEDIUM, LOW, UNKNOWN, CVETOTAL) are not getting populated. Query the metadata store for full CVE results.
 
 ### Known limitations with Grype scanner
 


### PR DESCRIPTION
For the SCST scan release notes, under "CVE print columns are not getting populated" add a note for where to see full CVE results.