### PR TITLE
VSEE-460 | Deprecate `scanning.apps.tanzu.vmware.com/v1alpha1`

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -90,6 +90,7 @@ occurs during scanning, the `Scan Phase` field is not updated to `Error` and rem
 ### <a id='1-1-known-issues'></a> Feature deprecation
 
 * Tanzu Application Platform profile - light
+* Supply Chain Security Tools - Scan deprecated API version `scanning.apps.tanzu.vmware.com/v1alpha1`
 
 
 ## <a id='1-0'></a> v1.0


### PR DESCRIPTION
Added a feature deprecation note for Supply Chain Security Tools - Scan API version

Signed-off-by: Monica Chao <monicac@vmware.com>

**Which other branches should this be merged with (if any)?**

This is applicable only for Docs 1.1.x
