### PR TITLE
Update install-app-acc.hbs.md

### DIFF
--- a/application-accelerator/install-app-acc.hbs.md
+++ b/application-accelerator/install-app-acc.hbs.md
@@ -26,7 +26,7 @@ When you install the Application Accelerator, you can configure the following op
 | Property | Default | Description |
 | --- | --- | --- |
 | registry.secret_ref | registry.tanzu.vmware.com | The secret used for accessing the registry where the App-Accelerator images are located |
-| server.service_type | LoadBalancer | The service type for the acc-ui-server service including LoadBalancer, NodePort, or ClusterIP |
+| server.service_type | ClusterIP | The service type for the acc-ui-server service including LoadBalancer, NodePort, or ClusterIP |
 | server.watched_namespace | accelerator-system | The namespace the server watches for accelerator resources |
 | server.engine_invocation_url | http://acc-engine.accelerator-system.svc.cluster.local/invocations | The URL to use for invoking the accelerator engine |
 | engine.service_type | ClusterIP | The service type for the acc-engine service including LoadBalancer, NodePort, or ClusterIP |


### PR DESCRIPTION
The default value for the server.service_type is ClusterIP and not LoadBalancer. I updated the table to match the value returned from checking the schema on the package as well (This threw me off when following the documents to find the url to configure accelerators in VSCode for example).

Running this command showed different defaults:  tanzu package available get accelerator.apps.tanzu.vmware.com/1.2.2 --values-schema --namespace tap-install

  KEY                                             DEFAULT                         TYPE     DESCRIPTION

  engine.service_type                  ClusterIP                         string   The service type for the Service of the engine.


Which other branches should this be merged with (if any)?
