### PR TITLE
fix typo in run cluster explanation

### DIFF
--- a/multicluster/reference/tap-values-run-sample.md
+++ b/multicluster/reference/tap-values-run-sample.md
@@ -25,4 +25,4 @@ Where:
 
 - `INGRESS-DOMAIN` is the subdomain for the host name that you point at the `tanzu-shared-ingress`
 service's external IP address.
-- `APP-LIVE-VIEW-INGRESS-DOMAIN` is the subdomain you setup on the View profile cluster. This matches the value key `appliveview.ingressDomain`. Include the default host name `applieview.` ahead of the domain.
+- `APP-LIVE-VIEW-INGRESS-DOMAIN` is the subdomain you setup on the View profile cluster. This matches the value key `appliveview.ingressDomain`. Include the default host name `appliveview.` ahead of the domain.


### PR DESCRIPTION
Which other branches should this be merged with (if any)? I think just 1.1.0 is good, which is when we introduced multi-cluster docs.