### PR TITLE
Update ingress-multicluster.md

### DIFF
--- a/scst-store/ingress-multicluster.md
+++ b/scst-store/ingress-multicluster.md
@@ -131,7 +131,8 @@ Install Supply Chain Security Tools - Scan with the following configuration:
 
 ```yaml
 ---
-metadataStore:
+scanning:
+  metadataStore:
     url: https://metadata-store.example.com
     caSecret:
         name: store-ca-cert


### PR DESCRIPTION
The yaml example provided in the "The Install Supply Chain Security Tools - Scan with the following configuration" section is missing "scanning:" as the top level property. This can cause someone to not realize the yaml is incorrect. I would be helpful to include the top level qualifier in the example so it matches what should be in TAP Values. 

This should be included in TAP 1.1 documents.

Which other branches should this be merged with (if any)?
