### PR TITLE
Replaced download link for the app accelerator vscode extension

### DIFF
--- a/application-accelerator/vscode.md
+++ b/application-accelerator/vscode.md
@@ -8,7 +8,7 @@ information on how to expose this server follow the instructions [here](./acc-cl
 
 # Installation
 
-1. Download the file `tanzu-app-accelerator-0.1.0.vsix` from the [release page](https://github.com/pivotal/acc-ide/releases/tag/0.1.0).
+1. Download Tanzu App Accelerator Extension for Visual Studio Code from the Tanzu Network
 
 2. Open VS Code.
 


### PR DESCRIPTION
Which other branches should this be merged with (if any)?
-> None