### PR TITLE
[VSEE-649] Update VSE troubleshooting scanning docs

### DIFF
--- a/scst-scan/observing.md
+++ b/scst-scan/observing.md
@@ -1,79 +1,92 @@
 # Observability and Troubleshooting
 
-This section outlines observability and troubleshooting methods for using the Supply Chain Security Tools - Scan components.
-
-#This section shows how to observe the scan job and get logs.
+This section outlines observability and troubleshooting methods and issues for using the Supply Chain Security Tools - Scan components.
 
 ## <a id="observability"></a>Observability
 
 The scans will run inside a k8s Job where the Job creates a Pod. Both the Job and Pod will be cleaned up automatically after completion.
 
-You can set a watch on the Job and Pod to observe progression before applying a new scan to observe the Job deployment:
+Before applying a new scan, you can set a watch on the Jobs, Pods, SourceScans, Imagescans to observe their progression:
 ```console
 watch kubectl get scantemplates,scanpolicies,sourcescans,imagescans,pods,jobs
 ```
 
-Run the following to e
-
 ## <a id="troubleshooting"></a>Troubleshooting
 
-### Debugging
+### <a id="debugging-commands"></a>Debugging commands
 
-#### Inspecting Scan Jobs
+Run the following commands to get more logs and details on the errors around scanning. The Jobs and Pods will only persist for a predefined amount of seconds before getting deleted. (`deleteScanJobsSecondsAfterFinished` is the tap pkg variable that defines this)
 
-When the scan pods are in a failing state:
+####  <a id="debugging-scan-pods"></a> Debugging Scan Pods
+Run the following to get error logs from a pod when scan pods are in a failing state:
 ```console
 kubectl logs <scan-pod-name> -n <DEV-NAMESPACE>
 ```
+See [here](https://jamesdefabia.github.io/docs/user-guide/kubectl/kubectl_logs/) for more details on debugging k8s pods.
 
-To inspect the init containers:
+The following is an example of a successful scan run output:
+```yaml
+scan:
+  cveCount:
+    critical: 20
+    high: 120
+    medium: 114
+    low: 9
+    unknown: 0
+  scanner:
+    name: Grype
+    vendor: Anchore
+    version: v0.37.0
+  reports:
+  - /workspace/scan.xml
+eval:
+  violations:
+  - CVE node-fetch GHSA-w7rc-rwvf-8q5r Low
+store:
+  locations:
+  - https://metadata-store-app.metadata-store.svc.cluster.local:8443/api/sources?repo=hound&sha=5805c6502976c10f5529e7f7aeb0af0c370c0354&org=houndci
+```
+A scan run that had an error would mean one of the init containers: scan-plugin, metadata-store-plugin, compliance-plugin, summary, or any other additional containers had a failure.
+
+To inspect for a specific init container in a pod:
 ```console
 kubectl logs <scan-pod-name> -n <DEV-NAMESPACE> -c <init-container-name>
 ```
 See [here](https://kubernetes.io/docs/tasks/debug/debug-application/debug-init-containers/) for debug init container tips.
 
-To retrieve status conditions of an SourceScan or ImageScan run the following:
+####  <a id="debug-source-image-scan"></a> Debugging SourceScan and ImageScan
+
+To retrieve status conditions of an SourceScan and ImageScan run the following:
 ```console
 kubectl describe sourcescan <sourcescan> -n <DEV-NAMESPACE>
 ```
-
 ```console
 kubectl describe imagescan <imagescan> -n <DEV-NAMESPACE>
 ```
 
+Under `Status.Conditions`, for a condition look at the "Reason", "Type", "Message" values that use the keyword "Error" to investigate issues.
+
+#### <a id="debug-scanning-in-supplychain"></a> Debugging Scanning within a SupplyChain
+
+See [here](../cli-plugins/apps/debug-workload.md) for tanzu workload commands for tailing build and runtime logs and getting workload status and details.
+
+
+#### <a id="view-scan-controller-manager-logs"></a> Viewing the Scan-Controller manager logs
 To retrieve scan-controller manager logs:
 ```console
 kubectl -n scan-link-system logs -f deployment/scan-link-controller-manager -c manager
 ```
 
-#### Debugging within a SupplyChain
-
-#### Restarting Deployment
+### <a id="restarting-deployment"></a> Restarting Deployment
 
 If you encounter an issue with the scan-link controller not being able to start, run the following to restart the deployment to see if it's reproducible or flaking upon starting:
 ```console
-kubectl rollout restart deployment scan-link-controller-manager  -n scan-link-system
+kubectl rollout restart deployment scan-link-controller-manager -n scan-link-system
 ```
 
---------------
+### <a id="troubleshooting-issues"></a> Troubleshooting issues
 
-## <a id="watch-inflight-jobs"></a>Watching in-flight jobs
-The scan will run inside the job, which creates a Pod. Both the job and Pod will be cleaned up automatically after completion. You can set a watch on the job and Pod before applying a new scan to observe the job deployment.
-
-```console
-watch kubectl get scantemplates,scanpolicies,sourcescans,imagescans,pods,jobs
-```
-
-## <a id="troubleshooting"></a>Troubleshooting
-If you run into any problems or face non-expected behavior, you can always address the logs to get more feedback.
-
-```console
-kubectl -n scan-link-system logs -f deployment/scan-link-controller-manager -c manager
-```
-
-
-
-### <a id="miss-img-ps"></a>Missing target image pull secret
+#### <a id="miss-img-ps"></a> Missing target image pull secret
 
 Scanning an image from a private registry requires an image pull secret to exist in the Scan CR's namespace and be referenced as `grype.targetImagePullSecret` in `tap-values.yaml`. See [Installing the Tanzu Application Platform Package and Profiles](../install.md) for more information.
 
@@ -83,8 +96,7 @@ If a private image scan is triggered and the secret is not configured, the scan 
 Job.batch "scan-${app}-${id}" is invalid: [spec.template.spec.volumes[2].secret.secretName: Required value, spec.template.spec.containers[0].volumeMounts[2].name: Not found: "registry-cred"]
 ```
 
-
-### <a id="disable-scst-store"></a> Disable Supply Chain Security Tools - Store
+#### <a id="disable-scst-store"></a> Disable Supply Chain Security Tools - Store
 
 Supply Chain Security Tools - Store is a prerequisite for installing Supply Chain Security Tools - Scan.
 If you choose to install without the Supply Chain Security Tools - Store,  you need to edit the
@@ -106,7 +118,7 @@ configurations to disable the Store:
     --values-file tap-values.yaml
   ```
 
-### <a id="incompatible-syft-schema-version"></a> Resolving Incompatible Syft Schema Version
+#### <a id="incompatible-syft-schema-version"></a> Resolving Incompatible Syft Schema Version
 
   You might encounter the following error:
 

--- a/scst-scan/observing.md
+++ b/scst-scan/observing.md
@@ -1,6 +1,61 @@
-# Observing and troubleshooting
+# Observability and Troubleshooting
 
-This section shows how to observe the scan job and get logs.
+This section outlines observability and troubleshooting methods for using the Supply Chain Security Tools - Scan components.
+
+#This section shows how to observe the scan job and get logs.
+
+## <a id="observability"></a>Observability
+
+The scans will run inside a k8s Job where the Job creates a Pod. Both the Job and Pod will be cleaned up automatically after completion.
+
+You can set a watch on the Job and Pod to observe progression before applying a new scan to observe the Job deployment:
+```console
+watch kubectl get scantemplates,scanpolicies,sourcescans,imagescans,pods,jobs
+```
+
+Run the following to e
+
+## <a id="troubleshooting"></a>Troubleshooting
+
+### Debugging
+
+#### Inspecting Scan Jobs
+
+When the scan pods are in a failing state:
+```console
+kubectl logs <scan-pod-name> -n <DEV-NAMESPACE>
+```
+
+To inspect the init containers:
+```console
+kubectl logs <scan-pod-name> -n <DEV-NAMESPACE> -c <init-container-name>
+```
+See [here](https://kubernetes.io/docs/tasks/debug/debug-application/debug-init-containers/) for debug init container tips.
+
+To retrieve status conditions of an SourceScan or ImageScan run the following:
+```console
+kubectl describe sourcescan <sourcescan> -n <DEV-NAMESPACE>
+```
+
+```console
+kubectl describe imagescan <imagescan> -n <DEV-NAMESPACE>
+```
+
+To retrieve scan-controller manager logs:
+```console
+kubectl -n scan-link-system logs -f deployment/scan-link-controller-manager -c manager
+```
+
+#### Debugging within a SupplyChain
+
+#### Restarting Deployment
+
+If you encounter an issue with the scan-link controller not being able to start, run the following to restart the deployment to see if it's reproducible or flaking upon starting:
+```console
+kubectl rollout restart deployment scan-link-controller-manager  -n scan-link-system
+```
+
+--------------
 
 ## <a id="watch-inflight-jobs"></a>Watching in-flight jobs
 The scan will run inside the job, which creates a Pod. Both the job and Pod will be cleaned up automatically after completion. You can set a watch on the job and Pod before applying a new scan to observe the job deployment.
@@ -15,6 +70,8 @@ If you run into any problems or face non-expected behavior, you can always addre
 ```console
 kubectl -n scan-link-system logs -f deployment/scan-link-controller-manager -c manager
 ```
+
+
 
 ### <a id="miss-img-ps"></a>Missing target image pull secret
 

--- a/troubleshooting-tap/troubleshoot-components.md
+++ b/troubleshooting-tap/troubleshoot-components.md
@@ -7,7 +7,7 @@ For component-level troubleshooting, see these topics:
 - [Troubleshoot Service Bindings](service-bindings/troubleshooting.md)
 - [Troubleshoot Source Controller](source-controller/troubleshooting.md)
 - [Troubleshoot Spring Boot Conventions](spring-boot-conventions/troubleshooting.md)
-- [Troubleshoot Supply Chain Security Tools - Scan](scst-scan/observing.md)
+- [Troubleshoot Supply Chain Security Tools - Scan](../scst-scan/observing.md)
 - [Troubleshoot Supply Chain Security Tools - Store](scst-store/troubleshooting.md)
 - [Troubleshoot Application Live View for VMware Tanzu](app-live-view/troubleshooting.md)
 - [Troubleshoot Cloud Native Runtimes for Tanzu](https://docs.vmware.com/en/Cloud-Native-Runtimes-for-VMware-Tanzu/1.3/tanzu-cloud-native-runtimes/GUID-troubleshooting.html)


### PR DESCRIPTION
Update the VSE troubleshooting scanning docs with:
* get logs from scan-pod 
* kubectl-describe sourcescan or imagescan
* tanzu workload command to get all logs from containers

Which other branches should this be merged with (if any)?
N/A