### PR TITLE
AppSSO: bump documentation links to 1.0.0 version

### DIFF
--- a/app-sso/about.md
+++ b/app-sso/about.md
@@ -3,9 +3,9 @@
 Application Single Sign-On for VMware Tanzu® (AppSSO) provides APIs for curating and consuming a "Single
 Sign-On as a service" offering on Tanzu Application Platform.
 
-- To provide app teams with Single Sign-On service as a **service operator**, see [AppSSO for Service Operators](https://docs.vmware.com/en/Application-Single-Sign-On-for-VMware-Tanzu/1.0.0-beta/appsso-1.0.0-beta/GUID-service-operators-index.html).
-- To secure your workload with Single Sign-On as an **application operator**, see [AppSSO for App Operators](https://docs.vmware.com/en/Application-Single-Sign-On-for-VMware-Tanzu/1.0.0-beta/appsso-1.0.0-beta/GUID-app-operators-index.html).
-- To install AppSSO manually rather than using the Tanzu Application Platform component as a **platform operator**, see [AppSSO for Platform Operators](https://docs.vmware.com/en/Application-Single-Sign-On-for-VMware-Tanzu/1.0.0-beta/appsso-1.0.0-beta/GUID-platform-operators-index.html).
+- To provide app teams with Single Sign-On service as a **service operator**, see [AppSSO for Service Operators](https://docs.vmware.com/en/Application-Single-Sign-On-for-VMware-Tanzu/1.0/appsso/GUID-service-operators-index.html).
+- To secure your workload with Single Sign-On as an **application operator**, see [AppSSO for App Operators](https://docs.vmware.com/en/Application-Single-Sign-On-for-VMware-Tanzu/1.0/appsso/GUID-app-operators-index.html).
+- To install AppSSO manually rather than using the Tanzu Application Platform component as a **platform operator**, see [AppSSO for Platform Operators](https://docs.vmware.com/en/Application-Single-Sign-On-for-VMware-Tanzu/1.0/appsso/GUID-platform-operators-index.html).
 
 With AppSSO, Service Operators can configure and deploy authorization servers. Application Operators can then
 configure their Workloads with these authorization servers to provide Single Sign-On to their end-users.
@@ -19,8 +19,3 @@ and client restrictions.
 
 AppSSO's authorization server is based off
 of [Spring Authorization Server](https://github.com/spring-projects/spring-authorization-server) in GitHub.
-
-> **Important:** The functionality of beta features is tested, but performance is not. Features enter the beta 
->stage for customers to gain early access to them and give feedback on their design and behavior. Beta features might 
->undergo changes based on that feedback before leaving beta. VMware discourages running beta features in production. 
->VMware does not guarantee that any beta feature can be upgraded in the future.

--- a/install-components.md
+++ b/install-components.md
@@ -15,7 +15,7 @@ For more information, see [Prerequisites](prerequisites.md).
 - [Install API portal](api-portal/install-api-portal.md)
 - [Install Application Accelerator](application-accelerator/install-app-acc.md)
 - [Install Application Live View](app-live-view/install.md)
-- [Install Application Single Sign-On](https://docs.vmware.com/en/Application-Single-Sign-On-for-VMware-Tanzu/1.0.0-beta/appsso-1.0.0-beta/GUID-platform-operators-installation.html)
+- [Install Application Single Sign-On](https://docs.vmware.com/en/Application-Single-Sign-On-for-VMware-Tanzu/1.0/appsso/GUID-platform-operators-installation.html)
 - [Install cert-manager, Contour, and FluxCD](cert-mgr-contour-fcd/install-cert-mgr.md)
 - [Install Cloud Native Runtimes](cloud-native-runtimes/install-cnrt.md)
 - [Install Convention Service](convention-service/install-conv-service.md)
@@ -58,6 +58,7 @@ Use the following procedure to verify that the packages are installed.
     app-accelerator          accelerator.apps.tanzu.vmware.com                  1.0.0            Reconcile succeeded
     app-live-view            appliveview.tanzu.vmware.com                       1.0.2            Reconcile succeeded
     appliveview-conventions  build.appliveview.tanzu.vmware.com                 1.0.2            Reconcile succeeded
+    appsso                   sso.apps.tanzu.vmware.com                          1.0.0            Reconcile succeeded
     cartographer             cartographer.tanzu.vmware.com                      0.1.0            Reconcile succeeded
     cloud-native-runtimes    cnrs.tanzu.vmware.com                              1.0.3            Reconcile succeeded
     convention-controller    controller.conventions.apps.tanzu.vmware.com       0.4.2            Reconcile succeeded
@@ -71,7 +72,6 @@ Use the following procedure to verify that the packages are installed.
     service-bindings         service-bindings.labs.vmware.com                   0.5.0            Reconcile succeeded
     services-toolkit         services-toolkit.tanzu.vmware.com                  0.6.0            Reconcile succeeded
     source-controller        controller.source.apps.tanzu.vmware.com            0.2.0            Reconcile succeeded
-    sso4k8s-install          sso.apps.tanzu.vmware.com                          1.0.0-beta.2-31  Reconcile succeeded
     tap-gui                  tap-gui.tanzu.vmware.com                           0.3.0-rc.4       Reconcile succeeded
     tekton-pipelines         tekton.tanzu.vmware.com                            0.30.0           Reconcile succeeded
     tbs                      buildservice.tanzu.vmware.com                      1.5.0            Reconcile succeeded


### PR DESCRIPTION
**Draft** until:

[ ] AppSSO 1.0 docs are published to docs.vmware.com 