### PR TITLE
The TBS descriptor name as an input must be "lite" instead of "light" or it will error

### DIFF
--- a/install-components.md
+++ b/install-components.md
@@ -1091,7 +1091,7 @@ To install Tanzu Build Service using the Tanzu CLI:
     - `TANZUNET-USERNAME` and `TANZUNET-PASSWORD` are the email address and password that you use to log in to Tanzu Network. The Tanzu Network credentials allow for configuration of the Dependencies Updater. This resource accesses and installs the build dependencies (buildpacks and stacks) Tanzu Build Service needs on your cluster. It also keeps these dependencies up to date as new versions are released on Tanzu Network.
     - `DESCRIPTOR-NAME` is the name of the descriptor to import automatically. Current available options at time of release:
         - `tap-1.0.0-full` contains all dependencies and is for production use.
-        - `tap-1.0.0-light` smaller footprint used for speeding up installs. Requires Internet access on the cluster.
+        - `tap-1.0.0-lite` smaller footprint used for speeding up installs. Requires Internet access on the cluster.
 
     >**Note:** Using the `tbs-values.yaml` configuration,
     >`enable_automatic_dependency_updates: false` can be used to pause the automatic update of
@@ -1123,7 +1123,7 @@ To install Tanzu Build Service using the Tanzu CLI:
     >**Note:** Installing the `buildservice.tanzu.vmware.com` package with Tanzu Network credentials
     >automatically relocates buildpack dependencies to your cluster. This install process can take
     >some time and the `--poll-timeout` flag increases the timeout duration.
-    >Using the `light` descriptor speeds this up significantly.
+    >Using the `lite` descriptor speeds this up significantly.
     >If the command times out, periodically run the installation verification step provided in the
     >following optional step. Image relocation continues in the background.
 

--- a/install.md
+++ b/install.md
@@ -439,7 +439,7 @@ Where:
     * For Google Cloud Registry, use the contents of the service account JSON key.
 - `DESCRIPTOR-NAME` is the name of the descriptor to import automatically. Current available options at time of release:
     * `tap-1.0.0-full` contains all dependencies, and is for production use.
-    * `tap-1.0.0-light` smaller footprint used for speeding up installs. Requires Internet access on the cluster.
+    * `tap-1.0.0-lite` smaller footprint used for speeding up installs. Requires Internet access on the cluster.
 - `SERVER-NAME` is the hostname of the registry server. Examples:
     * Harbor has the form `server: "my-harbor.io"`
     * Dockerhub has the form `server: "index.docker.io"`

--- a/prerequisites.md
+++ b/prerequisites.md
@@ -20,7 +20,7 @@ Tanzu Application Platform packages.
 When available, VMware recommends using a paid registry account to avoid potential rate-limiting
 associated with some free registry offerings.
 
-    - If installing using the `light` descriptor for Tanzu Build Service, 1&nbsp;GB of available
+    - If installing using the `lite` descriptor for Tanzu Build Service, 1&nbsp;GB of available
     storage is recommended.
     - If installing using the `full` descriptor for Tanzu Build Service, which is intended for production use
     and offline environments, 10&nbsp;GB of available storage is recommended.

--- a/tanzu-build-service/install-tanzu-build-service.md
+++ b/tanzu-build-service/install-tanzu-build-service.md
@@ -108,7 +108,7 @@ To install Tanzu Build Service by using the Tanzu CLI:
     - `TANZUNET-USERNAME` and `TANZUNET-PASSWORD` are the email address and password that you use to log in to Tanzu Network. The Tanzu Network credentials allow for configuration of the Dependencies Updater. This resource accesses and installs the build dependencies (buildpacks and stacks) Tanzu Build Service needs on your cluster. It also keeps these dependencies up to date as new versions are released on Tanzu Network.
     - `DESCRIPTOR-NAME` is the name of the descriptor to import automatically. Current available options at time of release:
         - `tap-1.0.0-full` contains all dependencies and is for production use.
-        - `tap-1.0.0-light` smaller footprint used for speeding up installs. Requires Internet access on the cluster.
+        - `tap-1.0.0-lite` smaller footprint used for speeding up installs. Requires Internet access on the cluster.
 
     >**Note:** Using the `tbs-values.yaml` configuration,
     >`enable_automatic_dependency_updates: false` can be used to pause the automatic update of
@@ -140,7 +140,7 @@ To install Tanzu Build Service by using the Tanzu CLI:
     >**Note:** Installing the `buildservice.tanzu.vmware.com` package with Tanzu Network credentials
     >automatically relocates buildpack dependencies to your cluster. This install process can take
     >some time and the `--poll-timeout` flag increases the timeout duration.
-    >Using the `light` descriptor speeds this up significantly.
+    >Using the `lite` descriptor speeds this up significantly.
     >If the command times out, periodically run the installation verification step provided in the
     >following optional step. Image relocation continues in the background.
 


### PR DESCRIPTION
It appears the "lite" profile has been renamed to "light", however the TBS input for `descriptor_name` must be "lite" or it will error.

@mgibson1121 

Which other branches should this be merged with (if any)?

1.0