### PR TITLE
add imagerepositories to sample role

### DIFF
--- a/tap-gui/cluster-view-setup.md
+++ b/tap-gui/cluster-view-setup.md
@@ -88,6 +88,10 @@ To do so:
       resources:
       - gitrepositories
       verbs: ['get', 'watch', 'list']
+    - apiGroups: ['source.apps.tanzu.vmware.com']
+      resources:
+      - imagerepositories
+      verbs: ['get', 'watch', 'list']
     - apiGroups: ['conventions.apps.tanzu.vmware.com']
       resources:
       - podintents


### PR DESCRIPTION
this corresponds to the fix for [TANZUSC-990](https://jira.eng.vmware.com/browse/TANZUSC-990).

Which other branches should this be merged with (if any)? Only 1.1.0 is affected
