### PR TITLE
add permission for log subresource to sample role

### DIFF
--- a/tap-gui/cluster-view-setup.md
+++ b/tap-gui/cluster-view-setup.md
@@ -46,7 +46,7 @@ To do so:
       name: k8s-reader
     rules:
     - apiGroups: ['']
-      resources: ['pods', 'services', 'configmaps']
+      resources: ['pods', 'pods/log', 'services', 'configmaps']
       verbs: ['get', 'watch', 'list']
     - apiGroups: ['apps']
       resources: ['deployments', 'replicasets']


### PR DESCRIPTION
the k8s-logging backend plugin, which powers the log viewers in RRV and supply-chain plugins, requires this permission

Which other branches should this be merged with (if any)? nope, these log viewers are new in TAP 1.2.0.
