### PR TITLE
Add to release notes to display where to find severity counts and cve total

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -103,7 +103,7 @@ to create the TLS Secret, once the TLS is created **you need to redeploy the Tra
  - **Failing Blob source scans:** Blob Source Scans have an edge case where, when a compressed file without a `.git` directory is provided, sending results to the Supply Chain Security Tools - Store fails and the scanned revision value is not set. The current workaround is to add the `.git` directory to the compressed file.
  - **Events show `SaveScanResultsSuccess` incorrectly:** `SaveScanResultsSuccess` appears in the events when the Supply Chain Security Tools - Store is not configured. The `.status.conditions` output, however, correctly reflects `SendingResults=False`.
  - **Scan Phase indicates `Scanning` incorrectly:** Scans have an edge case where, when an error has occurred during scanning, the Scan Phase field does not get updated to `Error` and instead remains in the `Scanning` phase. Read the scan Pod logs to verify there was an error.
- - **CVE print columns are not getting populated:** After running a scan and using `kubectl get` on the scan, the CVE print columns (CRITICAL, HIGH, MEDIUM, LOW, UNKNOWN, CVETOTAL) are not getting populated.
+ - **CVE print columns are not getting populated:** After running a scan and using `kubectl get` on the scan, the CVE print columns (CRITICAL, HIGH, MEDIUM, LOW, UNKNOWN, CVETOTAL) are not getting populated. To find these severity counts and "CVETOTAL", run `kubectl describe` on the scan and look under `Status.Conditions` for a message that says `Scan completed. Found x CVE(s): ...`.
 
 #### Supply Chain Security Tools - Sign
 


### PR DESCRIPTION
In release notes, for scanning release notes for "CVE print columns are not getting populated", add this note to run kubectl describe to get severity counts and cve total.