### PR TITLE
Clarify image scan secret description

### DIFF
--- a/install.md
+++ b/install.md
@@ -406,7 +406,7 @@ metadata_store:
 
 grype:
   namespace: "MY-DEV-NAMESPACE" # (optional) Defaults to default namespace.
-  targetImagePullSecret: "REGISTRY-CREDENTIALS-SECRET"
+  targetImagePullSecret: "TARGET-REGISTRY-CREDENTIALS-SECRET"
 ```
 
 Where:
@@ -436,7 +436,7 @@ Images are written to `SERVER-NAME/REPO-NAME/workload-name`. Examples:
 service's External IP address.
 - `GIT-CATALOG-URL` is the path to the `catalog-info.yaml` catalog definition file from either the included Blank catalog (provided as an additional download named "Blank Tanzu Application Platform GUI Catalog") or a Backstage-compliant catalog that you've already built and posted on the Git infrastucture you specified in the Integration section.
 - `MY-DEV-NAMESPACE` is the namespace where you want the `ScanTemplates` to be deployed to. This is the namespace where the scanning feature is going to run.
-- `REGISTRY-CREDENTIALS-SECRET` is the name of the secret that contains the credentials to pull the scanner image from the registry. For example, based on step 3 of [Add the Tanzu Application Platform package repository](#add-package-repositories), the value is `tap-registry`.
+- `TARGET-REGISTRY-CREDENTIALS-SECRET` is the name of the secret that contains the credentials to pull an image from the registry for scanning. If built images are pushed to the same registry as the Tanzu Application Platform images, this can reuse the `tap-registry` secret created in step 3 of [Add the Tanzu Application Platform package repository](#add-package-repositories).
 
 >**Note:** Using the `tap-values.yaml` configuration,
 >`buildservice.enable_automatic_dependency_updates: false` can be used to pause the automatic update


### PR DESCRIPTION
The grype.targetImagePullSecret is to pull application images to be scanned by the supply chain, not to pull the scanner image itself. Clarify that this might not be the same as tap-registry if apps are pushed to a different registry than where the TAP system components are pulled from.

Which other branches should this be merged with (if any)?
This is applicable to GA (main) and beta-4 branches
