### PR TITLE
Add links to GCP and Crossplane CSP use cases

### DIFF
--- a/getting-started/consume-services.hbs.md
+++ b/getting-started/consume-services.hbs.md
@@ -154,6 +154,30 @@ There are more service use cases not covered in this getting started guide. See 
     </td>
   </tr><tr>
     <td>
+      <a href="https://docs.vmware.com/en/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.7/svc-tlk/GUID-usecases-consuming_aws_rds_with_crossplane.html#claim-the-rds-postgresql-instance-and-connect-to-it-from-the-tanzu-application-platform-workload-8">Consuming AWS RDS on Tanzu Application Platform with Crossplane</a>
+    </td>
+    <td>
+      Using <a href="https://crossplane.io/">Crossplane</a> to provision an RDS instance and consume it from a Tanzu Application Platform workload.<br>
+      Involves making a third-party API consumable from Tanzu Application Platform.
+    </td>
+  </tr><tr>
+    <td>
+      <a href="https://docs.vmware.com/en/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.7/svc-tlk/GUID-usecases-consuming_gcp_sql_with_config_connector.html#discover-claim-and-bind-to-a-google-cloud-sql-postgresql-instance-3">Consuming Google Cloud SQL on Tanzu Application Platform with Config Connector</a>
+    </td>
+    <td>
+      Using GCP Config Connector to provision a Cloud SQL instance and consume it from a Tanzu Application Platform workload.<br>
+      Involves making a third-party API consumable from Tanzu Application Platform.
+    </td>
+  </tr><tr>
+    <td>
+      <a href="https://docs.vmware.com/en/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.7/svc-tlk/GUID-usecases-consuming_gcp_sql_with_crossplane.html#claim-the-cloudsql-postgresql-instance-and-connect-to-it-from-the-tanzu-application-platform-workload-8">Consuming Google Cloud SQL on Tanzu Application Platform with Crossplane</a>
+    </td>
+    <td>
+      Using <a href="https://crossplane.io/">Crossplane</a> to provision a Cloud SQL instance instance and consume it from a Tanzu Application Platform workload.<br>
+      Involves making a third-party API consumable from Tanzu Application Platform.
+    </td>
+  </tr><tr>
+    <td>
       <a href="https://docs.vmware.com/en/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.7/svc-tlk/GUID-usecases-direct_secret_references.html">Direct Secret References</a>
     </td>
     <td>

--- a/getting-started/set-up-services.hbs.md
+++ b/getting-started/set-up-services.hbs.md
@@ -285,6 +285,30 @@ There are more service use cases not covered in this getting started guide. See 
     </td>
   </tr><tr>
     <td>
+      <a href="https://docs.vmware.com/en/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.7/svc-tlk/GUID-usecases-consuming_aws_rds_with_crossplane.html">Consuming AWS RDS on Tanzu Application Platform with Crossplane</a>
+    </td>
+    <td>
+      Using <a href="https://crossplane.io/">Crossplane</a> to provision an RDS instance and consume it from a Tanzu Application Platform workload.<br>
+      Involves making a third-party API consumable from Tanzu Application Platform.
+    </td>
+  </tr><tr>
+    <td>
+      <a href="https://docs.vmware.com/en/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.7/svc-tlk/GUID-usecases-consuming_gcp_sql_with_config_connector.html">Consuming Google Cloud SQL on Tanzu Application Platform with Config Connector</a>
+    </td>
+    <td>
+      Using GCP Config Connector to provision a Cloud SQL instance and consume it from a Tanzu Application Platform workload.<br>
+      Involves making a third-party API consumable from Tanzu Application Platform.
+    </td>
+  </tr><tr>
+    <td>
+      <a href="https://docs.vmware.com/en/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.7/svc-tlk/GUID-usecases-consuming_gcp_sql_with_crossplane.html">Consuming Google Cloud SQL on Tanzu Application Platform with Crossplane</a>
+    </td>
+    <td>
+      Using <a href="https://crossplane.io/">Crossplane</a> to provision a Cloud SQL instance instance and consume it from a Tanzu Application Platform workload.<br>
+      Involves making a third-party API consumable from Tanzu Application Platform.
+    </td>
+  </tr><tr>
+    <td>
       <a href="https://docs.vmware.com/en/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.7/svc-tlk/GUID-usecases-direct_secret_references.html">Direct Secret References</a>
     </td>
     <td>


### PR DESCRIPTION
Hi there,

This PR adds links to recently-added GCP and Crossplane use cases for Services Toolkit / Services on TAP.

Which other branches should this be merged with (if any): TAP 1.2 / 1.2.1 / 1.2.2