### PR TITLE
Add release notes for TAP GUI 1.1.2

### DIFF
--- a/release-notes.md.hbs
+++ b/release-notes.md.hbs
@@ -32,6 +32,12 @@ This release includes the following changes, listed by component and area.
 - Fixed `SourceScan`s failing for a blob scan without `sourcescan.spec.revision` set and without a `.git` folder in the source code.
 - Fixed the values schema to include an `importFromNamespace` key for the authentication token needed to communicate to the Metadata Store.
 
+#### <a id="1-1-2-gui-resolved"></a>Tanzu Application Platform GUI
+
+- CVE fixes
+- Various styling and bug fixes
+- Update app-config.yaml creation for tap-gui releases
+
 ### <a id='1-1-2-known-issues'></a> Known issues
 
 This release has the following known issues, listed by area and component.


### PR DESCRIPTION
[PSTAR-623]

Which other branches should this be merged with (if any)?
Not sure, it seems release notes for 1.1.2 only go into branch 1-1