### PR TITLE
Fix example policy

### DIFF
--- a/scst-sign/configuring.md
+++ b/scst-sign/configuring.md
@@ -82,7 +82,7 @@ apiVersion: signing.apps.tanzu.vmware.com/v1beta1
 kind: ClusterImagePolicy
 metadata:
   name: image-policy
-spec
+spec:
   verification:
     exclude:
       resources:


### PR DESCRIPTION
A previous edit changed `spec:` to `spec`, breaking up the example policy