### PR TITLE
Chagned Developer namespace setup to create

### DIFF
--- a/install-components.md
+++ b/install-components.md
@@ -3021,7 +3021,7 @@ that you plan to create the `Workload` in:
 2. Add placeholder read secrets, a service account, and RBAC rules to the developer namespace by running:
 
     ```
-    cat <<EOF | kubectl -n YOUR-NAMESPACE apply -f -
+    cat <<EOF | kubectl -n YOUR-NAMESPACE create -f -
 
     apiVersion: v1
     kind: Secret


### PR DESCRIPTION
In order to remediate the warning in the CLI:
Warning: resource serviceaccounts/default is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.

I changed apply to create and it works the same without a warning.

Which other branches should this be merged with (if any)?
Both 1.0.0 and 1.0.1
