### PR TITLE
Update default descriptor version for tbs to 100.0.293

### DIFF
--- a/install.md
+++ b/install.md
@@ -293,7 +293,7 @@ this can reuse the `tap-registry` secret created in
 > You can find the buildpack and stack artifacts installed with Tanzu Application Platform
 > in the descriptor file on [Tanzu Network](https://network.pivotal.io/products/tbs-dependencies).
 > The current installed version of the descriptor is
-> [100.0.279](https://network.pivotal.io/products/tbs-dependencies#/releases/1066670). Sometimes the dependencies get
+> [100.0.293](https://network.pivotal.io/products/tbs-dependencies#/releases/1086670). Sometimes the dependencies get
 > out of date and require updates. You can do this using a
 > [manual process in a CI/CD context](tanzu-build-service/tbs-about.html#dependencies-manual), or
 > an [automatic update process](tanzu-build-service/tbs-about.html#auto-updates)

--- a/multicluster/reference/tap-values-build-sample.md
+++ b/multicluster/reference/tap-values-build-sample.md
@@ -71,7 +71,7 @@ you can reuse the `tap-registry` Secret created in
 > You can find the buildpack and stack artifacts installed with Tanzu Application Platform
 > in the descriptor file on [Tanzu Network](https://network.pivotal.io/products/tbs-dependencies).
 > The current installed version of the descriptor is
-> [100.0.279](https://network.pivotal.io/products/tbs-dependencies#/releases/1066670). Sometimes the dependencies get
+> [100.0.293](https://network.pivotal.io/products/tbs-dependencies#/releases/1086670). Sometimes the dependencies get
 > out of date and require updates. You can do this using a
 > [manual process in a CI/CD context](tanzu-build-service/tbs-about.html#dependencies-manual), or
 > an [automatic update process](tanzu-build-service/tbs-about.html#auto-updates)

--- a/tanzu-build-service/install-tbs.md
+++ b/tanzu-build-service/install-tbs.md
@@ -91,7 +91,7 @@ To install Tanzu Build Service by using the Tanzu CLI:
      >Tanzu Build Service dependencies (buildpacks and stacks) when they are released on
      >VMware Tanzu Network. You can set `enable_automatic_dependency_updates` as `false` to
      >pause the automatic update of Build Service dependencies. When automatic updates are paused,
-     >the pinned version of the descriptor for Tanzu Application Platform v1.1.0 is [100.0.279](https://network.pivotal.io/products/tbs-dependencies#/releases/1066670).
+     >the pinned version of the descriptor for Tanzu Application Platform v1.1.0 is [100.0.293](https://network.pivotal.io/products/tbs-dependencies#/releases/1086670).
      >If left undefined, this value is `false`. For information about updating dependencies manually,
      >see [Manual Control of Dependency Updates](tbs-about.html#manual-updates).
 


### PR DESCRIPTION
Which other branches should this be merged with (if any)?

This should be merged into `main` and `1-1` for the tap 1.1.x release version docs.