### PR TITLE
Update install-tanzu-cli.md to add imgpkg to the $PATH

### DIFF
--- a/install-tanzu-cli.md
+++ b/install-tanzu-cli.md
@@ -116,6 +116,11 @@ If using Linux, download `tanzu-cluster-essentials-linux-amd64-1.0.0.tgz`.
     ```
     sudo cp $HOME/tanzu-cluster-essentials/kapp /usr/local/bin/kapp
     ```
+7. Install the `imgpkg` CLI onto your `$PATH`:
+
+    ```
+    sudo cp $HOME/tanzu-cluster-essentials/imgpkg /usr/local/bin/imgpkg
+    ```
 
 ## <a id='cli-and-plugin'></a> Install or update the Tanzu CLI and plug-ins
 


### PR DESCRIPTION
updating document to add imgpkg to the path. imgpkg is needed in the install for performing TAP image relocation from Tanzunet to other Container Registries.

Which other branches should this be merged with (if any)?
