### PR TITLE
add supply-chain objects to k8s-reader role

### DIFF
--- a/tap-gui/cluster-view-setup.md
+++ b/tap-gui/cluster-view-setup.md
@@ -38,31 +38,72 @@ kind: ClusterRole
 metadata:
   name: k8s-reader
 rules:
-  - apiGroups: ['']
-    resources: ['pods', 'services', 'configmaps']
-    verbs: ['get', 'watch', 'list']
-  - apiGroups: ['apps']
-    resources: ['deployments', 'replicasets']
-    verbs: ['get', 'watch', 'list']
-  - apiGroups: ['autoscaling']
-    resources: ['horizontalpodautoscalers']
-    verbs: ['get', 'watch', 'list']
-  - apiGroups: ['networking.k8s.io']
-    resources: ['ingresses']
-    verbs: ['get', 'watch', 'list']
-  - apiGroups: ['networking.internal.knative.dev']
-    resources: ['serverlessservices']
-    verbs: ['get', 'watch', 'list']
-  - apiGroups: [ 'autoscaling.internal.knative.dev' ]
-    resources: [ 'podautoscalers' ]
-    verbs: [ 'get', 'watch', 'list' ]
-  - apiGroups: ['serving.knative.dev']
-    resources:
-    - configurations
-    - revisions
-    - routes
-    - services
-    verbs: ['get', 'watch', 'list']
+- apiGroups: ['']
+  resources: ['pods', 'services', 'configmaps']
+  verbs: ['get', 'watch', 'list']
+- apiGroups: ['apps']
+  resources: ['deployments', 'replicasets']
+  verbs: ['get', 'watch', 'list']
+- apiGroups: ['autoscaling']
+  resources: ['horizontalpodautoscalers']
+  verbs: ['get', 'watch', 'list']
+- apiGroups: ['networking.k8s.io']
+  resources: ['ingresses']
+  verbs: ['get', 'watch', 'list']
+- apiGroups: ['networking.internal.knative.dev']
+  resources: ['serverlessservices']
+  verbs: ['get', 'watch', 'list']
+- apiGroups: [ 'autoscaling.internal.knative.dev' ]
+  resources: [ 'podautoscalers' ]
+  verbs: [ 'get', 'watch', 'list' ]
+- apiGroups: ['serving.knative.dev']
+  resources:
+  - configurations
+  - revisions
+  - routes
+  - services
+  verbs: ['get', 'watch', 'list']
+- apiGroups: ['carto.run']
+  resources:
+  - clusterconfigtemplates
+  - clusterdeliveries
+  - clusterdeploymenttemplates
+  - clusterimagetemplates
+  - clusterruntemplates
+  - clustersourcetemplates
+  - clustersupplychains
+  - clustertemplates
+  - deliverables
+  - runnables
+  - workloads
+  verbs: ['get', 'watch', 'list']
+- apiGroups: ['source.toolkit.fluxcd.io']
+  resources:
+  - gitrepositories
+  verbs: ['get', 'watch', 'list']
+- apiGroups: ['conventions.apps.tanzu.vmware.com']
+  resources:
+  - podintents
+  verbs: ['get', 'watch', 'list']
+- apiGroups: ['kpack.io']
+  resources:
+  - images
+  - builds
+  verbs: ['get', 'watch', 'list']
+- apiGroups: ['scanning.apps.tanzu.vmware.com']
+  resources:
+  - sourcescans
+  - imagescans
+  verbs: ['get', 'watch', 'list']
+- apiGroups: ['tekton.dev']
+  resources:
+  - taskruns
+  - pipelineruns
+  verbs: ['get', 'watch', 'list']
+- apiGroups: ['kappctrl.k14s.io']
+  resources:
+  - apps
+  verbs: ['get', 'watch', 'list']
 ```
 
 Ensure the kubeconfig context is set to the cluster with resources to be viewed in Tanzu Application Platform GUI. Create the `Namespace`, `ServiceAccount`, `ClusterRole` and `ClusterRoleBinding` with the following command:


### PR DESCRIPTION
Since the addition of the supply-chain plugin in 1.1.0, there are a bunch more resource types that tap-gui will be querying for. In order to avoid a bunch of 403 errors cluttering up the runtime resources page, it'd be a bit better if users gave more permissions to tap-gui's service account.

Which other branches should this be merged with (if any)? None, I think; this is brand-new in 1.1.0.
