### PR TITLE
Add CNRS config so we have a domain for apps

### DIFF
--- a/install.md
+++ b/install.md
@@ -395,6 +395,9 @@ buildservice:
   enable_automatic_dependency_updates: true
 supply_chain: basic
 
+cnrs:
+  domain_name: apps.INGRESS-DOMAIN
+
 ootb_supply_chain_basic:
   registry:
     server: "SERVER-NAME"

--- a/install.md
+++ b/install.md
@@ -484,6 +484,9 @@ buildservice:
 
 supply_chain: basic
 
+cnrs:
+  domain_name: apps.INGRESS-DOMAIN
+
 ootb_supply_chain_basic:
   registry:
     server: "SERVER-NAME"


### PR DESCRIPTION
This adds the CNRS config to the "full" and "light" profile `tap-values.yaml` config files. Without this, a `tanzu apps workload create` will fail because the app will use the default `example.com` TLD
