### PR TITLE
Update ingress-multicluster.md

### DIFF
--- a/scst-store/ingress-multicluster.md
+++ b/scst-store/ingress-multicluster.md
@@ -139,4 +139,5 @@ scanning:
         importFromNamespace: metadata-store-secrets
     authSecret:
         name: store-auth-token
+        importFromNamespace: metadata-store-secrets
 ```


### PR DESCRIPTION
Found one more change (Apologize I didn't get it in the first PR):

The authSecret: property needs "importFromNamespace: metadata-store-secrets" child property to properly import the secret. 

This needs to go into TAP 1.1 documents and beyond. Thank you so much!

Supporting Slack Conversation: https://vmware.slack.com/archives/C02D60T1ZDJ/p1652479386667919

Which other branches should this be merged with (if any)?
