### PR TITLE
add checkmark to view profile for tap-auth/default roles

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -379,7 +379,7 @@ The following table lists the packages contained in each profile:
    </td>
    <td>&check;
    </td>
-   <td>
+   <td>&check;
    </td>
   </tr>
   <tr>


### PR DESCRIPTION
Which other branches should this be merged with (if any)? all branches for TAP 1.1+

this checkmark needs to be set because tap-auth is also in view profile in TAP 1.1. it was decided to not change this after code freeze so we will change it (and also change the docs) for version 1.2.
Cc: @Manifaust 
