### PR TITLE
Adds troubleshooting link to the latest stk release.

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -16,3 +16,4 @@ For component-level troubleshooting, see these topics:
 * [Troubleshoot Application Live View for VMware Tanzu](app-live-view/troubleshooting.md)
 * [Troubleshoot Cloud Native Runtimes for Tanzu](https://docs.vmware.com/en/Cloud-Native-Runtimes-for-VMware-Tanzu/1.3/tanzu-cloud-native-runtimes/GUID-troubleshooting.html)
 * [Troubleshoot Tanzu Build Service (FAQ)](https://docs.vmware.com/en/Tanzu-Build-Service/1.6/vmware-tanzu-build-service/GUID-faq.html)
+* [Troubleshoot Services Toolkit](https://docs-staging.vmware.com/en/draft/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.7/svc-tlk/GUID-reference-troubleshooting.html)


### PR DESCRIPTION
Our internal docs that we link to are not yet public. See internal doc changes for details.
I've guessed the URL that they will be eventually.

Which other branches should this be merged with (if any)?
