### PR TITLE
Rename `tekton` -> `tekton-pipelines`

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -31,6 +31,12 @@ See [Install Out of The Box Supply Chain Basic](install-components.md#install-oo
     >**Note:** If you used the default profiles provided in [Installing part II: Profiles](install.md),
     you have already installed the Out of The Box (OOTB) Supply Chain Basic.
 
+  - **Installed Tekton-Pipelines**<br>
+See [Install Tekton Pipelines](install-components.md#install-tekton-pipelines).
+
+    >**Note:** If you used the default profiles provided in [Installing part II: Profiles](install.md),
+    you have already installed Tekton Pipelines.
+
   - **Set up a developer namespace to accommodate the developer Workload**<br>
 See [Set up developer namespaces to use installed packages](install-components.md#setup).
 
@@ -501,16 +507,14 @@ The **OOTB Testing+Scanning** supply chain includes integrations for secure scan
 
 ### <a id="install-ootb-test"></a>Install OOTB Testing
 
-This section introduces how to install the OOTB Testing supply chain, which includes the steps required to install Tekton and provides a sample Tekton pipeline that tests your sample application.
-The pipeline is configurable. Therefore, you can customize the steps
-to perform either additional testing or other tasks with the
-Tekton pipeline.
+This section introduces how to install the OOTB Testing supply chain and
+provides a sample Tekton pipeline that tests your sample application.  The
+pipeline is configurable. Therefore, you can customize the steps to perform
+either additional testing or other tasks with Tekton Pipelines.
 
 To apply this install method, follow the following steps:
 
-1. Install Tekton (see [Install Tekton](install-components.md#install-tekton)) for instructions.
-
-2. With Tekton installed, you can activate the Out of the Box Supply Chain with Testing by updating our profile to use `testing` rather than `basic` as the selected supply chain for workloads in this cluster. Update `tap-values.yml` (the file used to customize the profile in `Tanzu package install tap
+1. You can activate the Out of the Box Supply Chain with Testing by updating our profile to use `testing` rather than `basic` as the selected supply chain for workloads in this cluster. Update `tap-values.yml` (the file used to customize the profile in `Tanzu package install tap
 --values-file=...`) with the following changes:
 
     ```
@@ -524,7 +528,7 @@ To apply this install method, follow the following steps:
           repository: "<REPO-NAME>"
     ```
 
-3. Update the installed profile by running:
+2. Update the installed profile by running:
 
     ```
     tanzu package installed update tap -p tap.tanzu.vmware.com -v 1.0.0 --values-file tap-values.yml -n tap-install

--- a/install-components.md
+++ b/install-components.md
@@ -33,7 +33,7 @@ For more information, see [Installing part I: Prerequisites, EULA, and CLI](inst
 + [Install Supply Chain Security Tools - Scan](#install-scst-scan)
 + [Install API portal](#install-api-portal)
 + [Install Services Toolkit](#install-services-toolkit)
-+ [Install Tekton](#install-tekton)
++ [Install Tekton Pipelines](#install-tekton-pipelines)
 
 
 ## <a id='install-prereqs'></a> Install cert-manager, contour and FluxCD Source Controller
@@ -1248,7 +1248,7 @@ cluster.
 
 ### <a id='ootb-template-prereqs'></a> Prerequisites
 
-- Tekton
+- Tekton Pipelines
 - Cartographer
 
 
@@ -2829,11 +2829,11 @@ To install Services Toolkit:
     ```
 
 
-## <a id='install-tekton'></a> Install Tekton
+## <a id='install-tekton-pipelines'></a> Install Tekton Pipelines
 
-To install Tekton:
+To install Tekton Pipelines:
 
-1. See what versions of Tekton are available to install by running:
+1. See what versions of Tekton Pipelines are available to install by running:
 
     ```
     tanzu package available list -n tap-install tekton.tanzu.vmware.com
@@ -2851,38 +2851,38 @@ To install Tekton:
 1. Install Tekton by running:
 
     ```
-    tanzu package install tekton -n tap-install -p tekton.tanzu.vmware.com -v 0.30.0
+    tanzu package install tekton-pipelines -n tap-install -p tekton.tanzu.vmware.com -v 0.30.0
     ```
 
     For example:
 
     ```
-    $ tanzu package install tekton -n tap-install -p tekton.tanzu.vmware.com -v 0.30.0
+    $ tanzu package install tekton-pipelines -n tap-install -p tekton.tanzu.vmware.com -v 0.30.0
     - Installing package 'tekton.tanzu.vmware.com'
     \ Getting package metadata for 'tekton.tanzu.vmware.com'
-    / Creating service account 'tekton-tap-install-sa'
-    / Creating cluster admin role 'tekton-tap-install-cluster-role'
-    / Creating cluster role binding 'tekton-tap-install-cluster-rolebinding'
+    / Creating service account 'tekton-pipelines-tap-install-sa'
+    / Creating cluster admin role 'tekton-pipelines-tap-install-cluster-role'
+    / Creating cluster role binding 'tekton-pipelines-tap-install-cluster-rolebinding'
     / Creating package resource
-    - Waiting for 'PackageInstall' reconciliation for 'tekton'
+    - Waiting for 'PackageInstall' reconciliation for 'tekton-pipelines'
     - 'PackageInstall' resource install status: Reconciling
 
 
-     Added installed package 'tekton'
+     Added installed package 'tekton-pipelines'
     ```
 
 1. Verify that the package installed by running:
 
     ```
-    tanzu package installed get tekton -n tap-install
+    tanzu package installed get tekton-pipelines -n tap-install
     ```
 
     For example:
 
     ```
-    $ tanzu package installed get tekton -n tap-install
+    $ tanzu package installed get tekton-pipelines -n tap-install
     \ Retrieving installation details for tekton...
-    NAME:                    tekton
+    NAME:                    tekton-pipelines
     PACKAGE-NAME:            tekton.tanzu.vmware.com
     PACKAGE-VERSION:         0.30.0
     STATUS:                  Reconcile succeeded
@@ -2892,9 +2892,9 @@ To install Tekton:
 
     STATUS should be `Reconcile succeeded`.
 
-1. Configuring a namespace to use Tekton:
+1. Configuring a namespace to use Tekton Pipelines:
 
-   > **Note:** This step covers configuring a namespace to run Tekton pipelines.
+   > **Note:** This step covers configuring a namespace to run Tekton Pipelines.
    If you rely on a SupplyChain to create Tekton PipelineRuns in your cluster,
    then skip this step because namespace configuration is covered in
    [Set up developer namespaces to use installed packages](#setup). Otherwise,
@@ -2946,7 +2946,7 @@ To install Tekton:
 
    > **Note:** The service account has access to the `pull-secret` image pull secret.
 
-For more details on Tekton, see the [Tekton documentation](https://tekton.dev/docs/) and the
+For more details on Tekton Pipelines, see the [Tekton documentation](https://tekton.dev/docs/) and the
 [github repository](https://github.com/tektoncd/pipeline).
 
 You can also view the Tekton [tutorial](https://github.com/tektoncd/pipeline/blob/main/docs/tutorial.md) and
@@ -2987,7 +2987,7 @@ Use the following procedure to verify that the packages are installed.
     services-toolkit         services-toolkit.tanzu.vmware.com                  0.5.0            Reconcile succeeded
     source-controller        controller.source.apps.tanzu.vmware.com            0.2.0            Reconcile succeeded
     tap-gui                  tap-gui.tanzu.vmware.com                           0.3.0-rc.4       Reconcile succeeded
-    tekton                   tekton.tanzu.vmware.com                            0.30.0           Reconcile succeeded
+    tekton-pipelines         tekton.tanzu.vmware.com                            0.30.0           Reconcile succeeded
     tbs                      buildservice.tanzu.vmware.com                      1.4.2            Reconcile succeeded
     ```
 

--- a/install.md
+++ b/install.md
@@ -340,7 +340,7 @@ The following table lists the packages contained in each profile:
    </td>
   </tr>
   <tr>
-   <td>Tekton
+   <td>Tekton Pipelines
    </td>
    <td>&check;
    </td>


### PR DESCRIPTION
This is more consistent with the package name in tap-packages which was a point of confusion. Also, since the package is part of the profiles, there's no need to install it separately

> Which other branches should this be merged with (if any)? 

I don't think so?