### PR TITLE
getting-started: mention Tekton as dependency for all supply chains

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -443,6 +443,8 @@ The following table and diagrams provide descriptions for each of the supply cha
 
 <li>Convention Service
 
+<li>Tekton
+
 <li>Cloud Native Runtimes
 <li>If using Service References:
    </li>
@@ -458,8 +460,7 @@ The following table and diagrams provide descriptions for each of the supply cha
 
 ### <a id="OOTB-testing"></a>2: **OOTB Testing**
 
-The **OOTB Testing** supply chain runs a Tekton pipeline within the supply chain. It depends on
-[Tekton](https://tekton.dev/) being installed on your cluster.
+The **OOTB Testing** supply chain runs a Tekton pipeline within the supply chain.
 
 ![Diagram depicting the Source-and-Test-to-URL chain: Watch Repo (Flux) to Test Code (Tekton) to Build Image (TBS) to Apply Conventions to Deploy to Cluster (CNR).](images/source-and-test-to-url-chain-new.png)
 
@@ -492,11 +493,9 @@ The **OOTB Testing** supply chain runs a Tekton pipeline within the supply chain
 </li>
 </ul>
    </td>
-   <td>All of the Source to URL dependencies, and:
+   <td>All of the Source to URL dependencies
 <ul>
 
-<li>Tekton
-</li>
 </ul>
    </td>
   </tr>


### PR DESCRIPTION
### context

despite the fact that the `testing` out of the box supply chain being
the one where tests get run according to the definition of a Tekton
pipeline that the developer creates, all the supply chains have a stage
in it where a tekton taskrun is created, thus, all supply chains have a
dependency on tekton.

more specifically, regardless of inner or outerloop flows, the supply
chains at the very end create this taskrun that either:

- does a `git push`, if in outerloop gitops flow
- does an `imgpkg push`, if in innerloop flow


### Which other branches should this be merged with (if any)?

the dependency on tekton for all supply chains is not new, being a
requirement since pre 1.0.0.