### PR TITLE
App Live View release notes update

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -26,6 +26,11 @@ Added apply command to Tanzu CLI plugin.
 
 Added -n short alias for all --namespace flags for Tanzu CLI plugin.
 
+#### Application Live View
+
+- Updated pod security policies for App Live View Components 
+- Updated Spring Boot 2.5.7 to 2.5.8
+
 ### <a id='1-0-1-resolved-issues'></a> Resolved issues
 
 This release has the following fixes:
@@ -44,6 +49,12 @@ The entity loader for TAP GUI will not stop when encountering invalid accelerato
 Deleted accelerators will no longer be shown in TAP GUI.
 
 The TAP GUI "Explore" feature now shows any engine errors.
+
+#### Application Live View
+
+- Includes changes to the App Live View connector to handle stream reset exceptions
+- Increased requests and limits for App Live View Connector to fix pod restarts
+- CVE vulnerability fix - to update protobuf-java to 3.19.2 in connector
 
 ### <a id='1-0-1-known-issues'></a> Known issues
 


### PR DESCRIPTION
ALV new features and fixes to go with tap 1.0.1

For 1.0.1. Therefore should go only in **1-0** branch i think
