### PR TITLE
Updated ingressDomain references

### DIFF
--- a/install.hbs.md
+++ b/install.hbs.md
@@ -262,7 +262,7 @@ Images are written to `SERVER-NAME/REPO-NAME/workload-name`. Examples:
 - `SSH-SECRET-KEY` is the SSH secret key in the developer namespace for the supply chain to fetch source code from and push configuration to.
 - `INGRESS-DOMAIN` is the subdomain for the host name that you point at the `tanzu-shared-ingress`
 service's External IP address.
-- `INGRESS-ENABLED` is a boolean flag, it can be "true" or "false". This property enable or disable the above INGRESS-DOMAIN value to be applied in the Tanzu Application Platform installation.
+- `INGRESS-ENABLED` is a boolean flag, it can be true or false. This property enable or disable the above INGRESS-DOMAIN value to be applied in the Tanzu Application Platform installation.
 - `GIT-CATALOG-URL` is the path to the `catalog-info.yaml` catalog definition file. You can download either a blank or populated catalog file from the [Tanzu Application Platform product page](https://network.pivotal.io/products/tanzu-application-platform/#/releases/1043418/file_groups/6091). Otherwise, you can use a Backstage-compliant catalog you've already built and posted on the Git infrastructure.
 - `MY-DEV-NAMESPACE` is the namespace where you want to deploy the `ScanTemplates`.
 This is the namespace where the scanning feature runs.

--- a/install.hbs.md
+++ b/install.hbs.md
@@ -194,7 +194,7 @@ The following is the YAML file sample for the full-profile:
 profile: full
 
 ingressDomain: INGRESS-DOMAIN
-ingressEnabled: INGRESS-ENABLED
+ingressEnabled: true
 
 ceip_policy_disclosed: FALSE-OR-TRUE-VALUE # Installation fails if this is not set to true. Not a string.
 buildservice:
@@ -262,7 +262,6 @@ Images are written to `SERVER-NAME/REPO-NAME/workload-name`. Examples:
 - `SSH-SECRET-KEY` is the SSH secret key in the developer namespace for the supply chain to fetch source code from and push configuration to.
 - `INGRESS-DOMAIN` is the subdomain for the host name that you point at the `tanzu-shared-ingress`
 service's External IP address.
-- `INGRESS-ENABLED` is a boolean flag, it can be true or false. This property enable or disable the above INGRESS-DOMAIN value to be applied in the Tanzu Application Platform installation.
 - `GIT-CATALOG-URL` is the path to the `catalog-info.yaml` catalog definition file. You can download either a blank or populated catalog file from the [Tanzu Application Platform product page](https://network.pivotal.io/products/tanzu-application-platform/#/releases/1043418/file_groups/6091). Otherwise, you can use a Backstage-compliant catalog you've already built and posted on the Git infrastructure.
 - `MY-DEV-NAMESPACE` is the namespace where you want to deploy the `ScanTemplates`.
 This is the namespace where the scanning feature runs.
@@ -275,6 +274,9 @@ credentials to pull an image from the registry for scanning.
 If built images are pushed to the same registry as the Tanzu Application Platform images,
 this can reuse the `tap-registry` secret created in
 [Add the Tanzu Application Platform package repository](#add-tap-package-repo) as described earlier.
+
+>**Note:** If you need to use more specific URLs in place of `INGRESS-DOMAIN` please take a look at the `tap-gui-values` in the [Installing the Tanzu Application Platform GUI](./tap-gui/install-tap-gui.hbs.md#tap-gui-values),
+> where you can copy specific values for your use case.
 
 ### <a id='light-profile'></a> Light profile
 

--- a/install.hbs.md
+++ b/install.hbs.md
@@ -214,16 +214,10 @@ ootb_supply_chain_basic:
 tap_gui:
   service_type: ClusterIP
   app_config:
-    app:
-      baseUrl: http://tap-gui.INGRESS-DOMAIN
     catalog:
       locations:
         - type: url
           target: https://GIT-CATALOG-URL/catalog-info.yaml
-    backend:
-      baseUrl: http://tap-gui.INGRESS-DOMAIN
-      cors:
-        origin: http://tap-gui.INGRESS-DOMAIN
 
 metadata_store:
   ns_for_export_app_cert: "MY-DEV-NAMESPACE"

--- a/install.hbs.md
+++ b/install.hbs.md
@@ -193,8 +193,8 @@ The following is the YAML file sample for the full-profile:
 ```yaml
 profile: full
 
-shared:
-  ingress_domain: INGRESS-DOMAIN
+ingressDomain: INGRESS-DOMAIN
+ingressEnabled: INGRESS-ENABLED
 
 ceip_policy_disclosed: FALSE-OR-TRUE-VALUE # Installation fails if this is not set to true. Not a string.
 buildservice:
@@ -268,6 +268,7 @@ Images are written to `SERVER-NAME/REPO-NAME/workload-name`. Examples:
 - `SSH-SECRET-KEY` is the SSH secret key in the developer namespace for the supply chain to fetch source code from and push configuration to.
 - `INGRESS-DOMAIN` is the subdomain for the host name that you point at the `tanzu-shared-ingress`
 service's External IP address.
+- `INGRESS-ENABLED` is a boolean flag, it can be "true" or "false". This property enable or disable the above INGRESS-DOMAIN value to be applied in the Tanzu Application Platform installation.
 - `GIT-CATALOG-URL` is the path to the `catalog-info.yaml` catalog definition file. You can download either a blank or populated catalog file from the [Tanzu Application Platform product page](https://network.pivotal.io/products/tanzu-application-platform/#/releases/1043418/file_groups/6091). Otherwise, you can use a Backstage-compliant catalog you've already built and posted on the Git infrastructure.
 - `MY-DEV-NAMESPACE` is the namespace where you want to deploy the `ScanTemplates`.
 This is the namespace where the scanning feature runs.

--- a/tap-gui/install-tap-gui.hbs.md
+++ b/tap-gui/install-tap-gui.hbs.md
@@ -55,6 +55,8 @@ To install Tanzu Application Platform GUI on a compliant Kubernetes cluster:
 
     For more information about values schema options, see the individual product documentation.
 
+### <a id='tap-gui-values'></a>
+
 1. Create `tap-gui-values.yaml` and paste in one of the following two code options:
 
   - If you prefer to pass the ingress domain once, paste in the following code.

--- a/tap-gui/install-tap-gui.hbs.md
+++ b/tap-gui/install-tap-gui.hbs.md
@@ -55,13 +55,13 @@ To install Tanzu Application Platform GUI on a compliant Kubernetes cluster:
 
     For more information about values schema options, see the individual product documentation.
 
-1. Create `tap-gui-values.yaml` and paste in one of the following two code options.
+1. Create `tap-gui-values.yaml` and paste in one of the following two code options:
 
   - If you prefer to pass the ingress domain once, paste in the following code.
 
     ```yaml
     service_type: ClusterIP
-    ingressEnabled: "true"
+    ingressEnabled: true
     ingressDomain: "INGRESS-DOMAIN"
     app_config:
       catalog:
@@ -74,7 +74,7 @@ To install Tanzu Application Platform GUI on a compliant Kubernetes cluster:
 
     ```yaml
     service_type: ClusterIP
-    ingressEnabled: "false"
+    ingressEnabled: false
     app_config:
       app:
         baseUrl: http://tap-gui.INGRESS-DOMAIN

--- a/tap-gui/install-tap-gui.hbs.md
+++ b/tap-gui/install-tap-gui.hbs.md
@@ -62,16 +62,10 @@ To install Tanzu Application Platform GUI on a compliant Kubernetes cluster:
     ingressEnabled: "true"
     ingressDomain: "INGRESS-DOMAIN"
     app_config:
-      app:
-        baseUrl: http://tap-gui.INGRESS-DOMAIN
       catalog:
         locations:
           - type: url
             target: https://GIT-CATALOG-URL/catalog-info.yaml
-      backend:
-        baseUrl: http://tap-gui.INGRESS-DOMAIN
-        cors:
-          origin: http://tap-gui.INGRESS-DOMAIN
     ```
 
     Where:

--- a/tap-gui/install-tap-gui.hbs.md
+++ b/tap-gui/install-tap-gui.hbs.md
@@ -55,7 +55,9 @@ To install Tanzu Application Platform GUI on a compliant Kubernetes cluster:
 
     For more information about values schema options, see the individual product documentation.
 
-1. Create `tap-gui-values.yaml` and paste in the following code:
+1. Create `tap-gui-values.yaml` and paste in one of the following two code options.
+
+  - If you prefer to pass the ingress domain once, paste in the following code.
 
     ```yaml
     service_type: ClusterIP
@@ -66,6 +68,24 @@ To install Tanzu Application Platform GUI on a compliant Kubernetes cluster:
         locations:
           - type: url
             target: https://GIT-CATALOG-URL/catalog-info.yaml
+    ```
+
+  - If you prefer to configure specific values for baseUrls and cors origin, paste in the following code.
+
+    ```yaml
+    service_type: ClusterIP
+    ingressEnabled: "false"
+    app_config:
+      app:
+        baseUrl: http://tap-gui.INGRESS-DOMAIN
+      catalog:
+        locations:
+          - type: url
+            target: https://GIT-CATALOG-URL/catalog-info.yaml
+      backend:
+        baseUrl: http://tap-gui.INGRESS-DOMAIN
+        cors:
+          origin: http://tap-gui.INGRESS-DOMAIN
     ```
 
     Where:


### PR DESCRIPTION
Updated documentation for the ingressDomain (hostname) references in

- `Installing Tanzu Application Platform package and profiles` page ( `Full profile` section )

- `Install Tanzu Application Platform GUI` page  ( `Procedure` section )

