### PR TITLE
Add Configure Tanzu Build Service to sign your image builds tutorial

### DIFF
--- a/getting-started/config-supply-chain.md
+++ b/getting-started/config-supply-chain.md
@@ -1,54 +1,50 @@
 # Configure image signing and verification in your supply chain
 
-This how-to guide walks you through configuring your supply chain to sign your image builds.
+This how-to guide walks you through configuring your supply chain to sign and verify your image builds.
 
 ## <a id="you-will"></a>What you will do
 
   - Configure your supply chain to sign your image builds.
   - Configure an admission control policy to verify image signatures before admitting pods to the cluster.
 
-## <a id="config-sc-to-img-builds"></a>Configure your supply chain to sign your image builds
+## <a id="config-sc-to-img-builds"></a>Configure your supply chain to sign and verify your image builds
 
-1. Use cosign to configure Tanzu Build Service to sign your container image builds. For instructions, see [Managing Image Resources and Builds](https://docs.vmware.com/en/Tanzu-Build-Service/1.6/vmware-tanzu-build-service/GUID-managing-images.html).
+1. Use cosign to configure Tanzu Build Service to sign your container image builds. For instructions, see [Configure Tanzu Build Service to sign your image builds](../tanzu-build-service/tbs-image-signing.md).
 
-2. Create a `values.yaml` file, and install the sign supply chain security tools and image policy web-hook. For instructions, see [Install Supply Chain Security Tools - Sign](../scst-sign/install-scst-sign.md).
+2. Create a `values.yaml` file, and install the Supply Chain Security Tools - Policy Controller. For instructions, see [Install Supply Chain Security Tools - Policy Controller](../scst-policy/install-scst-policy.md).
 
-3. Configure a `ClusterImagePolicy` resource to verify image signatures when deploying resources. The resource must be named `image-policy`.
+3. Configure at least one `ClusterImagePolicy` resource to verify image signatures when deploying resources. For instructions, see [Create a `ClusterImagePolicy` resource](../scst-policy/configuring.md#create-cip-resource).
 
     For example:
 
     ```yaml
     ---
-    apiVersion: signing.apps.tanzu.vmware.com/v1beta1
+    apiVersion: policy.sigstore.dev/v1beta1
     kind: ClusterImagePolicy
     metadata:
-       name: image-policy
+      name: example-policy
     spec:
-       verification:
-         exclude:
-           resources
-             namespaces:
-             - kube-system
-             - test-namespace
-             - <TAP system namespaces>
-         keys:
-         - name: first-key
-           publicKey: |
-             -----BEGIN PUBLIC KEY-----
-             <content ...>
-             -----END PUBLIC KEY-----
-         images:
-         - namePattern: registry.example.org/myproject/*
-           keys:
-           - name: first-key
-
+      images:
+      - glob: registry.example.org/myproject/*
+      authorities:
+      - key:
+          data: |
+            -----BEGIN PUBLIC KEY-----
+            <content ...>
+            -----END PUBLIC KEY-----
     ```
 
-> **Note:** System namespaces specific to your cloud provider might need to be excluded from the policy.
+4. Enable the policy controller verification in your namespace by adding the label
+`policy.sigstore.dev/include: "true"` to the namespace resource.
+    For example:
+    ```console
+    kubectl label namespace my-secure-namespace policy.sigstore.dev/include=true
+    ```
 
-To prevent the Image Policy Webhook from blocking components of Tanzu Application Platform, VMware recommends configuring exclusions for Tanzu Application Platform system namespaces listed in [Create a `ClusterImagePolicy` resource](../scst-sign/configuring.md#create-cip-resource).
+> **Note:** Supply Chain Security Tools - Policy Controller only validates resources in namespaces
+that have chosen to opt-in.
 
-When you apply the `ClusterImagePolicy` resource, your cluster requires valid signatures for all images that match the `namePattern:` you define in the configuration. For more information about configuring an image signature policy, see [Configuring Supply Chain Security Tools - Sign](../scst-sign/configuring.md).
+When you apply the `ClusterImagePolicy` resource, your cluster requires valid signatures for all images that match the `spec.images.glob[]` you define in the configuration. For more information about configuring an image policy, see [Configuring Supply Chain Security Tools - Policy](../scst-policy/configuring.md).
 
 ## <a id="config-img-next-steps"></a>Next steps
 
@@ -56,6 +52,6 @@ When you apply the `ClusterImagePolicy` resource, your cluster requires valid si
 
 Or learn more about Supply Chain Security Tools:
 
-- [Overview for Supply Chain Security Tools - Sign](../scst-sign/overview.md)
-- [Configuring Supply Chain Security Tools - Sign](../scst-sign/configuring.md)
-- [Supply Chain Security Tools - Sign known issues](../release-notes.md)
+- [Overview for Supply Chain Security Tools - Policy](../scst-policy/overview.md)
+- [Configuring Supply Chain Security Tools - Policy](../scst-policy/configuring.md)
+- [Supply Chain Security Tools - Policy known issues](../release-notes.md)

--- a/tanzu-build-service/tbs-image-signing.md
+++ b/tanzu-build-service/tbs-image-signing.md
@@ -1,0 +1,146 @@
+# Tanzu Build Service with image signing
+This section will walk through creating a Tanzu Build Service [Image](https://docs.vmware.com/en/Tanzu-Build-Service/1.5/vmware-tanzu-build-service/GUID-managing-images.html) resource to build a container image from source that is signed with [cosign](https://github.com/sigstore/cosign). This article builds upon the steps in the [kpack Tutorial](https://github.com/pivotal/kpack/blob/main/docs/tutorial.md).
+
+###  Prerequisites
+1. Tanzu Build Service is installed and available.
+
+    > Refer to [installing Tanzu Build Service](install-tbs.md) section.
+    The Full, Iterate, and Build profiles include Tanzu Build Service.
+
+2. Cosign
+    > Follow the official docs to [install cosign](https://docs.sigstore.dev/cosign/installation/)
+
+3. A [Builder or ClusterBuilder](https://docs.vmware.com/en/Tanzu-Build-Service/1.5/vmware-tanzu-build-service/GUID-managing-builders.html) and [Image](https://docs.vmware.com/en/Tanzu-Build-Service/1.5/vmware-tanzu-build-service/GUID-managing-images.html) resource configured.
+
+
+### Configure Tanzu Build Service to sign your image builds
+
+1. Generate a cosign key pair
+
+   The `cosign generate-key-pair` command generates a key-pair for you and stores it as a kubernetes secret with name `tutorial-cosign-key-pair` in the `default` namespace.
+
+   ```bash
+   cosign generate-key-pair k8s://default/tutorial-cosign-key-pair
+   ```
+
+   The command will ask you to enter a password for the private key. Enter any password you want. After the command has completed successfully, you should see the following output:
+
+   ```
+   Successfully created secret tutorial-cosign-key-pair in namespace default
+   Public key written to cosign.pub
+   ```
+
+   You should see a `cosign.pub` file in your current folder. Keep this file as it will be needed to verify the signature of the images built in this tutorial.
+
+
+   If you are using [dockerhub](https://hub.docker.com/) or a registry that does not support OCI media types, you need to add the annotation `kpack.io/cosign.docker-media-types: "1"` to the cosign secret. The secret `tutorial-cosign-key-pair` should look something like this:
+
+   ```yaml
+   apiVersion: v1
+   kind: Secret
+   type: Opaque
+   metadata:
+     name: tutorial-cosign-key-pair
+     namespace: default
+     annotations:
+       kpack.io/cosign.docker-media-types: "1"
+   data:
+     cosign.key: <PRIVATE KEY DATA>
+     cosign.password: <COSIGN PASSWORD>
+     cosign.pub: <PUBLIC KEY DATA>
+   ```
+
+    > Note: Learn more about configuring cosign key pairs with the [Tanzu Build Service Image documentation](https://docs.vmware.com/en/Tanzu-Build-Service/1.5/vmware-tanzu-build-service/GUID-managing-images.html#image-signing-with-cosign)
+
+
+2. Create or modify the service account that is referenced in the Image resource so it includes the cosign key pair secret created in the previous step.
+
+   Just by adding a cosign secret to the service account that is referenced in an Image resource enables cosign signing.
+
+   ```yaml
+   apiVersion: v1
+   kind: ServiceAccount
+   metadata:
+     name: tutorial-cosign-service-account
+     namespace: default
+   secrets:
+   - name: registry-credentials
+   - name: tutorial-cosign-key-pair
+   imagePullSecrets:
+   - name: registry-credentials
+   ```
+
+   Apply that service account to the cluster
+
+   ```bash
+   kubectl apply -f cosign-service-account.yaml
+   ```
+
+3. Create an Image resource:
+
+   Note that this Image has a references `tutorial-cosign-service-account`.
+
+   ```yaml
+   apiVersion: kpack.io/v1alpha2
+   kind: Image
+   metadata:
+     name: tutorial-cosign-image
+     namespace: default
+   spec:
+     tag: <IMAGE-REGISTRY>
+     serviceAccountName: tutorial-cosign-service-account
+     builder:
+       name: my-builder
+       kind: Builder
+     source:
+       git:
+         url: https://github.com/spring-projects/spring-petclinic
+         revision: 82cb521d636b282340378d80a6307a08e3d4a4c4
+   ```
+
+   - Replace `<IMAGE-REGISTRY>` with a writable repository in your registry. The secret `registry-credentials` referenced in the ServiceAccount is a secret providing credentials for the registry where application container images are pushed to.
+      * Harbor has the form `"my-harbor.io/my-project/my-repo"`
+      * Dockerhub has the form `"my-dockerhub-user/my-repo"` or `"index.docker.io/my-user/my-repo"`
+      * Google Cloud Registry has the form `"gcr.io/my-project/my-repo"`
+
+   - If you are using Out of the Box Supply Chains, you will [need to modify the respective](../scc/authoring-supply-chains.md) `ClusterImageTemplate` to enable signing in your supply chain.
+   Referencing the service account using the `service_account` value when installing the
+   Out of the Box Supply Chain is not recommended because that would give your run cluster access
+   to the private signing key.
+
+   Apply that Image resource to the cluster
+
+   ```bash
+   kubectl apply -f image-cosign.yaml
+   ```
+
+   Once the Image resource finishes building you can get the fully resolved built OCI image with `kubectl get`
+
+   ```
+   kubectl -n default get image tutorial-cosign-image
+   ```
+
+   The output should look something like this:
+   ```
+   NAME                  LATESTIMAGE                                        READY
+   tutorial-cosign-image index.docker.io/your-project/app@sha256:6744b...   True
+   ```
+
+4. Verify image signature
+
+   The image that was built in the previous step should have been signed. Here we use the `cosign.pub` public key file that was generated in the first step.
+   ```bash
+   cosign verify --key cosign.pub <latest-image-with-digest>
+   ```
+
+   You should see an output similar to this:
+   ```
+   Verification for <latest-image-with-digest> --
+   The following checks were performed on each of these signatures:
+    - The cosign claims were validated
+    - The signatures were verified against the specified public key
+    - Any certificates were verified against the Fulcio roots.
+   ```
+
+5. Now you can configure [Supply Chain Security Tools for VMware Tanzu - Policy Controller](../scst-policy/overview.md) to
+ensure that only signed images are allowed in your cluster.

--- a/tanzu-build-service/tbs-image-signing.md
+++ b/tanzu-build-service/tbs-image-signing.md
@@ -17,7 +17,7 @@ This section will walk through creating a Tanzu Build Service [Image](https://do
 
 1. Generate a cosign key pair
 
-   The `cosign generate-key-pair` command generates a key-pair for you and stores it as a kubernetes secret with name `tutorial-cosign-key-pair` in the `default` namespace.
+   The `cosign generate-key-pair k8s://<secret-name>` command generates a key-pair for you and stores it as a kubernetes secret with name `tutorial-cosign-key-pair` in the `default` namespace.
 
    ```bash
    cosign generate-key-pair k8s://default/tutorial-cosign-key-pair

--- a/tanzu-build-service/tbs-image-signing.md
+++ b/tanzu-build-service/tbs-image-signing.md
@@ -17,7 +17,7 @@ This section will walk through creating a Tanzu Build Service [Image](https://do
 
 1. Generate a cosign key pair
 
-   The `cosign generate-key-pair k8s://<secret-name>` command generates a key-pair for you and stores it as a kubernetes secret with name `tutorial-cosign-key-pair` in the `default` namespace.
+   The `cosign generate-key-pair k8s://<secret-name>` command generates a key-pair for you and stores it as a kubernetes secret with name `tutorial-cosign-key-pair` in the `default` namespace. This command requires a Kubernetes context where the operator is already authenticated and is authorized to create and edit the secret and service account resources.
 
    ```bash
    cosign generate-key-pair k8s://default/tutorial-cosign-key-pair

--- a/tanzu-build-service/tbs-image-signing.md
+++ b/tanzu-build-service/tbs-image-signing.md
@@ -78,7 +78,7 @@ This section will walk through creating a Tanzu Build Service [Image](https://do
 
 3. Create an Image resource:
 
-   Note that this Image has a references `tutorial-cosign-service-account`.
+   Note that this Image has references `tutorial-cosign-service-account`.
 
    ```yaml
    apiVersion: kpack.io/v1alpha2


### PR DESCRIPTION
Which other branches should this be merged with (if any)?
These articles are targeted for TAP 1.2.0.