### PR TITLE
Change the link where to download insight CLI

### DIFF
--- a/scst-store/cli_installation.md
+++ b/scst-store/cli_installation.md
@@ -1,14 +1,12 @@
 # CLI installation
 
->**Note:** The `insight` CLI is in beta and is separate from the Tanzu CLI.
->It works with the final production version of Supply Chain Security Tools - Store.
+>**Note:** The `insight` CLI is in beta and is separate from the `tanzu` CLI.
+>It works with Tanzu Application Platform v1.0.0.
 
-This topic explains how to install the `insight` CLI:
+This topic explains how to install the `insight` CLI.
 
-1. Sign in to [Tanzu Network](https://network.tanzu.vmware.com/).
-1. Navigate to [Tanzu Application Platform](https://network.tanzu.vmware.com/products/tanzu-application-platform/).
-1. In the releases drop-down menu, select version *0.4.0*.
-1. In the list of released files, select *insight-metadata-cli-v1.0.0...*.
+1. Log in to [Tanzu Network](https://network.tanzu.vmware.com/) on your browser.
+1. Search for and select [Supply Chain Security Tools for VMware Tanzu](https://network.tanzu.vmware.com/products/supply-chain-security-tools).
 1. Choose the file for your operating system.
     
     >**Note:** macOS is a Darwin-based platform.
@@ -16,7 +14,7 @@ This topic explains how to install the `insight` CLI:
 1. Put the binary in a location that is either already in your `PATH` environment variable,
 or add the location of the CLI to your `PATH` variable.
 1. Rename the binary to make it easier to invoke with your command line.
-For example, `mv insight-1.0.0-beta.2_darwin_amd64 insight`.
+For example, `mv insight-1.0.1_darwin_amd64 insight`.
 
 <details><summary>macOS only:</summary>
 <br/>


### PR DESCRIPTION
Our docs pointed to the TAP beta 4 tanzunet release in order to download the `insight` CLI. However, recently someone decided to hide that release, making it invisible to users.

We have to change the documentation to point the user to the new location.

Which other branches should this be merged with (if any)?
Merge this into the main and beta-4 branches.