### PR TITLE
VSEE-669 | Updating scan policy to fix typo and make it more accurate.

### DIFF
--- a/getting-started/add-test-and-security.md.hbs
+++ b/getting-started/add-test-and-security.md.hbs
@@ -216,19 +216,25 @@ Verify that both Scan Link and Grype Scanner are installed by running:
         } else = false { true }
 
         isSafe(match) {
-          fails := contains(notAllowedSeverities, match.ratings.rating[_])
+          severities := { e | e := match.ratings.rating.severity } | { e | e := match.ratings.rating[_].severity }
+          some i
+          fails := contains(notAllowedSeverities, severities[i])
           not fails
         }
 
         isSafe(match) {
-          ignore := contains(ignoreCves, match.Id)
+          ignore := contains(ignoreCves, match.id)
           ignore
         }
 
         deny[msg] {
-          comp := input.bom.components.component[_]
-          vuln := comp.vulnerabilities.vulnerability[_]
-          ratings := vuln.ratings.rating[_]
+          comps := { e | e := input.bom.components.component } | { e | e := input.bom.components.component[_] }
+          some i
+          comp := comps[i]
+          vulns := { e | e := comp.vulnerabilities.vulnerability } | { e | e := comp.vulnerabilities.vulnerability[_] }
+          some j
+          vuln := vulns[j]
+          ratings := { e | e := vuln.ratings.rating.severity } | { e | e := vuln.ratings.rating[_].severity }
           not isSafe(vuln)
           msg = sprintf("CVE %s %s %s", [comp.name, vuln.id, ratings])
         }

--- a/scc/ootb-supply-chain-testing-scanning.md
+++ b/scc/ootb-supply-chain-testing-scanning.md
@@ -144,19 +144,25 @@ spec:
     } else = false { true }
 
     isSafe(match) {
-      fails := contains(notAllowedSeverities, match.ratings.rating[_])
+      severities := { e | e := match.ratings.rating.severity } | { e | e := match.ratings.rating[_].severity }
+      some i
+      fails := contains(notAllowedSeverities, severities[i])
       not fails
     }
 
     isSafe(match) {
-      ignore := contains(ignoreCves, match.Id)
+      ignore := contains(ignoreCves, match.id)
       ignore
     }
 
     deny[msg] {
-      comp := input.bom.components.component[_]
-      vuln := comp.vulnerabilities.vulnerability[_]
-      ratings := vuln.ratings.rating[_]
+      comps := { e | e := input.bom.components.component } | { e | e := input.bom.components.component[_] }
+      some i
+      comp := comps[i]
+      vulns := { e | e := comp.vulnerabilities.vulnerability } | { e | e := comp.vulnerabilities.vulnerability[_] }
+      some j
+      vuln := vulns[j]
+      ratings := { e | e := vuln.ratings.rating.severity } | { e | e := vuln.ratings.rating[_].severity }
       not isSafe(vuln)
       msg = sprintf("CVE %s %s %s", [comp.name, vuln.id, ratings])
     }

--- a/scst-scan/policies.md
+++ b/scst-scan/policies.md
@@ -82,13 +82,13 @@ apiVersion: scanning.apps.tanzu.vmware.com/v1beta1
 kind: ScanPolicy
 metadata:
   name: scanpolicy-sample
-  annotations:
+  labels:
     'app.kubernetes.io/part-of': 'component-a'
 spec:
   regoFile: |
     ...
 ```
->**Note:** The value for the annotation can be anything. The Tanzu Application Platform GUI is looking for the existence of the `part-of` prefix string and doesn't match for anything else specific.
+>**Note:** The value for the label can be anything. The Tanzu Application Platform GUI is looking for the existence of the `part-of` prefix string and doesn't match for anything else specific.
 
 ## <a id="deprecated-rego-file"></a> Deprecated Rego file Definition
 

--- a/scst-scan/policies.md
+++ b/scst-scan/policies.md
@@ -42,19 +42,25 @@ Follow these steps to define a Rego file for policy enforcement that you can reu
         } else = false { true }
 
         isSafe(match) {
-          fails := contains(notAllowedSeverities, match.ratings.rating[_])
+          severities := { e | e := match.ratings.rating.severity } | { e | e := match.ratings.rating[_].severity }
+          some i
+          fails := contains(notAllowedSeverities, severities[i])
           not fails
         }
 
         isSafe(match) {
-          ignore := contains(ignoreCves, match.Id)
+          ignore := contains(ignoreCves, match.id)
           ignore
         }
 
         deny[msg] {
-          comp := input.bom.components.component[_]
-          vuln := comp.vulnerabilities.vulnerability[_]
-          ratings := vuln.ratings.rating[_]
+          comps := { e | e := input.bom.components.component } | { e | e := input.bom.components.component[_] }
+          some i
+          comp := comps[i]
+          vulns := { e | e := comp.vulnerabilities.vulnerability } | { e | e := comp.vulnerabilities.vulnerability[_] }
+          some j
+          vuln := vulns[j]
+          ratings := { e | e := vuln.ratings.rating.severity } | { e | e := vuln.ratings.rating[_].severity }
           not isSafe(vuln)
           msg = sprintf("CVE %s %s %s", [comp.name, vuln.id, ratings])
         }

--- a/scst-scan/policies.md
+++ b/scst-scan/policies.md
@@ -83,12 +83,12 @@ kind: ScanPolicy
 metadata:
   name: scanpolicy-sample
   annotations:
-    'backstage.io/kubernetes-label-selector': 'app.kubernetes.io/part-of=component-a'
+    'app.kubernetes.io/part-of': 'component-a'
 spec:
   regoFile: |
     ...
 ```
->**Note:** After the `part-of=` in `app.kubernetes.io/part-of=component-a`, it can be anything. The Tanzu Application Platform GUI is looking for the existence of the `part-of` prefix string and doesn't match for anything else specific.
+>**Note:** The value for the annotation can be anything. The Tanzu Application Platform GUI is looking for the existence of the `part-of` prefix string and doesn't match for anything else specific.
 
 ## <a id="deprecated-rego-file"></a> Deprecated Rego file Definition
 

--- a/scst-scan/samples/public-image-compliance.md
+++ b/scst-scan/samples/public-image-compliance.md
@@ -37,19 +37,25 @@ spec:
     } else = false { true }
 
     isSafe(match) {
-      fails := contains(notAllowedSeverities, match.ratings.rating[_])
+      severities := { e | e := match.ratings.rating.severity } | { e | e := match.ratings.rating[_].severity }
+      some i
+      fails := contains(notAllowedSeverities, severities[i])
       not fails
     }
 
     isSafe(match) {
-      ignore := contains(ignoreCves, match.Id)
+      ignore := contains(ignoreCves, match.id)
       ignore
     }
 
     deny[msg] {
-      comp := input.bom.components.component[_]
-      vuln := comp.vulnerabilities.vulnerability[_]
-      ratings := vuln.ratings.rating[_]
+      comps := { e | e := input.bom.components.component } | { e | e := input.bom.components.component[_] }
+      some i
+      comp := comps[i]
+      vulns := { e | e := comp.vulnerabilities.vulnerability } | { e | e := comp.vulnerabilities.vulnerability[_] }
+      some j
+      vuln := vulns[j]
+      ratings := { e | e := vuln.ratings.rating.severity } | { e | e := vuln.ratings.rating[_].severity }
       not isSafe(vuln)
       msg = sprintf("CVE %s %s %s", [comp.name, vuln.id, ratings])
     }

--- a/scst-scan/samples/public-source-compliance.md
+++ b/scst-scan/samples/public-source-compliance.md
@@ -43,19 +43,25 @@ SourceScan:
         } else = false { true }
 
         isSafe(match) {
-          fails := contains(notAllowedSeverities, match.ratings.rating[_])
+          severities := { e | e := match.ratings.rating.severity } | { e | e := match.ratings.rating[_].severity }
+          some i
+          fails := contains(notAllowedSeverities, severities[i])
           not fails
         }
 
         isSafe(match) {
-          ignore := contains(ignoreCves, match.Id)
+          ignore := contains(ignoreCves, match.id)
           ignore
         }
 
         deny[msg] {
-          comp := input.bom.components.component[_]
-          vuln := comp.vulnerabilities.vulnerability[_]
-          ratings := vuln.ratings.rating[_]
+          comps := { e | e := input.bom.components.component } | { e | e := input.bom.components.component[_] }
+          some i
+          comp := comps[i]
+          vulns := { e | e := comp.vulnerabilities.vulnerability } | { e | e := comp.vulnerabilities.vulnerability[_] }
+          some j
+          vuln := vulns[j]
+          ratings := { e | e := vuln.ratings.rating.severity } | { e | e := vuln.ratings.rating[_].severity }
           not isSafe(vuln)
           msg = sprintf("CVE %s %s %s", [comp.name, vuln.id, ratings])
         }

--- a/scst-scan/upgrading.md
+++ b/scst-scan/upgrading.md
@@ -144,19 +144,25 @@ If you're upgrading from a previous version of Supply Chain Security Tools - Sca
         } else = false { true }
 
         isSafe(match) {
-          fails := contains(notAllowedSeverities, match.ratings.rating[_])
+          severities := { e | e := match.ratings.rating.severity } | { e | e := match.ratings.rating[_].severity }
+          some i
+          fails := contains(notAllowedSeverities, severities[i])
           not fails
         }
 
         isSafe(match) {
-          ignore := contains(ignoreCves, match.Id)
+          ignore := contains(ignoreCves, match.id)
           ignore
         }
 
         deny[msg] {
-          comp := input.bom.components.component[_]
-          vuln := comp.vulnerabilities.vulnerability[_]
-          ratings := vuln.ratings.rating[_]
+          comps := { e | e := input.bom.components.component } | { e | e := input.bom.components.component[_] }
+          some i
+          comp := comps[i]
+          vulns := { e | e := comp.vulnerabilities.vulnerability } | { e | e := comp.vulnerabilities.vulnerability[_] }
+          some j
+          vuln := vulns[j]
+          ratings := { e | e := vuln.ratings.rating.severity } | { e | e := vuln.ratings.rating[_].severity }
           not isSafe(vuln)
           msg = sprintf("CVE %s %s %s", [comp.name, vuln.id, ratings])
         }


### PR DESCRIPTION
Changing sample scan policy to account for edge cases. 
Fixing typo present in the sample scan policy. 

Which other branches should this be merged with (if any)?

This is meant for 1.2.0
