### PR TITLE
[VSEE-631] Modifying grype airgap docs to use patch secret

### DIFF
--- a/scst-scan/offline-airgap.md
+++ b/scst-scan/offline-airgap.md
@@ -8,69 +8,74 @@ The `grype` URL accepts environment variables to satisfy these needs.
 
 For information about setting up an offline vulnerability database, see the [Anchore Grype README](https://github.com/anchore/grype#offline-and-air-gapped-environments) in Github.
 
-To update the existing ScanTemplates that call the `grype` CLI, you must pause the `kapp` installed `PackageInstall` before editing and then unpause after. Otherwise, Kubernetes overwrites the edits.
+## Overview
 
-1. Pause the top-level `PackageInstall/tap` object by running:
+To enable grype in offline air gap environments:
+1. Create ConfigMap
+2. Create Patch Secret
+3. Configure tap-values.yaml to use `package_overlays` and update tap
 
-    ```bash
-    kubectl edit -n tap-install packageinstall tap
-    ```
+### 1. Create ConfigMap
 
-    Make the following edit:
+* Create a ConfigMap that contains the public ca.crt to the file server hosting the grype database files and apply this ConfigMap to your developer namespace.
 
-    ```yaml
-    apiVersion: packaging.carvel.dev/v1alpha1
-    kind: PackageInstall
-    metadata:
-      name: tap
-      namespace: tap-install
-    spec:
-      paused: true                    # ! set this field to `paused: true`.
-      packageRef:
-        refName: tap.tanzu.vmware.com
-        versionSelection:
-    # ...
-    ```
+### 2. Create Patch Secret
 
-1. Pause the `PackageInstall/grypetemplates` object by running:
+* Create a Secret that contains the ytt overlay to add the grype environment variables to the ScanTemplates.
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grype-airgap-overlay
+  namespace: tap-install #! namespace where tap is installed
+stringData:
+  patch.yaml: |
+    #@ load("@ytt:overlay", "overlay")
 
-    ```bash
-    kubectl edit -n tap-install packageinstall grype-templates
-    ```
-
-1. Set the `packageinstall.spec.paused` field to `true` as done earlier with the `tap` object.
-
-1. There are five installed `ScanTemplates` to edit. Each `ScanTemplates` is edited the same way. For example, edit the `public-image-scan-template` by running:
-
-    ```bash
-    kubectl edit -n MY-DEV-NAMESPACE scantemplate public-image-scan-template
-    ```
-
-    Where `MY-DEV-NAMESPACE` is what was specified in the values file during installation.
-
-    Find the container in `spec.initContainers` named `scan-plugin` and append the required grype specific environment variables:
-
-    ```yaml
+    #@overlay/match by=overlay.subset({"kind":"ScanTemplate","metadata":{"namespace":"<DEV-NAMESPACE>"}}),expects="1+" #! developer namespace you are using
+    ---
     spec:
       template:
-        # ...
         initContainers:
+          #@overlay/match by=overlay.subset({"name": "scan-plugin"}), expects="1+"
           - name: scan-plugin
-            # ...
+            #@overlay/match missing_ok=True
             env:
-              # ...
+              #@overlay/append
               - name: GRYPE_CHECK_FOR_APP_UPDATE
-                value: false
+                value: "false"
               - name: GRYPE_DB_AUTO_UPDATE
-                value: false
+                value: "true"
               - name: GRYPE_DB_UPDATE_URL
-                value: <url of internal vulnerability db>
+                value: <INTERNAL-VULN-DB-URL> #! url points to the internal file server
               - name: GRYPE_DB_CA_CERT
-                value: |
-                  <certificate>
-    # ...
-    ```
+                value: "/etc/ssl/certs/custom-ca.crt"
+            volumeMounts:
+              #@overlay/append
+              - name: ca-cert
+                mountPath: /etc/ssl/certs/custom-ca.crt
+                subPath: <INSERT-KEY-IN-CONFIGMAP> #! key pointing to ca certificate
+        volumes:
+        #@overlay/append
+        - name: ca-cert
+          configMap:
+            name: <CONFIGMAP-NAME> #! name of the configmap created
+```
+NOTE: If you have more than one developer namespace and you want to apply this change to all of them, then change the `overlay match` on top of the patch.yaml to the following:
+```yaml
+#@overlay/match by=overlay.subset({"kind":"ScanTemplate"}),expects="1+"
+```
 
-1. Edit the remaining `ScanTemplates` following the earlier example.
+### 3. Configure tap-values.yaml to use `package_overlays` and update tap
 
-1. Unpause the paused objects by reverting the changes. For example, removing the `packageinstall.spec.paused` fields.
+* Add the following to your tap-values.yaml:
+```yaml
+package_overlays:
+   - name: "grype"
+     secrets:
+        - name: "grype-airgap-overlay"
+```
+* Update tap:
+```console
+tanzu package installed update tap -f tap-values.yaml -n tap-install
+```


### PR DESCRIPTION
Modifying grype airgap docs to use patch secret to pass in grype database environment variables to the ScanTemplates.

Which other branches should this be merged with (if any)?
N/A