### PR TITLE
Fixing missing command and snippets display

### DIFF
--- a/scst-scan/install-snyk-integration.md
+++ b/scst-scan/install-snyk-integration.md
@@ -303,13 +303,13 @@ To opt-out of Snyk for a specific Supply Chain, reconfigure the supply chain to 
 
 -  Edit the `ootb_supply_chain_testing_scanning.scanning.image.template` value to use a scan template that does not use Snyk, such as Grype.
 
-  ```yaml
-  ootb_supply_chain_testing_scanning:
-    scanning:
-      image:
-        template: "ALTERNATIVE-SCAN-TEMPLATE"
-        policy: scan-policy
-  ```
+    ```yaml
+    ootb_supply_chain_testing_scanning:
+      scanning:
+        image:
+          template: "ALTERNATIVE-SCAN-TEMPLATE"
+          policy: scan-policy
+    ```
 
 ### <a id="opt-out-of-snyk-entirely"></a> Opt-out of Snyk Entirely
 


### PR DESCRIPTION
Fixing a command that wasn't being shown in scst-scan/upgrading.md
Fixing yaml snippets indentation to be displayed properly in the webpage. 

Which other branches should this be merged with (if any)?
This is meant for 1.2.0