### PR TITLE
Update CEIP value in the TAP docs

### DIFF
--- a/install.md
+++ b/install.md
@@ -384,7 +384,7 @@ section.
 
 ```
 profile: full
-ceip_policy_disclosed: true # Installation fails if this is set to 'false'
+ceip_policy_disclosed: "true-OR-false" # Installation fails if this not set to `true`
 buildservice:
   kp_default_repository: "KP-DEFAULT-REPO"
   kp_default_repository_username: "KP-DEFAULT-REPO-USERNAME"
@@ -470,7 +470,7 @@ service's External IP address.
 
 ```
 profile: light
-ceip_policy_disclosed: true # Installation fails if this is set to 'false'
+ceip_policy_disclosed: "true-OR-false" # Installation fails if this not set to `true`
 
 buildservice:
   kp_default_repository: "KP-DEFAULT-REPO"


### PR DESCRIPTION
Update ceip value.  Legal requirements stipulate users must explicitly select `true`.

Which other branches should this be merged with (if any)?
