### PR TITLE
[VSEE-610] Add scanning config to disable embedded metadata store

### DIFF
--- a/multicluster/reference/tap-values-build-sample.md
+++ b/multicluster/reference/tap-values-build-sample.md
@@ -27,6 +27,9 @@ grype:
     authSecret:
         name: store-auth-token
         importFromNamespace: metadata-store-secrets
+scanning:
+  metadataStore:
+    url: "" # Disable embedded integration since it's deprecated
 ```
 
 Where:
@@ -66,3 +69,5 @@ you can reuse the `tap-registry` Secret created in
 > You can update dependencies by [upgrading Tanzu Application Platform](../../upgrading.md)
 > to the latest patch, or
 > by using an [automatic update process (deprecated)](../../tanzu-build-service/install-tbs.md#auto-updates-config).
+
+> **Note:** The `scanning.metadatastore.url` must be set to an empty string if you're installing Grype Scanner v1.2.0 or later or Snyk Scanner to disable the embedded Supply Chain Security Tools - Store integration.

--- a/scst-scan/install-scst-scan.md
+++ b/scst-scan/install-scst-scan.md
@@ -49,14 +49,17 @@ To install Supply Chain Security Tools - Scan (Scan controller):
     ```
 
 1. (Optional) Make changes to the default installation settings:
-   
-    If you're using the Grype Scanner `v1.2.0` or later, or the Snyk Scanner, then you need to disable the embedded Supply Chain Security Tools - Store integration with a `scan-values.yaml` file like this: 
+
+    If you're using the Grype Scanner `≥v1.2.0`, or the Snyk Scanner, the following scanning configuration can disable the embedded Supply Chain Security Tools - Store integration with a `scan-values.yaml` file like this:
 
     ```yaml
     ---
     metadataStore:
       url: ""
     ```
+
+    If you're using the Grype Scanner `<1.2.0`, the scanning configuration needs to configure the store parameters. See the [v1.1 docs](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.1/tap/GUID-scst-scan-install-scst-scan.html) for reference.
+
 
     You can retrieve any other configurable setting using the following command, and appending the key-value pair to the previous `scan-values.yaml` file:
 
@@ -66,7 +69,7 @@ To install Supply Chain Security Tools - Scan (Scan controller):
 
     Where `VERSION` is your package version number. For example, `1.1.0`.
 
-1. Install the package by running:
+2. Install the package by running:
 
     ```console
     tanzu package install scan-controller \

--- a/scst-scan/upgrading.md
+++ b/scst-scan/upgrading.md
@@ -100,6 +100,8 @@ If you're upgrading from a previous version of Supply Chain Security Tools - Sca
 
   For more insights on how to install Grype, please check out [Install Supply Chain Security Tools - Scan (Grype Scanner)](install-scst-scan.md#install-grype).
 
+  Note: If a mix of Grype templates (`<v1.2.0` and `≥v1.2.0`) are used, both `scanning` and `grype` need to configure the parameters, and the secret needs to export to both scan-link-system and the dev namespace (either by exporting to "*" or by defining multiple secrets and exports. (similarly if grype is installed to multiple namespaces there must be corresponding exports). See [Install Supply Chain Security Tools - Scan (Grype Scanner)](install-scst-scan.md#install-grype)
+
   Now update Tanzu Application Platform to apply the changes:
 
   ```console


### PR DESCRIPTION
* Follow-up from https://jira.eng.vmware.com/browse/TANZUSC-1404, in the build profile yaml starting from 1.2.0, we need to add:
```
scanning:
  metadataStore:
    url: "" # Disable embedded integration since it's deprecated
```
This will disable configuring metadata store thru scanning component.

* Show the scanning configuration of metadata store before v1.2.0 and v1.2.0 and after.

Which other branches should this be merged with (if any)?
1.2 and main