### PR TITLE
Added instructions around part of label

### DIFF
--- a/tap-gui/plugins/scc-tap-gui.md
+++ b/tap-gui/plugins/scc-tap-gui.md
@@ -10,7 +10,8 @@ You must have either of the Full or View profiles installed on your cluster, whi
 
 ## <a id="sc-visibility"></a> Supply Chain Visibility
 
-To visualize your workload through the SCC plug-in, you must first create a workload.
+To visualize your workload through the SCC plug-in, you must first create a workload. 
+- The workload must have the `app.kubernetes.io/part-of` label specified, whether you manually create the workload or use those supplied with the OOTB supply chains. 
 
 Use the left sidebar navigation to access your workload and visualize it in the supply chain that is installed on your cluster.
 


### PR DESCRIPTION
Numerous questions have been asked in tap-assist about why the workload was not showing up in the visualization and this change is necessary to ensure that we don't continue to have confusion

Please push to production