### PR TITLE
chore: tidy up references to gitops_repository

### DIFF
--- a/scc/install-ootb-sc-basic.md
+++ b/scc/install-ootb-sc-basic.md
@@ -80,7 +80,7 @@ instance of it running in a Kubernetes environment.
       repository: REGISTRY-REPOSITORY
 
     gitops:
-      repository_prefix: git@github.com:vmware-tanzu/
+      repository_prefix: ssh://git@github.com:vmware-tanzu/
       branch: main
       user_name: supplychain
       user_email: supplychain

--- a/scc/install-ootb-sc-wtest-scan.md
+++ b/scc/install-ootb-sc-wtest-scan.md
@@ -126,7 +126,7 @@ instance that:
       repository: REGISTRY-REPOSITORY
 
     gitops:
-      repository_prefix: git@github.com:vmware-tanzu/
+      repository_prefix: ssh://git@github.com:vmware-tanzu/
       branch: main
       user_name: supplychain
       user_email: supplychain

--- a/scc/install-ootb-sc-wtest.md
+++ b/scc/install-ootb-sc-wtest.md
@@ -120,7 +120,7 @@ Install by following these steps:
       repository: REGISTRY-REPOSITORY
 
     gitops:
-      repository_prefix: git@github.com:vmware-tanzu/
+      repository_prefix: ssh://git@github.com:vmware-tanzu/
       branch: main
       user_name: supplychain
       user_email: supplychain

--- a/scc/ootb-supply-chain-basic.md
+++ b/scc/ootb-supply-chain-basic.md
@@ -479,7 +479,7 @@ setting the source of the source code to a git repository and then as the
 supply chain progresses, configuration are pushed to a repository named
 after `$(gitops.repository_prefix) + $(workload.name)`.
 
-e.g, having `gitops.repository_prefix` configured to `git@github.com/foo/` and
+e.g, having `gitops.repository_prefix` configured to `ssh://git@github.com/foo/` and
 a Workload as such:
 
 ```
@@ -521,7 +521,7 @@ also manually overridden by the developers by tweaking the following parameters:
 
 -  `gitops_repository`: SSH URL of the git repository to push the Kubernetes
    configuration produced by the supply chain to.
-   Example: "ssh://git@foo.com/staging.git"
+   Example: "ssh://git@github.com/foo/"
 
 -  `gitops_branch`: Name of the branch to push the configuration to.
    Example: "main"


### PR DESCRIPTION
Which other branches should this be merged with (if any)?
