### PR TITLE
remove Default roles checkmark for view profile

### DIFF
--- a/about-package-profiles.md
+++ b/about-package-profiles.md
@@ -294,7 +294,7 @@ The following table lists the packages contained in each profile:
    </td>
    <td>&check;
    </td>
-   <td>&check;
+   <td>
    </td>
   </tr>
   <tr>


### PR DESCRIPTION
this checkmark needs to be removed as a result of this PR being merged to 1.2:
https://gitlab.eng.vmware.com/tap/tap-packages/-/merge_requests/582/diffs