### PR TITLE
Document how to enable kapp-controller to operate on relocated images in a registry with a private CA Certificate

### DIFF
--- a/install-tanzu-cli.md
+++ b/install-tanzu-cli.md
@@ -103,7 +103,7 @@ Tanzu Application Platform v1.1 is supported on Cluster Essentials v1.0 and v1.1
 
     ```
     kubectl create namespace kapp-controller
-    ```\
+    ```
 
    Create a configuration secret using the registry's `ca.crt` stored on local disk:
 

--- a/install-tanzu-cli.md
+++ b/install-tanzu-cli.md
@@ -97,6 +97,22 @@ Tanzu Application Platform v1.1 is supported on Cluster Essentials v1.0 and v1.1
 
     - `DOWNLOADED-CLUSTER-ESSENTIALS-PACKAGE` is the name of the cluster essentials package you downloaded.
 
+1. **If your registry needs a custom certificate**, you will need to [load that configuration](https://carvel.dev/kapp-controller/docs/v0.32.0/controller-config/) into the cluster before installing `kapp-controller`. If your registry uses a public certificate, this step is not needed.
+
+   Create the `kapp-controller` namespace:
+
+    ```
+    kubectl create namespace kapp-controller
+    ```\
+
+   Create a configuration secret using the registry's `ca.crt` stored on local disk:
+
+    ```
+    kubectl create secret generic kapp-controller-config \
+       --namespace kapp-controller \
+       --from-file caCerts=ca.crt
+    ```
+
 1. Configure and run `install.sh`, which installs `kapp-controller` and `secretgen-controller` on your cluster:
 
     ```


### PR DESCRIPTION
Document how to load CA certificates into `kapp-controller`. With the switch to recommending image relocation, users with registries secured by a private CA will fail to install the package repository or packages due to certificate trust issues.

(Validated on `kind` with an on-cluster registry created by https://github.com/evankanderson/k8s-private-local-registry)

## Which other branches should this be merged with (if any)?

TAP 1.0, which also contains the image relocation instructions.
