### PR TITLE
update "stateful pod" note

### DIFF
--- a/tap-gui/troubleshooting.md
+++ b/tap-gui/troubleshooting.md
@@ -76,7 +76,7 @@ When you need to update the configuration of Tanzu Application Platform GUI (eit
     kubectl delete pod -l app=backstage -n tap-gui
     ```
 
->**Note:** `tap-gui` Pods aren't stateful. `config` is held in ConfigMaps, Git catalog, or Secrets.
+>**Note:** Depending on your [database configuration](./database.md), deleting and re-instantiating the pod may cause the loss of user preferences and [manually registered entities](catalog/catalog-operations.md#-register-components). If you have configured an external PostgreSQL database, then `tap-gui` Pods are not stateful. In general, state is held in ConfigMaps, Secrets, or the database.
 
 ## <a id='tap-gui-logs'></a> Pull logs from Tanzu Application Platform GUI
 


### PR DESCRIPTION
Help! I'm not certain that my `catalog/catalog-operations.md#-register-components` link is going to render properly. I like the idea of linking directly to a specific section in another document, but if the markdown processor that gets used to generate the real docs doesn't handle that nicely I'd be OK with just linking to the overall catalog operations page.

Back in October 2021 the claim that the TAP GUI pods aren't stateful was generally true, but since then we've exposed the "Register Entity" flow which means that the in-memory database can accumulate state that cannot be recovered after a pod gets deleted.

Which other branches should this be merged with (if any)? Since the "Register Entity" flow existed in 1.0 as well, I think this change should be made on the `1-0` branch as well. Should I open a separate PR?