### PR TITLE
Remove enable_auto_updates config from main install examples

### DIFF
--- a/install-tanzu-cli.md
+++ b/install-tanzu-cli.md
@@ -12,7 +12,7 @@ To accept EULAs:
 
     - [Cluster Essentials for VMware Tanzu](https://network.tanzu.vmware.com/products/tanzu-cluster-essentials/#/releases/1011100)
     - [Tanzu Application Platform](https://network.tanzu.vmware.com/products/tanzu-application-platform/)
-    - [Tanzu Build Service](https://network.tanzu.vmware.com/products/build-service/) and its associated components:
+    - Tanzu Build Service associated components:
         - [Tanzu Build Service Dependencies](https://network.tanzu.vmware.com/products/tbs-dependencies/)
         - [Buildpacks for VMware Tanzu](https://network.tanzu.vmware.com/products/tanzu-buildpacks-suite)
         - [Stacks for VMware Tanzu](https://network.tanzu.vmware.com/products/tanzu-stacks-suite)

--- a/install.md
+++ b/install.md
@@ -172,7 +172,6 @@ buildservice:
   tanzunet_username: "TANZUNET-USERNAME"
   tanzunet_password: "TANZUNET-PASSWORD"
   descriptor_name: "DESCRIPTOR-NAME"
-  enable_automatic_dependency_updates: TRUE-OR-FALSE-VALUE # Optional, set as true or false. Not a string.
 supply_chain: basic
 
 cnrs:
@@ -249,14 +248,14 @@ If built images are pushed to the same registry as the Tanzu Application Platfor
 this can reuse the `tap-registry` secret created in
 [Add the Tanzu Application Platform package repository](#add-tap-package-repo).
 
->**Note:** When using the `tbs-values.yaml` configuration,
->`enable_automatic_dependency_updates: true` causes the dependency updater to update
->Tanzu Build Service dependencies (buildpacks and stacks) when they are released on
->VMware Tanzu Network. Use `false` to pause the automatic update of Build Service dependencies.
->When automatic updates are paused, the pinned version of the descriptor for TAP 1.1.0 is
->[100.0.279](https://network.pivotal.io/products/tbs-dependencies#/releases/1066670)
->If left undefined, this value is `false`. For details about updating dependencies manually, see
->[here](tanzu-build-service/tbs-about.html#dependencies-manual).
+> **Note:** When TAP is installed it is bootstrapped with a set of dependencies (buildpacks and stacks) for application 
+> builds. Documentation about buildpacks and stacks can be found [here](https://docs.vmware.com/en/VMware-Tanzu-Buildpacks/index.html). The buildpack and stack artifacts installed 
+> with TAP can be found in the descriptor on [Tanzu Network](https://network.pivotal.io/products/tbs-dependencies). 
+> The current installed version of the descriptor is 
+> [100.0.279](https://network.pivotal.io/products/tbs-dependencies#/releases/1066670). Sometimes the dependencies get 
+> out of date and require updates. This can be done via 
+> [manual process in a CI/CD context](tanzu-build-service/tbs-about.html#dependencies-manual), or 
+> [updated automatically](tanzu-build-service/tbs-about.html#dependencies-auto-updates) in the background by TAP.
 
 ### <a id='light-profile'></a> Light Profile
 

--- a/multicluster/reference/tap-values-build-sample.md
+++ b/multicluster/reference/tap-values-build-sample.md
@@ -11,7 +11,6 @@ buildservice:
   kp_default_repository_password: "KP-DEFAULT-REPO-PASSWORD"
   tanzunet_username: "TANZUNET-USERNAME"
   tanzunet_password: "TANZUNET-PASSWORD"
-  enable_automatic_dependency_updates: TRUE-OR-FALSE-VALUE # Optional, set as true or false. Not a string.
 supply_chain: basic
 
 ootb_supply_chain_basic:
@@ -59,9 +58,11 @@ If built images are pushed to the same registry as Tanzu Application Platform im
 you can reuse the `tap-registry` secret created in
 [Add the Tanzu Application Platform package repository](#add-tap-package-repo).
 
->**Note:** When using the `tbs-values.yaml` configuration,
->`enable_automatic_dependency_updates: true` causes the dependency updater to update
->Tanzu Build Service dependencies, such as buildpacks and stacks, when they are released on
->VMware Tanzu Network. Use `false` to pause the automatic update of Build Service dependencies.
->When automatic updates are paused, the pinned version of the descriptor for TAP 1.1.0 is [100.0.279](https://network.pivotal.io/products/tbs-dependencies#/releases/1066670)
->The default value is `false`. For details about updating dependencies manually, see [here](../../tanzu-build-service/tbs-about.html#dependencies-manual).
+> **Note:** When TAP is installed it is bootstrapped with a set of dependencies (buildpacks and stacks) for application
+> builds. Documentation about buildpacks and stacks can be found [here](https://docs.vmware.com/en/VMware-Tanzu-Buildpacks/index.html). The buildpack and stack artifacts installed
+> with TAP can be found in the descriptor on [Tanzu Network](https://network.pivotal.io/products/tbs-dependencies).
+> The current installed version of the descriptor is
+> [100.0.279](https://network.pivotal.io/products/tbs-dependencies#/releases/1066670). Sometimes the dependencies get
+> out of date and require updates. This can be done via
+> [manual process in a CI/CD context](tanzu-build-service/tbs-about.html#dependencies-manual), or
+> [updated automatically](tanzu-build-service/tbs-about.html#dependencies-auto-updates) in the background by TAP.

--- a/tanzu-build-service/tbs-about.md
+++ b/tanzu-build-service/tbs-about.md
@@ -4,7 +4,7 @@ VMware Tanzu Build Service automates container creation, management, and governa
 
 ## <a id="dependencies"> Tanzu Build Service Dependencies
 
-Tanzu Build Service requires dependencies (buildpacks and stacks) to build OCI images.
+Tanzu Build Service requires dependencies in the form of [Buildpacks](https://docs.vmware.com/en/VMware-Tanzu-Buildpacks/index.html) and [Stacks](https://docs.vmware.com/en/VMware-Tanzu-Buildpacks/services/tanzu-buildpacks/GUID-stacks.html) to build OCI images.
 
 ### <a id="dependencies-configuration"> Configuration
 


### PR DESCRIPTION
- This field defaults to false and has been a source of confusion. We want to remove
  it from the main install examples/flows and only make information about it
  available in more specific use-cases.
- Also remove the requirement to accept the TBS EULA which is not required.

Which other branches should this be merged with (if any)?

This should be merged into main and 1-1 for the TAP 1.1 docs and for future versions.