### PR TITLE
[VSEE-618] Update the metadata store ingress multicluster doc in regards to our scan component

### DIFF
--- a/scst-store/ingress-multicluster.md
+++ b/scst-store/ingress-multicluster.md
@@ -125,17 +125,4 @@ spec:
 EOF
 ```
 
-Install Supply Chain Security Tools - Scan with the following configuration:
-
-```yaml
----
-scanning:
-  metadataStore:
-    url: https://metadata-store.example.com
-    caSecret:
-        name: store-ca-cert
-        importFromNamespace: metadata-store-secrets
-    authSecret:
-        name: store-auth-token
-        importFromNamespace: metadata-store-secrets
-```
+Install Supply Chain Security Tools - Scan with the YAML file sample configuration for the build-profile specified [here](../multicluster/reference/tap-values-build-sample.md)


### PR DESCRIPTION
* For the ingress/multicluster setup docs in metadata store docs, point the reference of our scan component to the "build profile" docs which has the proper yaml configuration for setting up grype with metadata-store.

Which other branches should this be merged with (if any)?
