### PR TITLE
Moved metadata_store.ns_for_export_app_cert from notes into tap-values.

### DIFF
--- a/install.md.hbs
+++ b/install.md.hbs
@@ -230,6 +230,7 @@ tap_gui:
         origin: http://tap-gui.INGRESS-DOMAIN
 
 metadata_store:
+  ns_for_export_app_cert: "MY-DEV-NAMESPACE"
   app_service_type: LoadBalancer # (optional) Defaults to LoadBalancer. Change to NodePort for distributions that don't support LoadBalancer
 
 grype:

--- a/scst-scan/install-scst-scan.md
+++ b/scst-scan/install-scst-scan.md
@@ -19,14 +19,6 @@ Before installing Supply Chain Security Tools - Scan:
 - Install the Tanzu Insight CLI plug-in to query the Supply Chain Security Tools - Store for CVE results.
   See [Install the Tanzu Insight CLI plug-in](../cli-plugins/insight/cli-installation.md).
 
-## Update Supply Chain Security Tools - Store
-
-Developer namespaces (where the scans occur), need to have access to the secrets required to send results to the [Supply Chain Security Tools - Store](../install-components.md#install-scst-store). For this to occur, the [Supply Chain Security Tools - Store](../install-components.md#install-scst-store) needs to allow the secrets to be shared. Ensure the following property is set in the Store configuration and update if it is not:
-```yaml
----
-ns_for_export_app_cert: "*"
-```
-
 ## <a id="scanner-support"></a> Scanner support
 
 | Out-Of-The-Box Scanner | Version |

--- a/scst-scan/install-snyk-integration.md
+++ b/scst-scan/install-snyk-integration.md
@@ -9,14 +9,6 @@ Before installing Supply Chain Security Tools - Scan (Snyk Scanner):
 
 - Install [Supply Chain Security Tools - Scan](../install-components.md#install-scst-scan). It must be present on the same cluster. The prerequisites for Scan will also be required.
 
-## Update Supply Chain Security Tools - Store
-
-Developer namespaces (where the scans occur), need to have access to the secrets required to send results to the [Supply Chain Security Tools - Store](../install-components.md#install-scst-store). For this to occur, the [Supply Chain Security Tools - Store](../install-components.md#install-scst-store) needs to allow the secrets to be shared. Ensure the following property is set in the Store configuration and update if it is not:
-```yaml
----
-ns_for_export_app_cert: "*"
-```
-
 ## Scanner support
 
 | Scanner | Version |


### PR DESCRIPTION
Which other branches should this be merged with (if any)?
For 1.2