### PR TITLE
Fix: Known issue for TAP installation 

### DIFF
--- a/release-notes.md.hbs
+++ b/release-notes.md.hbs
@@ -182,7 +182,7 @@ This release has the following known issues, listed by area and component.
 
 #### Tanzu Application Platform
 
-- **AWS EKS clusters:** When connecting to AWS EKS clusters an error might appear with the text `Error: Unable to connect: connection refused. Confirm kubeconfig details and try again` or `invalid apiVersion "client.authentication.k8s.io/v1alpha1"`. The cause is [Kubernetes v1.24](https://kubernetes.io/blog/2022/05/03/kubernetes-1-24-release-announcement/) dropping support for `client.authentication.k8s.io/v1alpha1`. For more information, see [aws/aws-cli/issues/6920](https://github.com/aws/aws-cli/issues/6920) in GitHub. To fix, update `aws-cli` to the latest version, update kubectl to v1.24, and then run:
+- **AWS EKS clusters:** When connecting to AWS EKS clusters an error might appear with the text `Error: Unable to connect: connection refused. Confirm kubeconfig details and try again` or `invalid apiVersion "client.authentication.k8s.io/v1alpha1"`. The cause is [Kubernetes v1.24](https://kubernetes.io/blog/2022/05/03/kubernetes-1-24-release-announcement/) dropping support for `client.authentication.k8s.io/v1alpha1`. For more information, see [aws/aws-cli/issues/6920](https://github.com/aws/aws-cli/issues/6920) in GitHub. To fix, update `aws-cli` to the latest version, and then run:
 
     ```console
     aws eks update-kubeconfig --name ${EKS_CLUSTER_NAME} --region ${REGION}


### PR DESCRIPTION
Known issue for TAP installation  on AWS EKS suggested to update to kubectl 1.24 which might not be recommended for all EKS clusters

Which other branches should this be merged with (if any)? None
