### PR TITLE
docs: [SCST - Sign] add documentation for deployment namespace feature for version 1.1

### DIFF
--- a/scst-sign/configuring.md
+++ b/scst-sign/configuring.md
@@ -3,6 +3,16 @@
 This component requires extra configuration steps to start verifying your
 container images properly.
 
+> **Note**:
+> The instructions in this section refer to the deployment namespace of this
+> component. In most examples, this will be rendered as the default namespace
+> `image-policy-system`.
+>
+> If you deployed this component using a customized namespace specified in the
+> installation values file, make sure to replace `image-policy-system` with the
+> namespace name you specified in `deployment_namespace` to perform the
+> configuration steps.
+
 ## <a id="create-cip-resource"></a> Create a `ClusterImagePolicy` resource
 
 The cluster image policy is a custom resource containing the following properties:
@@ -115,7 +125,7 @@ protected by authentication, in order:
 container image name pattern that matches the container being admitted.
 
 1. [Reading `imagePullSecrets` from the `image-policy-registry-credentials` service account](#provide-secrets-iprc-sa)
-in the `image-policy-system` namespace.
+in the deployment namespace.
 
 > **Note:** Authentication fails in the following scenario:
 
@@ -135,7 +145,7 @@ as part of your policy configuration.
 
 1. Create secret resources and include them in the `image-policy-registry-credentials`
 service account. The service account and the secrets must be created in the
-`image-policy-system` namespace.
+deployment namespace.
 
 ### <a id="provide-pol-auth-secrets"></a> Provide secrets for authentication in your policy
 
@@ -179,7 +189,7 @@ spec:
 ```
 
 > **Note**: You may need to grant the service account
-> `image-policy-controller-manager` in the namespace `image-policy-system` RBAC
+> `image-policy-controller-manager` in the deployment namespace RBAC
 > permissions for the verbs `get` and `list` in the namespace that hosts
 > your secrets.
 
@@ -191,7 +201,7 @@ privilege that allows reading the signature stored in your registry.
 If you prefer to provide your secrets in the `image-policy-registry-credentials`
 service account, follow these steps:
 
-1. Create the required secrets in the `image-policy-system` namespace (once per secret):
+1. Create the required secrets in the deployment namespace (once per secret):
 
     ```
     kubectl create secret docker-registry SECRET-1 \
@@ -201,8 +211,9 @@ service account, follow these steps:
       --docker-password=<password>
     ```
 
-1. Create the `image-policy-registry-credentials` in the `image-policy-system`
-namespace and add the secret names from step 1 to the `imagePullSecrets` section:
+1. Create the `image-policy-registry-credentials` service account in the
+deployment namespace and add the secret names from step 1 to the
+`imagePullSecrets` section:
 
     ```
     cat <<EOF | kubectl apply -f -

--- a/scst-sign/install-scst-sign.md
+++ b/scst-sign/install-scst-sign.md
@@ -35,33 +35,35 @@ To install Supply Chain Security Tools - Sign:
     ```
     $ tanzu package available list image-policy-webhook.signing.apps.tanzu.vmware.com --namespace tap-install
     - Retrieving package versions for image-policy-webhook.signing.apps.tanzu.vmware.com...
-      NAME                                               VERSION         RELEASED-AT
-      image-policy-webhook.signing.apps.tanzu.vmware.com  1.0.1          2022-01-24 09:00:00 -0500 EST
+      NAME                                                VERSION        RELEASED-AT
+      image-policy-webhook.signing.apps.tanzu.vmware.com  1.1.0          2022-01-24 09:00:00 -0500 EST
     ```
 
 1. (Optional) Make changes to the default installation settings by running:
 
     ```
-    tanzu package available get image-policy-webhook.signing.apps.tanzu.vmware.com/1.0.1 --values-schema --namespace tap-install
+    tanzu package available get image-policy-webhook.signing.apps.tanzu.vmware.com/1.1.0 --values-schema --namespace tap-install
     ```
 
     For example:
 
     ```
-    $ tanzu package available get image-policy-webhook.signing.apps.tanzu.vmware.com/1.0.1 --values-schema --namespace tap-install
-    | Retrieving package details for image-policy-webhook.signing.apps.tanzu.vmware.com/1.0.1...
-      KEY                     DEFAULT  TYPE     DESCRIPTION
-      allow_unmatched_images  false    boolean  Feature flag for enabling admission of images that do not match
-                                                any patterns in the image policy configuration.
-                                                Set to true to allow images that do not match any patterns into
-                                                the cluster with a warning.
-      quota.pod_number        5        string   The maximum number of Image Policy Webhook Pods allowed to be
-                                                created with the priority class system-cluster-critical. This
-                                                value must be enclosed in quotes (""). If this value is not
-                                                specified then the default value of 5 is used.
-      replicas                1        integer  The number of replicas to be created for the Image Policy
-                                                Webhook. This value must not be enclosed in quotes. If this
-                                                value is not specified then the default value of 1 is used.
+    $ tanzu package available get image-policy-webhook.signing.apps.tanzu.vmware.com/1.1.0 --values-schema --namespace tap-install
+    | Retrieving package details for image-policy-webhook.signing.apps.tanzu.vmware.com/1.1.0...
+      KEY                     DEFAULT              TYPE     DESCRIPTION
+      deployment_namespace    image-policy-system  string   Deployment namespace specifies the namespace where this component should be deployed to.
+                                                            If not specified, "image-policy-system" is assumed.
+      allow_unmatched_images  false                boolean  Feature flag for enabling admission of images that do not match
+                                                            any patterns in the image policy configuration.
+                                                            Set to true to allow images that do not match any patterns into
+                                                            the cluster with a warning.
+      quota.pod_number        5                    string   The maximum number of Image Policy Webhook Pods allowed to be
+                                                            created with the priority class system-cluster-critical. This
+                                                            value must be enclosed in quotes (""). If this value is not
+                                                            specified then the default value of 5 is used.
+      replicas                1                    integer  The number of replicas to be created for the Image Policy
+                                                            Webhook. This value must not be enclosed in quotes. If this
+                                                            value is not specified then the default value of 1 is used.
     ```
 
 1. Create a file named `scst-sign-values.yaml` and add the settings you want to customize:

--- a/scst-sign/install-scst-sign.md
+++ b/scst-sign/install-scst-sign.md
@@ -93,7 +93,7 @@ To install Supply Chain Security Tools - Sign:
 
     - `quota.pod_number`:
       This setting is the maximum number of pods that are allowed in the
-      `image-policy-system` namespace with the `system-cluster-critical`
+      deployment namespace with the `system-cluster-critical`
       priority class. This priority class is added to the pods to prevent
       preemption of this component's pods in case of node pressure.
 
@@ -107,6 +107,13 @@ To install Supply Chain Security Tools - Sign:
 
         * **For production environments**: VMware recommends you increase the number of replicas to
           3 to ensure availability of the component for better admission performance.
+
+    - `deployment_namespace`:
+      This setting controls the namespace to which this component will be deployed.
+      When not specified, the namespace `image-policy-system` is assumed.
+      This component creates the specified namespace in order to deploy required
+      resources. Make sure to select a namespace that is not being used by any
+      other components.
 
 1. Install the package:
 


### PR DESCRIPTION
Add new documentation on how to use the new `deployment_namespace` feature for TAP version 1.1.