### PR TITLE
content/consistency updates

### DIFF
--- a/spring-boot-conventions/reference/CONVENTIONS.md
+++ b/spring-boot-conventions/reference/CONVENTIONS.md
@@ -19,13 +19,21 @@ look something like the following:
           image: springio/petclinic
   ```
 
-Most of the Spring Boot conventions will either modify or add properties to the environment variable `JAVA_TOOL_OPTIONS`.
+Most of the Spring Boot conventions will either modify or add 
+properties to the environment variable `JAVA_TOOL_OPTIONS`.
+It's possible to override those conventions by providing the 
+desired `JAVA_TOOL_OPTIONS` property/value via the Tanzu 
+CLI/workload.yaml.
 
-If a `JAVA_TOOL_OPTIONS` property already exists for a workload, the convention will use the existing value rather than the value the convention has been designed to apply by default (The provided property value will be used for the pod spec mutation.)
+When a `JAVA_TOOL_OPTIONS` property already exists for a 
+workload, the convention will use the existing value rather 
+than the value the convention has been designed to apply by 
+default (The provided property value will be used for the 
+pod spec mutation.)
 
-## <a id="set-java-tool-options"></a> Set the `JAVA_TOOL_OPTIONS` property for a workload
+## How to set a `JAVA_TOOL_OPTIONS` property for a workload <a id="set-java-tool-options"></a>
 
-To set `JAVA_TOOL_OPTIONS`, do one of the following:
+To set `JAVA_TOOL_OPTIONS` property/values, do one of the following:
 
 - **Use the Tanzu CLI `apps` plug-in:** When creating or updating a workload,
 set a `JAVA_TOOL_OPTIONS` property using the `--env` flag by running:
@@ -44,18 +52,31 @@ property in the `workload.yaml` as follows:
     ```
     apiVersion: carto.run/v1alpha1
     kind: Workload
+    
     ...
+    
     spec<!-- |specifications| is preferred. -->:
      env<!-- |environment| is preferred -->:
      - name: JAVA_TOOL_OPTIONS
        value: -Dmanagement.server.port=8082
      source:
+     
     ...
+    
     ```
 
-## <a id="spring-boot-convention"></a>Spring Boot convention
+## Spring Boot Convention<a id="spring-boot-convention"></a>
 
-  In the `bom` file's metadata, under `dependencies`, there is a `dependency` named `spring-boot`. The convention `spring-boot` adds a __label__ to the `PodTemplateSpec` setting the framework used by running `conventions.apps.tanzu.vmware.com/framework: spring-boot`. The convention `spring-boot` also adds an __annotation__ with the version of the _dependency_.
+In the metadata within the `SBOM` file, under `dependencies`, if the `dependency` 
+below is found, the Spring Boot convention will be applied to 
+the `PodTemplateSpec` object:
+
+- `spring-boot`
+
+The Spring Boot convention adds a _label_ (`conventions.apps.tanzu.vmware.com/framework: spring-boot`) to the 
+`PodTemplateSpec` which describes the framework associated with the workload and it adds an _annotation_ (`boot.spring.io/version: VERSION-NO`) which describes the Spring Boot version of the _dependency_.
+
+The label and annotation are added informational/visibility purposes only.
 
 Example of PodIntent after applying the convention:
 
@@ -66,21 +87,9 @@ Example of PodIntent after applying the convention:
     annotations:
       kubectl.kubernetes.io/last-applied-configuration: |
         {"apiVersion":"conventions.apps.tanzu.vmware.com/v1alpha1","kind":"PodIntent","metadata":{"annotations":{},"name":"spring-sample","namespace":"default"},"spec":{"template":{"spec":{"containers":[{"image":"springio/petclinic","name":"workload"}]}}}}
-    creationTimestamp: "..."
-    generation: 1
-    name: spring-sample
-    namespace: default
-    resourceVersion: "..."
-    uid: ...
-  spec:
-    serviceAccountName: default
-    template:
-      metadata: {}
-      spec:
-        containers:
-        - image: springio/petclinic
-          name: workload
-          resources: {}
+  
+  ...
+
   status:
     conditions:
     - lastTransitionTime: "..." # This status indicates that all worked as expected
@@ -105,9 +114,11 @@ Example of PodIntent after applying the convention:
           resources: {}
   ```
 
-## <a id="spring-boot-graceful-shutdown-convention"></a>Spring Boot graceful shutdown convention
+## Spring Boot Graceful Shutdown Convention<a id="spring-boot-graceful-shutdown-convention"></a>
 
-  In the `bom` file's metadata, under `dependencies`, if there are any of the following `dependencies`, the convention is applied to the `PodTemplateSpec` object:
+In the metadata within the `SBOM` file, under `dependencies`, if any of the `dependencies` 
+below are found, the Spring Boot graceful shutdown convention will be applied to 
+the `PodTemplateSpec` object:
 
   - spring-boot-starter-tomcat
   - spring-boot-starter-jetty
@@ -115,7 +126,11 @@ Example of PodIntent after applying the convention:
   - spring-boot-starter-undertow
   - tomcat-embed-core
 
-  The convention `spring-boot-graceful-shutdown` adds a _property_ in the environment variable `JAVA_TOOL_OPTIONS`. It adds _key_ `server.shutdown.grace-period` and _value_, which is 80% of the set value in `target.Spec.TerminationGracePeriodSeconds` (or 30 seconds).
+The Graceful Shutdown convention `spring-boot-graceful-shutdown` adds 
+a _property_ in the environment variable `JAVA_TOOL_OPTIONS` with _key_ 
+`server.shutdown.grace-period`. The key value is calculated to be 80% 
+of the value set in `.target.Spec.TerminationGracePeriodSeconds`. The 
+default value for `.target.Spec.TerminationGracePeriodSeconds` is 30 seconds.
 
 Example of PodIntent after applying the convention:
 
@@ -126,21 +141,9 @@ Example of PodIntent after applying the convention:
     annotations:
       kubectl.kubernetes.io/last-applied-configuration: |
         {"apiVersion":"conventions.apps.tanzu.vmware.com/v1alpha1","kind":"PodIntent","metadata":{"annotations":{},"name":"spring-sample","namespace":"default"},"spec":{"template":{"spec":{"containers":[{"image":"springio/petclinic","name":"workload"}]}}}}
-    creationTimestamp: "..."
-    generation: 1
-    name: spring-sample
-    namespace: default
-    resourceVersion: "..."
-    uid: ...
-  spec:
-    serviceAccountName: default
-    template:
-      metadata: {}
-      spec:
-        containers:
-        - image: springio/petclinic
-          name: workload
-          resources: {}
+  
+  ...
+  
   status:
     conditions:
     - lastTransitionTime: "..." # This status indicates that all worked as expected
@@ -169,14 +172,20 @@ Example of PodIntent after applying the convention:
           resources: {}
   ```
 
-## <a id="spring-boot-web-convention"></a>Spring Boot web convention
+## Spring Boot Web Convention<a id="spring-boot-web-convention"></a>
 
-In the `bom` file's metadata, under `dependencies`, if there are any of the following `dependencies`, the convention is applied to the `PodTemplateSpec` object:
+In the metadata within the `SBOM` file, under `dependencies`, if any of the `dependencies` 
+below are found, the Spring Boot web convention will be applied to 
+the `PodTemplateSpec` object:
 
   - spring-boot
   - spring-boot-web
 
-The convention `spring-boot-web` adds the default 8080 `port` to the `PodTemplateSpec`.
+The Web Convention `spring-boot-web` gets the `server.port` property from 
+the `JAVA_TOOL_OPTIONS` environment variable and sets it as a port in the 
+`PodTemplateSpec`. If `JAVA_TOOL_OPTIONS` environment variable doesn't 
+contain a `server.port` property/value, the convention adds the property and
+sets the value to `8080` (the Spring Boot default).
 
 Example of PodIntent after applying the convention:
 
@@ -187,21 +196,9 @@ Example of PodIntent after applying the convention:
     annotations:
       kubectl.kubernetes.io/last-applied-configuration: |
         {"apiVersion":"conventions.apps.tanzu.vmware.com/v1alpha1","kind":"PodIntent","metadata":{"annotations":{},"name":"spring-sample","namespace":"default"},"spec":{"template":{"spec":{"containers":[{"image":"springio/petclinic","name":"workload"}]}}}}
-    creationTimestamp: "..."
-    generation: 1
-    name: spring-sample
-    namespace: default
-    resourceVersion: "..."
-    uid: ...
-  spec:
-    serviceAccountName: default
-    template:
-      metadata: {}
-      spec:
-        containers:
-        - image: springio/petclinic
-          name: workload
-          resources: {}
+  
+  ... 
+  
   status:
     conditions:
     - lastTransitionTime: "..." # This status indicates that all worked as expected
@@ -233,10 +230,15 @@ Example of PodIntent after applying the convention:
           resources: {}
   ```
 
-## <a id="spring-boot-actuator-convention"></a>Spring Boot actuator convention
+## Spring Boot Actuator Convention<a id="spring-boot-actuator-convention"></a>
 
-In the metadata for the `SBOM` file, under `dependencies`, there is a `dependency`
-with the name `spring-boot-actuator`. The `spring-boot-actuator` convention does the following:
+In the metadata within the `SBOM` file, under `dependencies`, if the following `dependency` 
+below is found, the Spring Boot actuator convention will be applied to 
+the `PodTemplateSpec` object:
+
+  - `spring-boot-actuator`
+
+The Spring Boot Actuator convention does the following:
 
 1. Sets the management port in the `JAVA_TOOL_OPTIONS` environment variable to `8081`.
 1. Sets the base path in the `JAVA_TOOL_OPTIONS` environment variable to `/actuator`.
@@ -248,18 +250,19 @@ on the management port when it is set to the default `8080`, the threat of
 exposure through internal access remains.
 The best practice for security is to set the management port to something other than `8080`.
 
-However, if the management port number is provided using the `-Dmanagement.server.port`
-property in `JAVA_TOOL_OPTIONS`, the Spring Boot actuator convention will respect the value provided for that property.
-The management port will be set to the provided port number rather than `8081`.
-For instructions for providing the management port number for an application, see
-[Set the `JAVA_TOOL_OPTIONS` property for a workload](#set-java-tool-options) earlier in this topic.
+However, if a management port number value is provided via the `-Dmanagement.server.port`
+property in `JAVA_TOOL_OPTIONS`, the Spring Boot actuator convention will respect 
+that value and use it, rather than its default `8081` as the management port. 
 
-Alternative methods for setting the management port are overwritten.
-The convention overrides other common methods to configure the management port
-such as `application.properties/yml` and `config server`.
-
-You can access the management context of a Spring Boot application by creating
+The management context of a Spring Boot application can be accessed by creating
 a service pointing to port `8081` and base path `/actuator`.
+
+**IMPORTANT NOTES:** 
+* To override the management port setting applied by this convention, see
+[How to set a `JAVA_TOOL_OPTIONS` property for a workload](#set-java-tool-options).
+* Any alternative methods for setting the management port will be overwritten.
+For example, if the management port has been configured via `application.properties/yml` 
+or `config server`, the Spring Boot Actuator convention will overrite that config.
 
 Example of PodIntent after applying the convention:
 
@@ -270,21 +273,9 @@ Example of PodIntent after applying the convention:
     annotations:
       kubectl.kubernetes.io/last-applied-configuration: |
         {"apiVersion":"conventions.apps.tanzu.vmware.com/v1alpha1","kind":"PodIntent","metadata":{"annotations":{},"name":"spring-sample","namespace":"default"},"spec":{"template":{"spec":{"containers":[{"image":"springio/petclinic","name":"workload"}]}}}}
-    creationTimestamp: "..."
-    generation: 1
-    name: spring-sample
-    namespace: default
-    resourceVersion: "..."
-    uid: ...
-  spec:
-    serviceAccountName: default
-    template:
-      metadata: {}
-      spec:
-        containers:
-        - image: springio/petclinic
-          name: workload
-          resources: {}
+   
+  ...
+  
   status:
     conditions:
     - lastTransitionTime: "..." # This status indicates that all worked as expected
@@ -318,9 +309,29 @@ Example of PodIntent after applying the convention:
           resources: {}
   ```
 
-## <a id="spring-boot-actuator-probes-convention"></a>Spring Boot Actuator Probes convention
+## Spring Boot Actuator Probes Convention<a id="spring-boot-actuator-probes-convention"></a>
 
-  In the `bom` file's metadata, under `dependencies`, there is a `dependency` with the name `spring-boot-actuator-probes` with version equal to or greater than **2.6**. The convention `spring-boot-actuator-probes` adds the *liveness* and *readiness* [probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) whenever the property `management.health.probes.enabled` is not set to true.
+The Spring Boot Actuator Probes convention will applied only if **all** 
+of the following conditions are met:
+
+  - The `spring-boot-actuator` dependency exists and is **>= 2.6**
+  - The `JAVA_TOOL_OPTIONS` environment variable does not include the following 
+properties _or_, if either of the properties _is_ included, it is set to a value of `true`:
+    - `-Dmanagement.health.probes.enabled`
+    - `-Dmanagement.endpoint.health.probes.add-additional-paths`
+
+
+The Spring Boot Actuator Probes convention does the following:
+
+1. Uses the main server port (the `server.port` property/value on `JAVA_TOOL_OPTIONS`) to set the _liveness_ and _readiness_ [probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+2. Adds the following properies/values to the `JAVA_TOOL_OPTIONS` environment variable
+  - `-Dmanagement.health.probes.enabled="true"`
+  - `-Dmanagement.endpoint.health.probes.add-additional-paths="true"`
+
+When this convention has been applied, the probes will be exposed as follows:
+- Liveness probe: `/livez`
+- Readiness probe: `/readyz`
+
 
 Example of PodIntent after applying the convention:
 
@@ -331,21 +342,9 @@ Example of PodIntent after applying the convention:
     annotations:
       kubectl.kubernetes.io/last-applied-configuration: |
         {"apiVersion":"conventions.apps.tanzu.vmware.com/v1alpha1","kind":"PodIntent","metadata":{"annotations":{},"name":"spring-sample","namespace":"default"},"spec":{"template":{"spec":{"containers":[{"image":"springio/petclinic","name":"workload"}]}}}}
-    creationTimestamp: "..."
-    generation: 1
-    name: spring-sample
-    namespace: default
-    resourceVersion: "..."
-    uid: ...
-  spec:
-    serviceAccountName: default
-    template:
-      metadata: {}
-      spec:
-        containers:
-        - image: springio/petclinic
-          name: workload
-          resources: {}
+  
+  ...
+  
   status:
     conditions:
     - lastTransitionTime: "..." # This status indicates that all worked as expected
@@ -370,7 +369,7 @@ Example of PodIntent after applying the convention:
         containers:
         - env:
           - name: JAVA_TOOL_OPTIONS
-            value: -Dmanagement.endpoint.health.probes.add-additional-paths="true" -Dmanagement.endpoint.health.show-details="always" -Dmanagement.endpoints.web.base-path="/actuator" -Dmanagement.endpoints.web.exposure.include="*" -Dmanagement.health.probes.enabled="true" -Dmanagement.server.port="8081" -Dserver.port="8080"
+            value: -Dmanagement.endpoint.health.probes.add-additional-paths="true" -Dmanagement.endpoints.web.base-path="/actuator" -Dmanagement.health.probes.enabled="true" -Dmanagement.server.port="8081" -Dserver.port="8080"
           image: index.docker.io/springio/petclinic@sha256:...
           name: workload
           livenessProbe:


### PR DESCRIPTION
# Hi Docs Team! 

Which other branches should this be merged with (if any)?
These changes should be applied to **TAP v1.1+**

A couple things:
1. I removed the comments on spec and env where someone wrote "<!-- |specifications| is preferred. -->:" and "<!-- |environment| is preferred -->:"
because if someone used specifications and/or environment instead of spec and/or env, the workload.yaml would fail.
so we CAN'T prefer those alternatives under any circumstances.
2. I added content informing users how to override the conventions
