### PR TITLE
[VSEE-613] Update scanpolicy docs (TAP GUI and new scanpolicy ways)

### DIFF
--- a/release-notes.md.hbs
+++ b/release-notes.md.hbs
@@ -132,6 +132,7 @@ This release has the following breaking changes, listed by area and component.
   - The package name has changed from `package policies` to `package main`.
   - The deny rule has changed from the boolean `isCompliant` to the array of strings `deny[msg]`.
   - Please note that the sample `ScanPolicy` is different if you're using Grype Scanner with a cyclonedx structure or Snyk Scanner with a spdx json structure.
+  - See [Enforce compliance policy using Open Policy Agent](./scst-scan/policies.md) for an example.
 
 #### Supply Chain Security Tools - Store
 

--- a/release-notes.md.hbs
+++ b/release-notes.md.hbs
@@ -132,7 +132,7 @@ This release has the following breaking changes, listed by area and component.
   - The package name has changed from `package policies` to `package main`.
   - The deny rule has changed from the boolean `isCompliant` to the array of strings `deny[msg]`.
   - Please note that the sample `ScanPolicy` is different if you're using Grype Scanner with a cyclonedx structure or Snyk Scanner with a spdx json structure.
-  - See [Enforce compliance policy using Open Policy Agent](./scst-scan/policies.md) for an example.
+  - See [Enforce compliance policy using Open Policy Agent](./scst-scan/policies.md) for an example of the current ScanPolicy format (v1.2.0+).
 
 #### Supply Chain Security Tools - Store
 

--- a/scst-scan/policies.md
+++ b/scst-scan/policies.md
@@ -10,11 +10,11 @@ The Scan Controller supports policy enforcement by using an Open Policy Agent (O
 
 To define a Rego file for an image scan or source scan, you must comply with the requirements defined for every Rego file for the policy verification to work properly.
 
-- **Package policies:** The Rego file must define a package in its body called `policies`, because the system looks for this package to verify the scan's results compliance.
+- **Package main:** The Rego file must define a package in its body called `main`, because the system looks for this package to verify the scan's results compliance.
 
 - **Input match:** The Rego file evaluates one vulnerability match at a time, iterating as many times as different vulnerabilities are found in the scan. The match structure can be accessed in the `input.currentVulnerability` object inside the Rego file and has the [CycloneDX](https://cyclonedx.org/docs/1.3/) format.
 
-- **isCompliant rule:** The Rego file must define inside its body an `isCompliant` rule. This must be a Boolean type containing the result whether or not the vulnerability violates the security policy. If `isCompliant` is `true`, the vulnerability is allowed in the Source or Image scan; `false` is considered otherwise. Any scan that finds at least one vulnerability that evaluates to `isCompliant=false` makes the `PolicySucceeded` condition set to false.
+- **deny rule:** The Rego file must define inside its body a `deny` rule. `deny` is a set of error messages that is returned to the user. Each rule you write adds to that set of error messages. If the conditions in the body of the `deny` statement are true then the user is handed an error message. If false the vulnerability is allowed in the Source or Image scan.
 
 ## <a id="define-rego-file"></a>Define a Rego file for policy enforcement
 
@@ -23,7 +23,6 @@ Follow these steps to define a Rego file for policy enforcement that you can reu
 1. Create a scan policy with a Rego file. Here is a sample scan policy resource:
 
     ```console
-    ---
     apiVersion: scanning.apps.tanzu.vmware.com/v1beta1
     kind: ScanPolicy
     metadata:
@@ -59,8 +58,56 @@ Follow these steps to define a Rego file for policy enforcement that you can reu
         }
     ```
 
-1. Deploy the scan policy to the cluster by running:
+2. Deploy the scan policy to the cluster by running:
 
     ```console
     kubectl apply -f <path_to_scan_policy>/<scan_policy_filename>.yaml -n <desired_namespace>
     ```
+
+## <a id="gui-view-scan-policy"></a>Enable TAP GUI to view ScanPolicy Resource
+
+In order for the TAP GUI to view the ScanPolicy resource, it must have a matching `kubernetes-label-selector` with a `part-of` prefix.
+
+Here is an example of a ScanPolicy that is viewable by the TAP GUI:
+```
+apiVersion: scanning.apps.tanzu.vmware.com/v1beta1
+kind: ScanPolicy
+metadata:
+  name: scanpolicy-sample
+  annotations:
+    'backstage.io/kubernetes-label-selector': 'app.kubernetes.io/part-of=component-a'
+spec:
+  regoFile: |
+    ...
+```
+Note: After the `part-of=` in `app.kubernetes.io/part-of=component-a`, it can be anything. The TAP GUI is simply looking for the existence of the `part-of` prefix string and doesn't match for anything else specific.
+
+## <a id="deprecated-rego-file"></a> Deprecated Rego file Definition
+
+Prior to Scan Controller v1.2.0, you must use the following format where the rego file differences are:
+- The package name must be `package policies` instead of `package main`.
+- The deny rule is a boolean `isCompliant` instead of `deny[msg]`.
+  - **isCompliant rule:** The Rego file must define inside its body an `isCompliant` rule. This must be a Boolean type containing the result whether or not the vulnerability violates the security policy. If `isCompliant` is `true`, the vulnerability is allowed in the Source or Image scan; `false` is considered otherwise. Any scan that finds at least one vulnerability that evaluates to `isCompliant=false` makes the `PolicySucceeded` condition set to false.
+- Here is a sample scan policy resource:
+```
+apiVersion: scanning.apps.tanzu.vmware.com/v1alpha1
+kind: ScanPolicy
+metadata:
+  name: v1alpha1-scan-policy
+spec:
+  regoFile: |
+    package policies
+
+    default isCompliant = false
+
+    ignoreSeverities := ["Low","Medium","High","Critical"]
+
+    contains(array, elem) = true {
+      array[_] = elem
+    } else = false { true }
+
+    isCompliant {
+      ignore := contains(ignoreSeverities, input.currentVulnerability.Ratings.Rating[_].Severity)
+      ignore
+    }
+```


### PR DESCRIPTION
Update scanpolicy docs to:
* Distinguish between Scan Controller ScanPolicy v1.2.0+ and before v1.2.0.
* How to get TAP GUI to view ScanPolicy

Which other branches should this be merged with (if any)?
N/A