### PR TITLE
reverting a setup dev namespace change

### DIFF
--- a/install-components.md
+++ b/install-components.md
@@ -3029,7 +3029,7 @@ that you plan to create the `Workload` in:
 2. Add placeholder read secrets, a service account, and RBAC rules to the developer namespace by running:
 
     ```
-    cat <<EOF | kubectl -n YOUR-NAMESPACE create -f -
+    cat <<EOF | kubectl -n YOUR-NAMESPACE apply -f -
 
     apiVersion: v1
     kind: Secret


### PR DESCRIPTION
Looks like we'll have to revert the change from last week where we swapped apply for create. The warning is expected and we'll just have to tolerate it. This needs to change both 1.0.0 and 1.0.1 docs. THanks.

Which other branches should this be merged with (if any)?
