### PR TITLE
added known issue for SCC plug-in

### DIFF
--- a/release-notes.md.hbs
+++ b/release-notes.md.hbs
@@ -224,7 +224,8 @@ This release has the following known issues, listed by area and component.
 
 #### Tanzu Application Platform GUI
 
-- Known issue 1
+- Supply Chain Plug-in
+    - Delivery section of the supply chain graph may show deliverables that do not pertain to the currently selected workload. There is currently no workaround.  
 - Known issue 2
 
 #### VSCode Extension


### PR DESCRIPTION
added known issue around possibility of the delivery section showing deliverables that are not relevant to the currently selected workload. 

add to main please

Which other branches should this be merged with (if any)?
