### PR TITLE
scc: bump versions to final versions

### DIFF
--- a/scc/install-ootb-delivery-basic.md
+++ b/scc/install-ootb-delivery-basic.md
@@ -25,7 +25,7 @@ To install Out of the Box Delivery Basic:
    configured by running:
 
     ```
-    tanzu package available get ootb-delivery-basic.tanzu.vmware.com/0.7.0-build.2 \
+    tanzu package available get ootb-delivery-basic.tanzu.vmware.com/0.7.0 \
       --values-schema \
       -n tap-install
     ```
@@ -58,7 +58,7 @@ To install Out of the Box Delivery Basic:
     ```
     tanzu package install ootb-delivery-basic \
       --package-name ootb-delivery-basic.tanzu.vmware.com \
-      --version 0.7.0-build.2 \
+      --version 0.7.0 \
       --namespace tap-install \
       --values-file ootb-delivery-basic-values.yaml
     ```

--- a/scc/install-ootb-sc-basic.md
+++ b/scc/install-ootb-sc-basic.md
@@ -26,7 +26,7 @@ To install Out of the Box Supply Chain Basic:
    configured by running:
 
     ```
-    tanzu package available get ootb-supply-chain-basic.tanzu.vmware.com/0.7.0-build.2 \
+    tanzu package available get ootb-supply-chain-basic.tanzu.vmware.com/0.7.0 \
       --values-schema \
       -n tap-install
     ```
@@ -102,7 +102,7 @@ To install Out of the Box Supply Chain Basic:
     ```
     tanzu package install ootb-supply-chain-basic \
       --package-name ootb-supply-chain-basic.tanzu.vmware.com \
-      --version 0.7.0-build.2 \
+      --version 0.7.0 \
       --namespace tap-install \
       --values-file ootb-supply-chain-basic-values.yaml
     ```

--- a/scc/install-ootb-sc-wtest-scan.md
+++ b/scc/install-ootb-sc-wtest-scan.md
@@ -71,7 +71,7 @@ To install Out of the Box Supply Chain with Testing and Scanning:
 1. Check the values of the package that can be configured by running:
 
     ```
-    tanzu package available get ootb-supply-chain-testing-scanning.tanzu.vmware.com/0.7.0-build.2 \
+    tanzu package available get ootb-supply-chain-testing-scanning.tanzu.vmware.com/0.7.0 \
       --values-schema \
       -n tap-install
     ```
@@ -151,7 +151,7 @@ To install Out of the Box Supply Chain with Testing and Scanning:
     ```
     tanzu package install ootb-supply-chain-testing-scanning \
       --package-name ootb-supply-chain-testing-scanning.tanzu.vmware.com \
-      --version 0.7.0-build.2 \
+      --version 0.7.0 \
       --namespace tap-install \
       --values-file ootb-supply-chain-testing-scanning-values.yaml
     ```

--- a/scc/install-ootb-sc-wtest.md
+++ b/scc/install-ootb-sc-wtest.md
@@ -143,7 +143,7 @@ Install by following these steps:
     ```
     tanzu package install ootb-supply-chain-testing \
       --package-name ootb-supply-chain-testing.tanzu.vmware.com \
-      --version 0.7.0-build.2 \
+      --version 0.7.0 \
       --namespace tap-install \
       --values-file ootb-supply-chain-testing-values.yaml
     ```

--- a/scc/install-ootb-templates.md
+++ b/scc/install-ootb-templates.md
@@ -27,7 +27,7 @@ To install Out of the Box Templates:
 1. View the configurable values of the package by running:
 
     ```
-    tanzu package available get ootb-templates.tanzu.vmware.com/0.7.0-build.2 \
+    tanzu package available get ootb-templates.tanzu.vmware.com/0.7.0 \
       --values-schema \
       -n tap-install
     ```
@@ -55,7 +55,7 @@ To install Out of the Box Templates:
     ```
     tanzu package install ootb-templates \
       --package-name ootb-templates.tanzu.vmware.com \
-      --version 0.7.0-build.2 \
+      --version 0.7.0 \
       --namespace tap-install \
       --values-file ootb-templates-values.yaml
     ```

--- a/scc/install-scc.md
+++ b/scc/install-scc.md
@@ -26,13 +26,13 @@ Before installing Supply Chain Choreographer:
 
 To install Supply Chain Choreographer:
 
-1. Install v0.3.0-build.3 of the `cartographer.tanzu.vmware.com` package, naming the installation `cartographer`.
+1. Install v0.3.0 of the `cartographer.tanzu.vmware.com` package, naming the installation `cartographer`.
 
     ```
     tanzu package install cartographer \
       --namespace tap-install \
       --package-name cartographer.tanzu.vmware.com \
-      --version 0.3.0-build.3
+      --version 0.3.0
     ```
 
     Example output:


### PR DESCRIPTION
### proposed changes

Bump the versions of the SCC component to the final ones:

- carto: 0.3.0
- ootb:  0.7.0

### Which other branches should this be merged with (if any)?

The changes here are specific to TAP v1.1+
