### PR TITLE
Fix typo for scst-scan explanation page

### DIFF
--- a/scst-scan/explanation.md
+++ b/scst-scan/explanation.md
@@ -36,7 +36,7 @@ By default, there will be 3 scan templates deployed (`public-source-scan-templat
 
 If targetImagePullSecret is set in the tap-values.yml, then a `private-image-scan-template` would also be deployed.
 
-If targetSourceSshSecret is set in the tap-values.yml, then a `private-image-scan-template` would also be deployed.
+If targetSourceSshSecret is set in the tap-values.yml, then a `private-source-scan-template` would also be deployed
 
 The private scan templates reference secrets created using the docker server and credentials you provided, so they are ready to use out-of-the-box. We make use of them when running the samples.
 


### PR DESCRIPTION
Which other branches should this be merged with (if any)? main

This is a follow-up from https://github.com/pivotal/docs-tap/pull/929. We were told to do changes on main but since this is a follow-up, I didn't want to create merge conflicts. But moving forward I will try to do main changes primarily.
