### PR TITLE
Update usages of ingress domains to use new shared key introduced in https://gitlab.eng.vmware.com/tap/tap-packages/-/merge_requests/534

### DIFF
--- a/app-live-view/install.md
+++ b/app-live-view/install.md
@@ -74,7 +74,7 @@ To install Application Live View Backend:
     ingressEnabled: "false"
     ```
 
-    For a multicluster environment, use the following values:
+    For a multicluster environment, TAP uses the `shared.ingress_domain` by default. You may override this setting with the following values:
 
     ```yaml
     ingressEnabled: "true"

--- a/application-accelerator/install-app-acc.md
+++ b/application-accelerator/install-app-acc.md
@@ -34,7 +34,7 @@ When you install the Application Accelerator, you can configure the following op
 | samples.include | True | Option to include the bundled sample Accelerators in the installation |
 | ingress.include | False | Option to include the ingress configuration in the installation |
 | ingress.enable_tls | False | Option to include TLS for the ingress configuration |
-| domain | tap.example.com | Top-level domain to use for ingress configuration |
+| domain | tap.example.com | Top-level domain to use for ingress configuration, defaults to `shared.ingress_domain` if set |
 | tls.secretName | tls | The name of the secret |
 | tls.namespace | tanzu-system-ingress | The namespace for the secret |
 

--- a/cli-plugins/accelerator/overview.md
+++ b/cli-plugins/accelerator/overview.md
@@ -17,7 +17,7 @@ available in an Application Accelerator server.
 Developers use the `--server-url` to point to the Application Accelerator server they want to use.
 The URL depends on the configuration settings for Application Accelerator:
 
-- For installations configured with a **shared ingress**, use `https://accelerator.<domain>` where `domain` is provided in the values file for the accelerator configuration.
+- For installations configured with a **shared ingress**, use `https://accelerator.<domain>` where `domain` defaults to the `shared.ingress_domain` value provided in the TAP values file.
 - For installations using a **LoadBalancer**, look up the External IP address by using:
 
     ```

--- a/install.md.hbs
+++ b/install.md.hbs
@@ -190,6 +190,10 @@ The following is the YAML file sample for the full-profile:
 
 ```yaml
 profile: full
+
+shared:
+  ingress_domain: INGRESS-DOMAIN
+
 ceip_policy_disclosed: FALSE-OR-TRUE-VALUE # Installation fails if this is not set to true. Not a string.
 buildservice:
   kp_default_repository: "KP-DEFAULT-REPO"
@@ -198,10 +202,8 @@ buildservice:
   tanzunet_username: "TANZUNET-USERNAME"
   tanzunet_password: "TANZUNET-PASSWORD"
   descriptor_name: "DESCRIPTOR-NAME"
-supply_chain: basic
 
-cnrs:
-  domain_name: INGRESS-DOMAIN
+supply_chain: basic
 
 ootb_supply_chain_basic:
   registry:
@@ -210,13 +212,8 @@ ootb_supply_chain_basic:
   gitops:
     ssh_secret: "SSH-SECRET-KEY"
 
-learningcenter:
-  ingressDomain: "DOMAIN-NAME"
-
 tap_gui:
   service_type: ClusterIP
-  ingressEnabled: "true"
-  ingressDomain: "INGRESS-DOMAIN"
   app_config:
     app:
       baseUrl: http://tap-gui.INGRESS-DOMAIN
@@ -262,7 +259,6 @@ Images are written to `SERVER-NAME/REPO-NAME/workload-name`. Examples:
     * Google Cloud Registry has the form `repository: "my-project/supply-chain"`
 - `SSH-SECRET-KEY` is the SSH secret key supported by the specific package.
 See [Identify the values for your package](#identify-values) for more information.
-- `DOMAIN-NAME` has a value such as `learningcenter.example.com`.
 - `INGRESS-DOMAIN` is the subdomain for the host name that you point at the `tanzu-shared-ingress`
 service's External IP address.
 - `GIT-CATALOG-URL` is the path to the `catalog-info.yaml` catalog definition file. You can download either a blank or populated catalog file from the [Tanzu Application Platform product page](https://network.pivotal.io/products/tanzu-application-platform/#/releases/1043418/file_groups/6091). Otherwise, you can use a Backstage-compliant catalog you've already built and posted on the Git infrastructure.

--- a/learning-center/getting-started/learning-center-operator.md
+++ b/learning-center/getting-started/learning-center-operator.md
@@ -65,13 +65,15 @@ by using an external URL for access to define the domain name that is used as a 
 
 >**Note:** For the custom domain you are using, DNS must have been configured with a wildcard domain to forward all requests for subdomains of the custom domain to the ingress router of the Kubernetes cluster.
 
-VMware recommends that you avoid using a `.dev` domain name because such domain names require
-using HTTPS and not HTTP. Although you can provide a certificate for secure
+VMware recommends that you avoid using a `.dev` or `.app` domain name because such domain names require
+browsers to use HTTPS and not HTTP. Although you can provide a certificate for secure
 connections under the domain name for use by Learning Center, this doesn't extend to what a workshop
 may do. If workshop instructions require that you create ingresses in Kubernetes
-using HTTP only, a `.dev` domain name cannot work.
+using HTTP only, a `.dev` or `.app` domain name cannot work in the browser.
 
 >**Note:** If you are running Kubernetes on your local machine using a system such as `minikube` and you don't have a custom domain name that maps to the IP address for the cluster, you can use a `nip.io` address. For example, if `minikube ip` returned `192.168.64.1`, you can use the 192.168.64.1.nip.io domain. You cannot use an address of form `127.0.0.1.nip.io`, or `subdomain.localhost`. This causes a failure as internal services needing to connect to each other end up connecting to themselves instead, because the address resolves to the host loopback address of `127.0.0.1`.
+
+If needed, you can override the `shared.ingress_domain` TAP-level setting with the `ingressDomain` parameter to learning center:
 
 ```console
 ingressDomain: learningcenter.my-domain.com

--- a/learning-center/install-learning-center.md
+++ b/learning-center/install-learning-center.md
@@ -52,7 +52,7 @@ To install Learning Center:
 
 1. Create a config file named `learning-center-config.yaml`.
 
-1. Add the parameter `ingressDomain` to `learning-center-config.yaml`, as in this example:
+1. If you want to override the `shared.ingress_domain` in the TAP-level values file, add the parameter `ingressDomain` to `learning-center-config.yaml`, as in this example:
 
     ```yaml
     ingressDomain: YOUR-INGRESS-DOMAIN

--- a/multicluster/installing-multicluster.md
+++ b/multicluster/installing-multicluster.md
@@ -30,7 +30,7 @@ Install the View profile cluster first, because some components must exist befor
 To install the View cluster:
 
 1. Follow the steps for installing the Full profile in [Installing the Tanzu Application Platform package and profiles](../install.md). Alternatively, you can use a reduced values file for the View profile, as shown in [View profile](reference/tap-values-view-sample.md).
-2. Verify that you can access Tanzu Application Platform GUI by using the ingress that you have set up. The address must follow this format: `http://tap-gui.INGRESS-DOMAIN`, where `INGRESS-DOMAIN` is the DNS domain you've set to point to the shared Contour installation in the `tanzu-system-ingress` namespace with the service `envoy`.
+2. Verify that you can access Tanzu Application Platform GUI by using the ingress that you have set up. The address must follow this format: `http://tap-gui.INGRESS-DOMAIN`, where `INGRESS-DOMAIN` is the DNS domain you've set in `shared.ingress_domain` which points to the shared Contour installation in the `tanzu-system-ingress` namespace with the service `envoy`.
 3. Verify that you have followed the instructions for [Multicluster setup](../scst-store/ingress-multicluster.md#a-id"multicluster-setup"amulticluster-setup) for the Supply Chain Security Tools - Store.
 
 ## <a id='install-build'></a> Install Build clusters
@@ -44,7 +44,7 @@ To install the Build profile cluster:
 To install the Run profile cluster:
 
 1. Follow the steps for installing the Full profile in [Installing the Tanzu Application Platform package and profiles](../install.md). Alternatively, you can use a reduced values file for the Run profile, as shown in [Run profile](./reference/tap-values-run-sample.md).
-2. To use Application Live View, set the `INGRESS-DOMAIN` for `appliveview_connector` to match the value you set on the View profile for the `appliveview` in the values file.
+2. To use Application Live View, set the `INGRESS-DOMAIN` for `appliveview_connector` to match the value you set on the View profile for the `appliveview` in the values file. Note that the default configuration of `shared.ingress_domain` will point to the local Run cluster, rather than the View cluster, so this parameter will need to be set explicitly.
 
 ## <a id='add-view'></a> Add Build and Run clusters to Tanzu Application Platform GUI
 

--- a/multicluster/reference/tap-values-run-sample.md
+++ b/multicluster/reference/tap-values-run-sample.md
@@ -5,10 +5,11 @@ The following is the YAML file sample for the run-profile:
 ```yaml
 profile: run
 ceip_policy_disclosed: FALSE-OR-TRUE-VALUE # Installation fails if this is not set to true. Not a string.
-supply_chain: basic
 
-cnrs:
-  domain_name: INGRESS-DOMAIN
+shared:
+  ingress_domain: INGRESS-DOMAIN
+
+supply_chain: basic
 
 contour:
   envoy:
@@ -18,11 +19,11 @@ contour:
 appliveview_connector:
   backend:
     sslDisabled: TRUE-OR-FALSE-VALUE
-    host: appliveview.APP-LIVE-VIEW-INGRESS-DOMAIN
+    host: appliveview.VIEW-CLUSTER-INGRESS-DOMAIN
 ```
 
 Where:
 
 - `INGRESS-DOMAIN` is the subdomain for the host name that you point at the `tanzu-shared-ingress`
 service's external IP address.
-- `APP-LIVE-VIEW-INGRESS-DOMAIN` is the subdomain you setup on the View profile cluster. This matches the value key `appliveview.ingressDomain`. Include the default host name `appliveview.` ahead of the domain.
+- `VIEW-CLUSTER-INGRESS-DOMAIN` is the subdomain you setup on the View profile cluster. This matches the value key `appliveview.ingressDomain` or `shared.ingress_domain` **on the view cluster**. Include the default host name `appliveview.` ahead of the domain.

--- a/multicluster/reference/tap-values-view-sample.md
+++ b/multicluster/reference/tap-values-view-sample.md
@@ -6,18 +6,16 @@ The following is the YAML file sample for the view-profile:
 profile: view
 ceip_policy_disclosed: FALSE-OR-TRUE-VALUE # Installation fails if this is not set to true. Not a string.
 
+shared:
+  ingress_domain: "INGRESS-DOMAIN"
+
 contour:
   envoy:
     service:
       type: LoadBalancer #NodePort can be used if your Kubernetes cluster doesn't support LoadBalancing
 
-learningcenter:
-  ingressDomain: "DOMAIN-NAME"
-
 tap_gui:
   service_type: ClusterIP
-  ingressEnabled: "true"
-  ingressDomain: "INGRESS-DOMAIN"
   app_config:
     app:
       baseUrl: http://tap-gui.INGRESS-DOMAIN
@@ -43,15 +41,10 @@ tap_gui:
 
 metadata_store:
   app_service_type: LoadBalancer # (optional) Defaults to LoadBalancer. Change to NodePort for distributions that don't support LoadBalancer
-
-appliveview:
-  ingressEnabled: TRUE-OR-FALSE-VALUE
-  ingressDomain: APP-LIVE-VIEW-INGRESS-DOMAIN
 ```
 
 Where:
 
-- `DOMAIN-NAME` has a value such as `learningcenter.example.com`.
 - `INGRESS-DOMAIN` is the subdomain for the host name that you point at the `tanzu-shared-ingress`
 service's external IP address.
 - `GIT-CATALOG-URL` is the path to the `catalog-info.yaml` catalog definition file. You can download either a blank or populated catalog file from the [Tanzu Application Platform product page](https://network.pivotal.io/products/tanzu-application-platform/#/releases/1043418/file_groups/6091). Otherwise, use a Backstage-compliant catalog you've already built and posted on the Git infrastructure in the Integration section.

--- a/prerequisites.md
+++ b/prerequisites.md
@@ -34,12 +34,12 @@ Tanzu Application Platform to store images.
 
 There are some optional but recommended DNS records you must allocate if you decide to use these particular components:
 
-- Cloud Native Runtimes (knative) - Allocate a wildcard subdomain for your developer's applications. This is specified in the `cnrs.domain_name` key of the `tap-values.yaml` configuration file that you input with the installation. This wildcard must be pointed at the external IP address of the `tanzu-system-ingress`'s `envoy` service. See [Ingress Method](tap-gui/accessing-tap-gui.md#ingress-method) for more information about `tanzu-system-ingress`.
+- Cloud Native Runtimes (knative) - Allocate a wildcard subdomain for your developer's applications. This is specified in the `shared.ingress_domain` key of the `tap-values.yaml` configuration file that you input with the installation. This wildcard must be pointed at the external IP address of the `tanzu-system-ingress`'s `envoy` service. See [Ingress Method](tap-gui/accessing-tap-gui.md#ingress-method) for more information about `tanzu-system-ingress`.
 
-- Tanzu Learning Center - Similar to Cloud Native Runtimes, allocate a wildcard subdomain for your workshops and content. This is specified in the `learningcenter.ingressDomain` key of the `tap-values.yaml` configuration file that you input with the installation. This wildcard must be pointed at the external IP address of the `tanzu-system-ingress`'s `envoy` service.
+- Tanzu Learning Center - Similar to Cloud Native Runtimes, allocate a wildcard subdomain for your workshops and content. This also specified by the `shared.ingress_domain` key of the `tap-values.yaml` configuration file that you input with the installation. This wildcard must be pointed at the external IP address of the `tanzu-system-ingress`'s `envoy` service.
 
 - Tanzu Application Platform GUI - If you decide to implement the shared ingress and include Tanzu Application Platform GUI, allocate a fully Qualified Domain Name (FQDN) that can be pointed at the `tanzu-system-ingress` service.
-The default host name consists of `tap-gui` and an `IngressDomain` of your choice. For example,
+The default host name consists of `tap-gui` and the `shared.ingress_domain` value. For example,
 `tap-gui.example.com`.
 
 

--- a/tap-gui/accessing-tap-gui.md.hbs
+++ b/tap-gui/accessing-tap-gui.md.hbs
@@ -62,19 +62,21 @@ running:
 1. Specify parameters in your `tap-values.yaml` related to Ingress following this example:
 
     ```yaml
+    shared:
+      ingress_domain: "example.com"
+
     tap_gui:
       service_type: ClusterIP
-      ingressEnabled: "true"
-      ingressDomain: 'example.com' # This makes the host name tap-gui.example.com
     ```
 
 1. Update your other host names in the `tap_gui` section of your `tap-values.yaml` with the new host name following this example:
 
     ```yaml
+    shared:
+      ingress_domain: "example.com"
+
     tap_gui:
       service_type: ClusterIP
-      ingressEnabled: "true"
-      ingressDomain: 'example.com' # This makes the host name tap-gui.example.com
     # Existing tap-values.yaml above
       app_config:
         app:

--- a/tap-gui/auth.md
+++ b/tap-gui/auth.md
@@ -25,10 +25,11 @@ Configure the OIDC provider with your OAuth App values.
 For example:
 
 ```yaml
+shared:
+  ingress_domain: "INGRESS-DOMAIN"
+
 tap_gui:
   service_type: ClusterIP
-  ingressEnabled: "true"
-  ingressDomain: "INGRESS-DOMAIN"
   app_config:
     app:
       baseUrl: http://tap-gui.INGRESS-DOMAIN


### PR DESCRIPTION
Which other branches should this be merged with (if any)?

TAP 1.2 when available.

This requires TAP 1.2.0-build.4, which should be built tonight.