### PR TITLE
Add notes about an unexpected behavior of tbs while upgrading from TA…

### DIFF
--- a/install.md.hbs
+++ b/install.md.hbs
@@ -263,6 +263,10 @@ If built images are pushed to the same registry as the Tanzu Application Platfor
 this can reuse the `tap-registry` secret created in
 [Add the Tanzu Application Platform package repository](#add-tap-package-repo).
 
+>**Note:** When upgrading TAP from 1.1 to 1.2, Tanzu Build Service Image resources will automatically run a build that will fail due to a missing dependency.
+>This error will not persist and any subsequent builds will resolve this error. This means that users can safely wait for the next build of their workloads which
+>will be triggered by new source code changes. For more info see [here](release-notes.html#tbs-breaking-upgrading).
+
 ### <a id='full-dependencies'></a> Configure Tanzu Application Platform with full dependencies
 
 By default, when you install a profile that includes Tanzu Build Service,

--- a/release-notes.md.hbs
+++ b/release-notes.md.hbs
@@ -173,6 +173,30 @@ This release has the following breaking changes, listed by area and component.
 - Breaking change 1
 - Breaking change 2
 
+#### <a id="tbs-breaking"></a> Tanzu Build Service
+
+##### <a id="tbs-breaking-upgrading"></a> Breaking Change when Upgrading TAP 1.1 to TAP 1.2
+
+**Note:** If your TAP 1.1 installation was configured with `enable_automatic_updates: false`, this breaking change can be ignored.
+
+When upgrading TAP from 1.1 to 1.2, Tanzu Build Service Image resources will automatically run a build that will fail due to a missing dependency.
+This error will not persist and any subsequent builds will resolve this error. This means that users can safely wait for the next build of their workloads which
+will be triggered by source code changes.
+
+If you do not want to wait for subsequent builds to run, you can use the open source [kp](https://github.com/vmware-tanzu/kpack-cli) cli:
+
+1. List the image resources in the developer namespace:
+
+```console
+kp image list -n DEVELOPER-NAMESPACE
+```
+
+1. Manually trigger the image resources to re-run builds for each failing image:
+
+```console
+kp image trigger IMAGE-NAME -n DEVELOPER-NAMESPACE
+```
+
 #### <a id="grype-scanner-changes"></a> Grype Scanner
 
 - Information to integrate with the Supply Chain Security Tools - Store should be provided in the `tap-values.yaml` file for the Grype Scanner `v1.2+`


### PR DESCRIPTION
- When upgrading all TBS image resources will be in a failed state but the will fix themselves on the
  next build.

Which other branches should this be merged with (if any)?

This is only relevant for TAP 1.2

Jira: https://jira.eng.vmware.com/browse/TANZUSC-1467