### PR TITLE
docs: Updating sub-path info to match the correct way of the flag

### DIFF
--- a/release-notes.md.hbs
+++ b/release-notes.md.hbs
@@ -44,7 +44,7 @@ This release includes the following changes, listed by component and area.
 
 #### <a id="apps-plugin"></a> Tanzu CLI - Apps plug-in
 
-- Added support for [`--subPath`](cli-plugins/apps/command-reference/commands-details/workload_create_update_apply.md#a-idapply-subpatha---sub-path) flag where users can specify a relative path inside the repository or image to treat as application root for source.
+- Added support for [`--sub-path`](cli-plugins/apps/command-reference/commands-details/workload_create_update_apply.md#a-idapply-subpatha---sub-path) flag where users can specify a relative path inside the repository or image to treat as application root for source.
 - Added [`--service-account`](cli-plugins/apps/command-reference/commands-details/workload_create_update_apply.md#a-idapply-service-accounta---service-account) flag to specify ServiceAccount name used by the workload to create resources submitted by the supply chain.
 - Added shorthand `-s` for [`--source-image`](cli-plugins/apps/command-reference/commands-details/workload_create_update_apply.md#a-idapply-source-imagea---source-image--s) flag.
 - Added support for [`--output`](cli-plugins/apps/command-reference/commands-details/workload_list.md#a-idlist-outputa---output--o) flag to `workloads list` command.


### PR DESCRIPTION
There was an error in the release notes for subpath (--sub-path) flag in apps plugin. This PR is meant to correct it. 
