### PR TITLE
How to allow non-GitHub repo for TAP GUI

### DIFF
--- a/tap-gui/integrations.md
+++ b/tap-gui/integrations.md
@@ -20,6 +20,21 @@ Where `GITHUB-TOKEN` is a valid token generated from your Git infrastructure of 
 >**Note:** The `integrations` section earlier uses GitHub. For additional integrations, see the
 >format in the [Backstage integration documentation](https://backstage.io/docs/integrations/).
 
+To allow Tanzu Application GUI to read non-GitHub repositories containing component information, please add the following to the `tap-values-file.yml` file:
+
+```
+      app_config:
+        # Existing tap-values-file.yml above  
+        backend:
+          reading:
+            allow:
+            - host: "GIT-CATALOG-URL-1"
+            - host: "GIT-CATALOG-URL-2" # Optional, if several URLs
+```
+
+Where `GIT-CATALOG-URL-X` is a URL in a list URLs what Tanzu Application Platform GUI is allowed to read when registering new components. For example, `"git.example.com"`. More on registering new components could be found in [Adding Catalog Entities](/tap-gui/catalog/catalog-operations.md#add-cat-entities).
+
+
 After making the changes to the `tap-values-file.yml`, you can update the package profile by running:
 
 ```


### PR DESCRIPTION
Added instructions according to slack discussion: https://vmware.slack.com/archives/CRHUG2VQF/p1643071499176700 
