### PR TITLE
tbs standalone descriptor name

### DIFF
--- a/tanzu-build-service/install-tbs.md
+++ b/tanzu-build-service/install-tbs.md
@@ -115,8 +115,8 @@ To install Tanzu Build Service by using the Tanzu CLI:
     VMware Tanzu Network.
     - `DESCRIPTOR-NAME` is the name of the descriptor to import automatically. The
     available options at time of release are:
-        - `tap-1.0.1-full` contains all dependencies and is for production use.
-        - `tap-1.0.1-lite` has a smaller footprint that enables faster installations. It requires Internet access on the cluster.
+        - `tap-1.0.0-full` contains all dependencies and is for production use.
+        - `tap-1.0.0-lite` has a smaller footprint that enables faster installations. It requires Internet access on the cluster.
 
     >**Note:** By using the `tbs-values.yaml` configuration,
     >`enable_automatic_dependency_updates: true` causes the dependency updater to update


### PR DESCRIPTION
- This user input should still be 1.0.0 even when running tap 1.0.1/2

Which other branches should this be merged with (if any)?

This only needs to be merged into 1-0 branch