### PR TITLE
Tbs enable auto updates details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _md-cli/*
 
 # Markdown Project Tool
 _md-cli/
+
+.idea/

--- a/install.md
+++ b/install.md
@@ -390,7 +390,7 @@ buildservice:
   tanzunet_username: "TANZUNET-USERNAME"
   tanzunet_password: "TANZUNET-PASSWORD"
   descriptor_name: "DESCRIPTOR-NAME"
-  enable_automatic_dependency_updates: "true-or-false" # Optional
+  enable_automatic_dependency_updates: true/false # Optional
 supply_chain: basic
 
 cnrs:
@@ -461,8 +461,8 @@ service's External IP address.
 - `MY-DEV-NAMESPACE` is the namespace where you want the `ScanTemplates` to be deployed to. This is the namespace where the scanning feature is going to run.
 - `TARGET-REGISTRY-CREDENTIALS-SECRET` is the name of the secret that contains the credentials to pull an image from the registry for scanning. If built images are pushed to the same registry as the Tanzu Application Platform images, this can reuse the `tap-registry` secret created in step 3 of [Add the Tanzu Application Platform package repository](#add-package-repositories).
 
-    >**Note:** Using the `tbs-values.yaml` configuration,
-    >`enable_automatic_dependency_updates:` `true` will cause the dependency updater to update Tanzu Build Service dependencies (buildpacks and stacks) when they are released on Tanzu network. `false` can be used to pause the automatic update of Build Service dependencies. If left undefined, this value will be configured as `false`.
+>**Note:** Using the `tbs-values.yaml` configuration,
+>`enable_automatic_dependency_updates:` `true` will cause the dependency updater to update Tanzu Build Service dependencies (buildpacks and stacks) when they are released on Tanzu network. `false` can be used to pause the automatic update of Build Service dependencies. If left undefined, this value will be configured as `false`.
 
 
 
@@ -479,6 +479,7 @@ buildservice:
   kp_default_repository_password: "KP-DEFAULT-REPO-PASSWORD"
   tanzunet_username: "TANZUNET-USERNAME"
   tanzunet_password: "TANZUNET-PASSWORD"
+  enable_automatic_dependency_updates: true/false # Optional
 
 supply_chain: basic
 
@@ -536,6 +537,9 @@ Images are written to `SERVER-NAME/REPO-NAME/workload-name`. Examples:
     See [Identify the SSH secret key for your package](#ssh-secret-key) for more information.
 - `INGRESS-DOMAIN` is the subdomain for the host name that you will point at the `tanzu-shared-ingress` service's External IP address.
 - `GIT-CATALOG-URL` is the path to the `catalog-info.yaml` catalog definition file from either the included Blank catalog (provided as an additional download named "Blank Tanzu Application Platform GUI Catalog") or a Backstage-compliant catalog you've already built and posted on the Git infrastructure you specified in the Integration section.
+
+>**Note:** Using the `tbs-values.yaml` configuration,
+>`enable_automatic_dependency_updates:` `true` will cause the dependency updater to update Tanzu Build Service dependencies (buildpacks and stacks) when they are released on Tanzu network. `false` can be used to pause the automatic update of Build Service dependencies. If left undefined, this value will be configured as `false`.
 
 ### <a id="view-pkge-config-settings"></a>View possible configuration settings for your package
 

--- a/install.md
+++ b/install.md
@@ -390,7 +390,7 @@ buildservice:
   tanzunet_username: "TANZUNET-USERNAME"
   tanzunet_password: "TANZUNET-PASSWORD"
   descriptor_name: "DESCRIPTOR-NAME"
-  enable_automatic_dependency_updates: true
+  enable_automatic_dependency_updates: "true-or-false" # Optional
 supply_chain: basic
 
 cnrs:
@@ -461,9 +461,9 @@ service's External IP address.
 - `MY-DEV-NAMESPACE` is the namespace where you want the `ScanTemplates` to be deployed to. This is the namespace where the scanning feature is going to run.
 - `TARGET-REGISTRY-CREDENTIALS-SECRET` is the name of the secret that contains the credentials to pull an image from the registry for scanning. If built images are pushed to the same registry as the Tanzu Application Platform images, this can reuse the `tap-registry` secret created in step 3 of [Add the Tanzu Application Platform package repository](#add-package-repositories).
 
->**Note:** Using the `tap-values.yaml` configuration,
->`buildservice.enable_automatic_dependency_updates: false` can be used to pause the automatic update
->of Build Service dependencies.
+    >**Note:** Using the `tbs-values.yaml` configuration,
+    >`enable_automatic_dependency_updates:` `true` will cause the dependency updater to update Tanzu Build Service dependencies (buildpacks and stacks) when they are released on Tanzu network. `false` can be used to pause the automatic update of Build Service dependencies. If left undefined, this value will be configured as `false`.
+
 
 
 

--- a/tanzu-build-service/install-tanzu-build-service.md
+++ b/tanzu-build-service/install-tanzu-build-service.md
@@ -92,7 +92,7 @@ To install Tanzu Build Service by using the Tanzu CLI:
     tanzunet_username: TANZUNET-USERNAME
     tanzunet_password: TANZUNET-PASSWORD
     descriptor_name: DESCRIPTOR-NAME
-    enable_automatic_dependency_updates: true
+    enable_automatic_dependency_updates: true/false # Optional 
     ```
     Where:
 
@@ -105,14 +105,13 @@ To install Tanzu Build Service by using the Tanzu CLI:
         * Harbor: `harbor.io/my-project/build-service`
 
     - `REGISTRY-USERNAME` and `REGISTRY-PASSWORD` are the user name and password for the registry. The install requires a `kp_default_repository_username` and `kp_default_repository_password` to write to the repository location.
-    - `TANZUNET-USERNAME` and `TANZUNET-PASSWORD` are the email address and password that you use to log in to Tanzu Network. The Tanzu Network credentials allow for configuration of the Dependencies Updater. This resource accesses and installs the build dependencies (buildpacks and stacks) Tanzu Build Service needs on your cluster. It also keeps these dependencies up to date as new versions are released on Tanzu Network.
+    - `TANZUNET-USERNAME` and `TANZUNET-PASSWORD` are the email address and password that you use to log in to Tanzu Network. The Tanzu Network credentials allow for configuration of the Dependencies Updater. This resource accesses and installs the build dependencies (buildpacks and stacks) Tanzu Build Service needs on your cluster. It can also optionally keep these dependencies up to date as new versions are released on Tanzu Network.
     - `DESCRIPTOR-NAME` is the name of the descriptor to import automatically. Current available options at time of release:
         - `tap-1.0.0-full` contains all dependencies and is for production use.
         - `tap-1.0.0-lite` smaller footprint used for speeding up installs. Requires Internet access on the cluster.
 
     >**Note:** Using the `tbs-values.yaml` configuration,
-    >`enable_automatic_dependency_updates: false` can be used to pause the automatic update of
-    >Build Service dependencies.
+    >`enable_automatic_dependency_updates:` `true` will cause the dependency updater to update Tanzu Build Service dependencies (buildpacks and stacks) when they are released on Tanzu network. `false` can be used to pause the automatic update of Build Service dependencies. If left undefined, this value will be configured as `false`.
 
 1. Install the package by running:
 


### PR DESCRIPTION
Which other branches should this be merged with (if any)?

1.0

- Update install instructions for automatic dependency updates in TBS component install docs
- Update install instructions for automatic dependency updates in full and lite profiles

This is a consolidation of https://github.com/pivotal/docs-tap/pull/842 and https://github.com/pivotal/docs-tap/pull/843 as well as adding info for lite profile. These PRs can be closed in favor of this one.