### PR TITLE
fix path error for file location in Windows instructions

### DIFF
--- a/install-tanzu-cli.md
+++ b/install-tanzu-cli.md
@@ -163,7 +163,7 @@ the CLI core and plug-ins are installed by running:
 1. From the `Program Files\tanzu` directory, move and rename the executable file from
 
     ```console
-    Program Files\tanzu\core\v0.11.2\tanzu-core-windows_amd64.exe
+    Program Files\tanzu\cli\core\v0.11.2\tanzu-core-windows_amd64.exe
     ```
 
     to


### PR DESCRIPTION
Which other branches should this be merged with (if any)?
TAP v1.1.0+
