### PR TITLE
scc: update ootb-scc-*

### DIFF
--- a/scc/ootb-supply-chain-basic.md
+++ b/scc/ootb-supply-chain-basic.md
@@ -1,119 +1,130 @@
 # Out of the Box Supply Chain Basic
 
-This Cartographer Supply Chain ties together a series of Kubernetes resources which
-drive a developer-provided Workload from source code to a Kubernetes configuration
-ready to be deployed to a cluster.
+This Package contains Cartographer Supply Chains that tie together a series of
+Kubernetes resources which drive a developer-provided Workload from source code
+to a Kubernetes configuration ready to be deployed to a cluster.
 
-This is the most basic supply chain that provides a quick path to deployment. It
-makes no use of testing or scanning steps.
+It contains the most basic supply chains that focus on providing a quick path
+to deployment making no use of testing or scanning resources in between. With
+it, the supply chains included here performs the following:
 
-```
-SUPPLYCHAIN
-  source-provider                          flux/GitRepository|vmware/ImageRepository
-       <--[src]-- image-builder            kpack/Image           : kpack/Build
-           <--[img]-- convention-applier   convention/PodIntent
-             <--[config]-- config-creator  corev1/ConfigMap
-              <--[config]-- config-pusher  carto/Runnable        : tekton/TaskRun
+- Building from source code:
 
-DELIVERY
-  config-provider                           flux/GitRepository|vmware/ImageRepository
-    <--[src]-- app-deployer                 kapp-ctrl/App
-```
+  1. Watching a Git repository or local directory for changes
+  1. Building a container image out of the source code with Buildpacks
+  1. Applying operator-defined conventions to the container definition
+  1. Creating a Deliverable object for deploying the application to a cluster
 
-- Watching a Git repository or local directory for changes
-- Building a container image out of the source code with Buildpacks
-- Applying operator-defined conventions to the container definition
-- Deploying the application to the same cluster
+- Using a pre-built application image:
+
+  1. Applying operator-defined conventions to the container definition
+  1. Creating a Deliverable object for deploying the application to a cluster
 
 
 ## <a id="prerequisites"></a> Prerequisites
 
-To use this supply chain, you must:
+To use consume this Package, you must:
 
 - Install [Out of the Box Templates](ootb-templates.html)
-- Install [Out of the Box Delivery Basic](ootb-delivery-basic.html)
 - Configure the Developer namespace with auxiliary objects that are used by the
   supply chain as described below
+- (optionally) Install [Out of the Box Delivery
+  Basic](ootb-delivery-basic.html), if willing to deploy the application to the
+same cluster as where the Workload and supply chains.
+
 
 ### <a id="developer-namespace"></a> Developer Namespace
 
-The supply chains provide definitions of many of the objects that they create to transform the source code
-to a container image and make it available as an application in the cluster.
+The supply chains provide definitions of many of the objects that they create
+to transform the source code to a container image and make it available as an
+application in a cluster.
 
-The developer must provide or configure particular objects in the developer namespace so that
-the supply chain can provide credentials and use permissions granted to a
-particular development team.
+The developer must provide or configure particular objects in the developer
+namespace so that the supply chain can provide credentials and use permissions
+granted to a particular development team.
 
 The objects that the developer must provide or configure include:
 
-- **[image secret](#image-secret)**: A Kubernetes secret of type
-  `kubernetes.io/dockerconfigjson` that contains credentials for pushing the
-  container images built by the supply chain
+- **[registries secrets](#registries-secrets)**: Kubernetes secrets of type
+  `kubernetes.io/dockerconfigjson` that contains credentials for pushing and
+  pulling the container images built by the supply chain as well as the
+  installation of TAP
 
-- **[service account](#service-account)**: The identity to be used for any interaction with the
-  Kubernetes API made by the supply chain
+- **[service account](#service-account)**: The identity to be used for any
+  interaction with the Kubernetes API made by the supply chain
 
-- **[role](#role-rolebinding)**: The set of capabilities that you want to assign to the service
-  account. It must provide the ability to manage all of the resources that the
-  supplychain is responsible for.
-
-- **[rolebinding](#role-rolebinding)**: Binds the role to the service account. It grants the
-  capabilities to the identity.
-
-- (Optional) **[git credentials secret](#git-credentials-secret)**: When using GitOps for managing the
-  delivery of applications or a private git source, this secret provides the
-  credentials for interacting with the git repository.
+- **[rolebinding](#rolebinding)**: Grant to the identity the necessary roles
+  for creating the resources prescribed by the supply chain.
 
 
-#### <a id="image-secret"></a> Image Secret
 
-Regardless of the supply chain that a Workload goes through, there must be a secret
-in the developer namespace. This secret contains the credentials to be passed to:
+#### <a id="registries-secrets"></a> Registries Secrets
 
-* Resources that push container images to image registries, such as Tanzu Build
-Service
-* Those resources that must pull container images from such image registry, such
-as Convention Service and Knative.
+Regardless of the supply chain that a Workload goes through, there must be
+Kubernetes Secrets in the developer namespace containing credentials for both
+pushing and pulling the container image that gets built by the supply chains
+when source code is provided, as well registry credentials for Kubernetes to
+run Pods using images from the installation of TAP.
 
-Use the `tanzu secret registry add` command from the Tanzu CLI to provision a
-secret that contains such credentials.
+1. Add read/write registry credentials for pushing/pulling application images:
 
-```
-# create a Secret object using the `dockerconfigjson` format using the
-# credentials provided, then a SecretExport (`secretgen-controller`
-# resource) so that it gets exported to all namespaces where a
-# placeholder secret can be found.
-#
-#
-tanzu secret registry add image-secret \
-  --server https://index.docker.io/v1/ \
-  --username $REGISTRY_USERNAME \
-  --password $REGISTRY_PASSWORD
-```
-```
-- Adding image pull secret 'image-secret'...
- Added image pull secret 'image-secret' into namespace 'default'
-```
+    ```
+    tanzu secret registry add registry-credentials \
+      --server REGISTRY-SERVER \
+      --username REGISTRY-USERNAME \
+      --password REGISTRY-PASSWORD \
+      --namespace YOUR-NAMESPACE
+    ```
 
-With the command above, the secret `image-secret` of type
-`kubernetes.io/dockerconfigjson` is created in the namespace.
-This makes the secret available for Workloads in this same namespace.
+    Where:
 
-To export the secret to all namespaces, use the `--export-to-all-namespaces`
-flag.
+    - `YOUR-NAMESPACE` is the name that you want to use for the developer
+      namespace.  For example, use `default` for the default namespace.
+
+    - `REGISTRY-SERVER` is the URL of the registry. For Dockerhub, this must be
+      `https://index.docker.io/v1/`. Specifically, it must have the leading
+      `https://`, the `v1` path, and the trailing `/`. For GCR, this is
+      `gcr.io`.  Based on the information used in [Installing the Tanzu
+      Application Platform Package and Profiles](install.md), you can use the
+      same registry server as in `ootb_supply_chain_basic` - `registry` -
+      `server`.
+
+1. Add a placeholder secret for gathering the credentials used for pulling
+   container images from the installation of TAP:
+
+    ```
+    cat <<EOF | kubectl -n YOUR-NAMESPACE apply -f -
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: tap-registry
+      annotations:
+        secretgen.carvel.dev/image-pull-secret: ""
+    type: kubernetes.io/dockerconfigjson
+    data:
+      .dockerconfigjson: e30K
+    ```
+
+With the two secrets  created
+
+- `tap-registry`, placeholder secret filled indirectly by
+  `secretgen-controller` TAP credentials set up during the installation of TAP
+- `registry-credentials`, secret providing credentials for the registry where
+  application container images will be pushed to
+
+we can move on to setting up the identity required for the Workload.
 
 
 #### <a id="service-account"></a> ServiceAccount
 
 In a Kubernetes cluster, a ServiceAccount provides a way of representing an
-identity within the Kubernetes role base access control (RBAC) system. In
-the case of a developer namespace, this represents a developer or development team.
+actor within the Kubernetes role base access control (RBAC) system. In the case
+of a developer namespace, this represents a developer or development team.
 
-You can directly attach secrets to the ServiceAccount as bind roles. This allows you
-to provide indirect ways for resources to find credentials without them needing to know the
-exact name of the secrets, as well as reduce the set of permissions that a
-group would have, through the use of Roles and RoleBinding objects.
-
+You can directly attach secrets to the ServiceAccount via both the `secrets`
+and `imagePullSecets` fields. This allows you to provide indirect ways for
+resources to find credentials without them needing to know the exact name of
+the secrets.
 
 ```
 apiVersion: v1
@@ -121,459 +132,96 @@ kind: ServiceAccount
 metadata:
   name: default
 secrets:
-  - name: image-secret
+  - name: registry-credentials
+  - name: tap-registry
 imagePullSecrets:
-  - name: image-secret
+  - name: registry-credentials
+  - name: tap-registry
 ```
 
-The ServiceAccount must have the secret created above linked to
-it. If it does not, services like Tanzu Build Service (used in the supply chain)
-lack the necessary credentials for pushing the images it builds for that
-Workload.
+> **Note:** The ServiceAccount must have the secrets created above linked to it. If
+> it does not, services like Tanzu Build Service (used in the supply chain)
+> lack the necessary credentials for pushing the images it builds for that
+> Workload.
 
-#### <a id="role-rolebinding"></a> Role and RoleBinding
+
+#### <a id="rolebinding"></a> RoleBinding
 
 As the Supply Chain takes action in the cluster on behalf of the users who
 created the Workload, it needs permissions within Kubernetes' RBAC system to do
 so.
 
-To achieve that, you must first describe a set of permissions for particular
-resources, meaning create a Role, and then bind those permissions to an actor.
-For example, creating a RoleBinding that binds the Role to the ServiceAccount.
+TAP v1.1 ships with two ClusterRoles that describe all of the necessary
+permissions we need to grant to the service account:
 
-So, create a Role describing the permissions:
+- `workload` clusterrole, providing the necessary roles for the supply chains
+  to be able to manage the resources prescribed by them
 
-```
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: default
-rules:
-- apiGroups: [source.toolkit.fluxcd.io]
-  resources: [gitrepositories]
-  verbs: ['*']
-- apiGroups: [source.apps.tanzu.vmware.com]
-  resources: [imagerepositories]
-  verbs: ['*']
-- apiGroups: [carto.run]
-  resources: [deliverables, runnables]
-  verbs: ['*']
-- apiGroups: [kpack.io]
-  resources: [images]
-  verbs: ['*']
-- apiGroups: [conventions.apps.tanzu.vmware.com]
-  resources: [podintents]
-  verbs: ['*']
-- apiGroups: [""]
-  resources: ['configmaps']
-  verbs: ['*']
-- apiGroups: [""]
-  resources: ['pods']
-  verbs: ['list']
-- apiGroups: [tekton.dev]
-  resources: [taskruns, pipelineruns]
-  verbs: ['*']
-- apiGroups: [tekton.dev]
-  resources: [pipelines]
-  verbs: ['list']
-- apiGroups: [kappctrl.k14s.io]
-  resources: [apps]
-  verbs: ['*']
-- apiGroups: [serving.knative.dev]
-  resources: ['services']
-  verbs: ['*']
-- apiGroups: [servicebinding.io]
-  resources: ['servicebindings']
-  verbs: ['*']
-- apiGroups: [services.apps.tanzu.vmware.com]
-  resources: ['resourceclaims']
-  verbs: ['*']
-- apiGroups: [scanning.apps.tanzu.vmware.com]
-  resources: ['imagescans', 'sourcescans']
-  verbs: ['*']
-```
+- `deliverable` clusterrole, providing the roles for deliveries to deploy to
+  the cluster the application Kubernetes objects produced by the supply chain
 
-Then bind it to the ServiceAccount:
+To provide those permissions to the identity we created for this Workload, bind
+the `workload` ClusterRole to the ServiceAccount we created above:
 
 ```
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: default
+  name: default-permit-workload
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: default
+  kind: ClusterRole
+  name: workload
 subjects:
   - kind: ServiceAccount
     name: default
 ```
 
+If this is just a Build cluster that does not intend to run the appication in
+it, this single RoleBinding is all that's necessary.
+
+If intending to also deploy the application that's been built, bind to the same
+ServiceAccount the `deliverable` ClusterRole too:
+
+```
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default-permit-deliverable
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: deliverable
+subjects:
+  - kind: ServiceAccount
+    name: default
+```
+
+To know more about authentication and authorization in TAP v1.1, check out
+https://github.com/pivotal/docs-tap/blob/main/authn-authz/overview.md.
 
 ### <a id="developer-workload"></a> Developer workload
 
-With the developer namespace setup with the objects above (image, secret,
-serviceaccount, role, and rolebinding), you can create the Workload
-object.
+With the developer namespace setup with the objects above (secret,
+serviceaccount, and rolebinding), you can create the Workload object.
 
-Configure the Workload with three scenarios in mind:
-
-- **[local iteration](#local)**: takes source code from the filesystem and drives is
-  through the supply chain making no use of external git repositories
-
-- **[local iteration with code from git](#local-with-git)**: takes source code from a git
-  repository and drives it through the supply chain without persisting the
-  final configuration in git (enabled **only** if the installation did not include
-  a default repository prefix for git-based workflows)
-
-- **[gitops](#gitops)**: source code is provided by an external git repository (public or
-  private), and the final Kubernetes configuration to deploy the application is
-  persisted in a repository
-
-
-#### <a id="local"></a> Local Iteration with Local Code
-
-In this scenario, you need the source code (in the example below,
-assuming the current directory `.` as the location of the source code you want
-to send through the supply chain), and a container image registry to use as the
-mean for making the source code available inside the Kubernetes cluster.
-
+To do so, we can make use of the `apps` plugin from the Tanzu CLI:
 
 ```
-tanzu apps workload create tanzu-java-web-app \
-  --local-path . \
-  --source-image $REGISTRY/source \
-  --label app.kubernetes.io/part-of=tanzu-java-web-app \
-  --type web
-```
-```
-Create workload:
-      1 + |---
-      2 + |apiVersion: carto.run/v1alpha1
-      3 + |kind: Workload
-      4 + |metadata:
-      5 + |  labels:
-      6 + |    apps.tanzu.vmware.com/workload-type: web
-      7 + |    app.kubernetes.io/part-of: tanzu-java-web-app
-      8 + |  name: tanzu-java-web-app
-      9 + |  namespace: default
-     10 + |spec:
-     11 + |  source:
-     12 + |    image: 10.188.0.3:5000/source:latest@sha256:1cb23472fcdcce276c316d9bed6055625fbc4ac3e50a971f8f8004b1e245981e
-
-? Do you want to create this workload? Yes
-Created workload "tanzu-java-web-app"
+tanzu apps workload create [flags] [workload-name]
 ```
 
-With the Workload submitted, you can track of the resulting
-series of Kubernetes objects created to drive the source code all the way to a
-deployed application by making use of the `tail` command:
+Depending on what one is aiming to achieve, different flags should be
+specified. To know more about those (including details about different features
+of the supply chains), check out the following sections:
 
-```
-tanzu apps workload tail tanzu-java-web-app
-```
+- [Building from source](building-from-source.md), for knowing more about
+  different ways of creating a Workload that has the application built from
+  source code
 
+- [Pre-built image](pre-built-image.md), for more information on how to
+  leverage pre-built images in the supply chains
 
-#### <a id="local-with-git"></a> Local Iteration with Code from Git
-
-Similar to local iteration with local code, here we make use of the same type
-(`web`), but instead of pointing at source code that we have locally, we can
-make use of a git repository to feed the supply chain with new changes as they
-are pushed to a branch.
-
->**Note**: If you plan to use a private git repository, skip
-to the next section, [Private Source Git Repository](#private-source).
-
-
-```
-tanzu apps workload create tanzu-java-web-app \
-  --git-branch main \
-  --git-repo https://github.com/sample-accelerators/tanzu-java-web-app
-  --label app.kubernetes.io/part-of=tanzu-java-web-app \
-  --type web
-```
-```
-Create workload:
-      1 + |---
-      2 + |apiVersion: carto.run/v1alpha1
-      3 + |kind: Workload
-      4 + |metadata:
-      5 + |  labels:
-      6 + |    apps.tanzu.vmware.com/workload-type: web
-      7 + |    app.kubernetes.io/part-of: tanzu-java-web-app
-      8 + |  name: tanzu-java-web-app
-      9 + |  namespace: default
-     10 + |spec:
-     11 + |  source:
-     12 + |    git:
-     13 + |      ref:
-     14 + |        branch: main
-     15 + |      url: https://github.com/sample-accelerators/tanzu-java-web-app
-```
-
-This scenario is only possible if the installation of the supply
-chain did not include a default git repository prefix
-(`gitops.repository_prefix`).
-
-
-##### <a id="private-source"></a> Private Source Git Repository
-
-In the example above, we make use of a public repository. To
-make use of a private repository instead, you create a Secret in the
-same namespace as the one where the Workload is being submitted to named after
-the value of `gitops.ssh_secret` (the installation defaults the name to
-`git-ssh`):
-
-```
-apiVersion: v1
-kind: Secret
-metadata:
-  name: git-ssh
-type: kubernetes.io/ssh-auth
-stringData:
-  known_hosts: string             # git server public keys
-  identity: string                # private key with pull permissions
-  identity.pub: string            # public of the `identity` private key
-```
-
->**Note**: For a particular Workload, you can override the name of the secret
-by using the `gitops_ssh_secret` parameter (`--param gitops_ssh_secret`)
-in the Workload.
-
-If this is your first time setting up SSH credentials for your user, the following
-steps can serve as a guide:
-
-```
-# generate a new keypair.
-#
-#   - `identity`     (private)
-#   - `identity.pub` (public)
-#
-# once done, head to your git provider and add the `identity.pub` as a
-# deployment key for the repository of interest or add to an account that has
-# access to it. for instance, for github:
-#
-#   https://github.com/<repository>/settings/keys/new
-#
-ssh-keygen -t rsa -q -b 4096 -f "identity" -N "" -C ""
-
-
-# gather public keys from the provider (e.g., github):
-#
-ssh-keyscan github.com > ./known_hosts
-
-
-# create the secret.
-#
-kubectl create secret generic git-ssh \
-    --from-file=./identity \
-    --from-file=./identity.pub \
-    --from-file=./known_hosts
-```
-
->**Note**: When you create a Secret that provides credentials for accessing your
-private git repository, you can create a deploy key if your Git Provider
-supports it (GitHub does). Any Git secrets you apply to
-your cluster can potentially be viewed by others who have access to that
-cluster. So, it is better to use Deploy keys or shared bot accounts instead of
-adding personal Git Credentials.
-
-With the namespace configured and having added the secret to be used for
-fetching source code from a private repository, you can create the
-Workload:
-
-
-```
-tanzu apps workload create tanzu-java-web-app \
-  --git-branch main \
-  --git-repo https://github.com/sample-accelerators/tanzu-java-web-app
-  --label app.kubernetes.io/part-of=tanzu-java-web-app \
-  --type web
-```
-```
-Create workload:
-      1 + |---
-      2 + |apiVersion: carto.run/v1alpha1
-      3 + |kind: Workload
-      4 + |metadata:
-      5 + |  labels:
-      6 + |    apps.tanzu.vmware.com/workload-type: web
-      7 + |    app.kubernetes.io/part-of: tanzu-java-web-app
-      8 + |  name: tanzu-java-web-app
-      9 + |  namespace: default
-     10 + |spec:
-     11 + |  source:
-     12 + |    git:
-     13 + |      ref:
-     14 + |        branch: main
-     15 + |      url: https://github.com/sample-accelerators/tanzu-java-web-app
-```
-
-
-#### <a id="gitops"></a> GitOps
-
-Different from local iteration, the GitOps approach configures the supply chain to push the Kubernetes Configuration to a remote Git repository.  This allows users to compare configuration changes and promote changes through environments using GitOps principles. 
-
-```
-SUPPLY CHAIN
-
-    given a Workload
-      watches sourcecode repo
-        builds container image
-          prepare configuration
-            pushes config to git
-
-
-DELIVERY
-
-    given a Deliverable
-      watches configurations repo
-        deploys the kubernetes configurations
-
-```
-
-In order to authenticate to a remote Git repository, a secret containing credentials for the remote provider (e.g., GitHub) must be created in the developer namespace.  Because this operation requires push permissions, this is true regardless if the repository is public or private.
-
-Before proceeding, create a secret in the following format:
-
-```
-apiVersion: v1
-kind: Secret
-metadata:
-  name: git-ssh   # `git-ssh` is the default name.
-                  #   - operators can change the default using `gitops.ssh_secret`.
-                  #   - developers can override using `gitops_ssh_secret`
-  annotations:
-    tekton.dev/git-0: github.com  # git server host   (!! required)
-type: kubernetes.io/ssh-auth
-stringData:
-  ssh-privatekey: string          # private key with push-permissions
-  known_hosts: string             # git server public keys
-  identity: string                # private key with pull permissions (same as ssh-privatekey)
-  identity.pub: string            # public of the `identity` private key
-```
-
-For example (with secrets redacted):
-
-```
-apiVersion: v1
-kind: Secret
-metadata:
-  name: git-ssh   # `git-ssh` is the default name.
-                  #   - operators can change the default using `gitops.ssh_secret`.
-                  #   - developers can override using `gitops_ssh_secret`
-  annotations:
-    tekton.dev/git-0: github.com  # git server host   (!! required)
-type: kubernetes.io/ssh-auth
-stringData:
-  ssh-privatekey: |
-    -----BEGIN OPENSSH PRIVATE KEY-----
-    AAAA
-    ....
-    ....
-    ....
-    ....
-    -----END OPENSSH PRIVATE KEY-----      
-  known_hosts: |
-    <known hosts entrys for git provider>          
-  identity: |
-    -----BEGIN OPENSSH PRIVATE KEY-----
-    AAAA
-    ....
-    ....
-    ....
-    ....
-    -----END OPENSSH PRIVATE KEY-----            
-  identity.pub: ssh-ed25519 AAAABBBCCCCDDDDeeeeFFFF user@example.com
-```
-
->**Note**: Because of incompatibilities between Kubernetes resources
- `ssh-privatekeys` must be set to the same value as `identity`.
-
-Now that the secret has been created, ensure that it is added to the service account for the developer namespace is using.  For example, if you are using the `default` service account from the "Getting Started" guide, the service account should look like this:
-
-```
-apiVersion: v1
-imagePullSecrets:
-- name: registry-credentials
-- name: tap-registry
-kind: ServiceAccount
-metadata:
-  name: default
-  namespace: default
-secrets:
-- name: registry-credentials
-- name: default-token-zjbjs
-- name: git-ssh
-```
-
-With the Secret created and added to the service account, we can move on to the Workload.
-
-##### <a id="workload-using-default-git-organization"></a> Workload Using Default Git Organization
-
-During the installation of `ootb-*`, one of the values that operators can
-configure is one that dictates what the prefix the supply chain should use when
-forming the name of the repository to push to the Kubernetes configurations
-produced by the supply chains - `gitops.repository_prefix`.
-
-That being set, all it takes to change the behavior towards using GitOps is
-setting the source of the source code to a git repository and then as the
-supply chain progresses, configuration are pushed to a repository named
-after `$(gitops.repository_prefix) + $(workload.name)`.
-
-e.g, having `gitops.repository_prefix` configured to `ssh://git@github.com/foo/gitops` and
-a Workload as such:
-
-```
-tanzu apps workload create tanzu-java-web-app \
-  --git-branch main \
-  --git-repo https://github.com/sample-accelerators/tanzu-java-web-app
-  --label app.kubernetes.io/part-of=tanzu-java-web-app \
-  --type web
-```
-```
-Create workload:
-      1 + |---
-      2 + |apiVersion: carto.run/v1alpha1
-      3 + |kind: Workload
-      4 + |metadata:
-      5 + |  labels:
-      6 + |    apps.tanzu.vmware.com/workload-type: web
-      7 + |    app.kubernetes.io/part-of: tanzu-java-web-app
-      8 + |  name: tanzu-java-web-app
-      9 + |  namespace: default
-     10 + |spec:
-     11 + |  source:
-     12 + |    git:
-     13 + |      ref:
-     14 + |        branch: main
-     15 + |      url: https://github.com/sample-accelerators/tanzu-java-web-app
-```
-
- You see the Kubernetes configuration pushed to
-`git@github.com/foo/gitops-tanzu-java-web-app.git`.
-
-Regardless of the setup, the repository where configuration is pushed to can be
-also manually overridden by the developers by tweaking the following parameters:
-
--  `gitops.ssh_secret`: Name of the secret in the same namespace as the
-   Workload where SSH credentials exist for pushing the configuration produced
-   by the supply chain to a git repository.
-   Example: "ssh-secret"
-
--  `gitops.repository`: SSH URL of the git repository to push the Kubernetes
-   configuration produced by the supply chain to.
-   Example: "ssh://git@foo.com/staging.git"
-
--  `gitops.branch`: Name of the branch to push the configuration to.
-   Example: "main"
-
--  `gitops.commit_message`: Message to write as the body of the commits
-   produced for pushing configuration to the git repository.
-   Example: "ci bump"
-
--  `gitops.user_name`: Username to use in the commits.
-   Example: "Alice Lee"
-
--  `gitops.user_email`: User email address to use for the commits.
-   Example: "foo@example.com"
+- [GitOps vs RegistryOps](gitops-vs-regops.md), for a description of the
+  different ways of propagating the deployment configuration through external
+  systems (git repositories and image registries).

--- a/scc/ootb-supply-chain-testing-scanning.md
+++ b/scc/ootb-supply-chain-testing-scanning.md
@@ -1,39 +1,33 @@
 # Out of the Box Supply Chain with Testing and Scanning
 
-This Cartographer Supply Chain ties a series of Kubernetes resources which,
-when working together, drives a developer-provided Workload from source code
+
+This Package contains Cartographer Supply Chains that tie together a series of
+Kubernetes resources which drive a developer-provided Workload from source code
 all the way to a Kubernetes configuration ready to be deployed to a cluster,
 having not only passed that source code through testing and vulnerability
 scanning, but also the container image produced.
 
-
-```
-SUPPLYCHAIN
-  source-provider                          flux/GitRepository|vmware/ImageRepository
-    <--[src]-- source-tester               carto/Runnable        : tekton/PipelineRun
-      <--[src]-- source-scanner            scst/SourceScan       : v1/Job
-       <--[src]-- image-builder            kpack/Image           : kpack/Build
-          <--[img]-- image-scanner         scst/ImageScan        : v1/Job
-           <--[img]-- convention-applier   convention/PodIntent
-             <--[config]-- config-creator  corev1/ConfigMap
-              <--[config]-- config-pusher  carto/Runnable        : tekton/TaskRun
-
-DELIVERY
-  config-provider                           flux/GitRepository|vmware/ImageRepository
-    <--[src]-- app-deployer                 kapp-ctrl/App
-```
-
-
 It includes all the capabilities of the Out of the Box Supply Chain With
-Testing, but adds on top source and image scanning using Grype:
+Testing, but adds on top source and image scanning using Grype.
 
-- Watching a Git Repository or local directory for changes
-- Running tests from a developer-provided Tekton or Pipeline
-- Scanning the source code for known vulnerabilities using Grype
-- Building a container image out of the source code with Buildpacks
-- Scanning the image for known vulnerabilities
-- Applying operator-defined conventions to the container definition
-- Deploying the application to the same cluster
+Similarly, it allows Workloads providing both source code and pre-built images
+to make use of it performing the following:
+
+- Building from source code:
+
+  1. Watching a Git Repository or local directory for changes
+  1. Running tests from a developer-provided Tekton or Pipeline
+  1. Scanning the source code for known vulnerabilities using Grype
+  1. Building a container image out of the source code with Buildpacks
+  1. Scanning the image for known vulnerabilities
+  1. Applying operator-defined conventions to the container definition
+  1. Deploying the application to the same cluster
+
+- Using a pre-built application image:
+
+  1. Scanning the image for known vulnerabilities
+  1. Applying operator-defined conventions to the container definition
+  1. Creating a Deliverable object for deploying the application to a cluster
 
 
 ## <a id="prerequisites"></a> Prerequisites
@@ -41,12 +35,14 @@ Testing, but adds on top source and image scanning using Grype:
 To make use this supply chain, it is required that:
 
 - Out of the Box Templates is installed
-- Out of the Box Delivery Basic is installed
 - Out of the Box Supply Chain With Testing **is NOT installed**
 - Out of the Box Supply Chain With Testing and Scanning **is installed**
 - Developer namespace is configured with the objects per Out of the Box Supply
   Chain With Testing guidance (this supply chain is additive to the testing
   one)
+- (optionally) Install [Out of the Box Delivery
+  Basic](ootb-delivery-basic.html), if willing to deploy the application to the
+same cluster as where the Workload and supply chains.
 
 You can verify that you have the right set of supply chains installed (i.e. the
 one with Scanning and _not_ the one with testing) by running the following
@@ -74,27 +70,28 @@ Out of the Box Supply Chain examples, so only additions are included here.
 To ensure that you have configured the namespace correctly, it is important that
 the namespace has the objects that you configured in the other supply chain setups:
 
-- **image secret**: A Kubernetes secret of type `kubernetes.io/dockerconfigjson` filled with
-credentials for pushing the container images built by the supply chain. For more information, see
-[Supply Chain Basic](ootb-supply-chain-basic.md).
+- **registries secrets**: Kubernetes secrets of type
+  `kubernetes.io/dockerconfigjson` that contains credentials for pushing and
+  pulling the container images built by the supply chain as well as the
+  installation of TAP
 
-- **service account**: The identity to be used for any interaction with the Kubernetes API made by
-the supply chain. For more information, see [Supply Chain Basic](ootb-supply-chain-basic.md).
+  For more information, see [Out of the Box Supply Chain Basic](ootb-supply-chain-basic.md).
 
-- **role**: The set of capabilities that you want to assign to the service account. It must provide
-the ability to manage all of the resources that the supplychain is responsible for.
-For more information, see [Supply Chain Basic](ootb-supply-chain-basic.md).
+- **service account**: The identity to be used for any
+  interaction with the Kubernetes API made by the supply chain
 
-- **rolebinding**: Binds the role to the service account, which grants the capabilities to the
-identity. For more information, see [Supply Chain Basic](ootb-supply-chain-basic.md).
+  For more information, see [Out of the Box Supply Chain Basic](ootb-supply-chain-basic.md).
 
-- (Optional) **git credentials secret**: When using GitOps for managing the delivery of applications
-or a private Git source, provides the required credentials for interacting with the Git repository.
-For more information, see [Supply Chain Basic](ootb-supply-chain-basic.md).
 
-- **tekton pipeline**: A pipeline to be ran whenever the supply chain hits the stage of testing the
-source code. For more information, see [Supply Chain with Testing](ootb-supply-chain-testing.md).
+- **rolebinding**: Grant to the identity the necessary roles
+  for creating the resources prescribed by the supply chain.
 
+  For more information, see [Out of the Box Supply Chain Basic](ootb-supply-chain-basic.md).
+
+- **Tekton pipeline**: A pipeline runs whenever the supply chain hits the stage
+  of testing the source code.
+
+  For more information, see [Out of the Box Supply Chain Testing](ootb-supply-chain-testing.md).
 
 And the new ones, that you create here:
 


### PR DESCRIPTION
### proposed changes

- authn/authz: make use of the `workload` and `deliverable` ClusterRoles
  instead of providing the full Role

- overview: mention the dual capabilities of the ootb-sc packages (from
  source vs pre-built images)

- basic: update the namespace setup to account for the placeholder
  secret for `tap-registry` secret as, without it, one wouldn't be able
  to have kpack/image etc running as they'd point at a serviceaccount
  that wouldn't provide pull secrets for tanzunet

note that we're able to remove a bunch of information about gitops
because those sections are now covered under #1083 

### Which other branches should this be merged with (if any)?

the changes here are for TAP v1.1+
