### PR TITLE
[VSEE-690] Add release docs for scanning/grype for TAP 1.2.2

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -20,12 +20,27 @@ This release has the following breaking changes, listed by area and component.
 
 The following issues, listed by area and component, are resolved in this release.
 
+#### <a id="1-2-2-scst-scan-issues"></a>Supply Chain Security Tools - Scan
+
+* Resolved blob source scan reporting wrong source URL to the metadata store when the .git file does not exist.
 
 ### <a id='1-2-2-known-issues'></a> Known issues
 
 This release has the following known issues, listed by area and component.
 
+#### <a id="1-2-2-grype-scan-issues"></a>Grype scanner
 
+- **Scanning Java source code that uses Gradle package manager may not reveal vulnerabilities:**
+  - For most languages, source code scanning only scans files present in the source code repository.
+    Except for support added for Java projects using Maven, no network calls are made to fetch dependencies.
+    For languages using dependency lock files, such as Golang and Node.js,
+    Grype uses the lock files to check the dependencies for vulnerabilities.
+  - For Java using Gradle, dependency lock files are not guaranteed, so Grype uses
+    the dependencies present in the built binaries (`.jar` or `.war` files) instead.
+  - Because VMware does not encourage committing binaries to source code repositories,
+    Grype fails to find vulnerabilities during a source scan.
+    The vulnerabilities are still found during the image scan
+    after the binaries are built and packaged as images.
 
 ## <a id='1-2-1'></a> v1.2.1
 


### PR DESCRIPTION
Summary:
* Carry over grype issue which hasn't been resolved
* Add resolved issue for fluxcd

Which other branches should this be merged with (if any)?

main