### PR TITLE
Typo in install-components section "Install Out of The Box Supply Chain with Testing and Scanning"

### DIFF
--- a/install-components.md
+++ b/install-components.md
@@ -1542,7 +1542,7 @@ and image for vulnerabilities.
                               default on image objects managed by the supply chain.
     ```
 
-1. Create a file named `ootb-supply-chain-testing-values.yaml` that specifies
+1. Create a file named `ootb-supply-chain-testing-scanning-values.yaml` that specifies
    the corresponding values to the properties you want to change. For example:
 
     ```


### PR DESCRIPTION
This is a typo because "ootb-supply-chain-testing-values.yaml" is for a file in the previous section and "ootb-supply-chain-testing-scanning-values.yaml" will be used in the next step.

I'm running thru install step, that's how I ran into this issue.