### PR TITLE
[VSEE-618] Remove scanning and put metadata store config under grype config

### DIFF
--- a/multicluster/reference/tap-values-build-sample.md
+++ b/multicluster/reference/tap-values-build-sample.md
@@ -18,17 +18,17 @@ ootb_supply_chain_testing_scanning:
     repository: "REPO-NAME"
   gitops:
     ssh_secret: "SSH-SECRET-KEY"
-scanning:
-  metadataStore:
-    url: "METADATA-STORE-URL-ON-VIEW-CLUSTER"
-    caSecret:
-      name: store-ca-cert
-      importFromNamespace: metadata-store-secrets
-    authSecret:
-      name: store-auth-token
 grype:
   namespace: "MY-DEV-NAMESPACE" # (optional) Defaults to default namespace.
   targetImagePullSecret: "TARGET-REGISTRY-CREDENTIALS-SECRET"
+  metadataStore:
+    url: METADATA-STORE-URL-ON-VIEW-CLUSTER
+    caSecret:
+        name: store-ca-cert
+        importFromNamespace: metadata-store-secrets
+    authSecret:
+        name: store-auth-token
+        importFromNamespace: metadata-store-secrets
 ```
 
 Where:


### PR DESCRIPTION
Summary
VSEE-618 -> found an issue in #tap-assist and it was due to these docs not reflecting the 1.2.0-build.10 changes.

Which other branches should this be merged with (if any)?
None