### PR TITLE
VSEE-671 Updated Scan Policies and added additional troubleshooting section

### DIFF
--- a/getting-started/add-test-and-security.hbs.md
+++ b/getting-started/add-test-and-security.hbs.md
@@ -208,6 +208,8 @@ Verify that both Scan Link and Grype Scanner are installed by running:
     kind: ScanPolicy
     metadata:
       name: scan-policy
+      labels:
+        'app.kubernetes.io/part-of': 'component-a'
     spec:
       regoFile: |
         package main

--- a/scc/ootb-supply-chain-testing-scanning.hbs.md
+++ b/scc/ootb-supply-chain-testing-scanning.hbs.md
@@ -148,6 +148,8 @@ apiVersion: scanning.apps.tanzu.vmware.com/v1beta1
 kind: ScanPolicy
 metadata:
   name: scan-policy
+  labels:
+    'app.kubernetes.io/part-of': 'component-a'
 spec:
   regoFile: |
     package main

--- a/scst-scan/install-carbonblack-integration.hbs.md
+++ b/scst-scan/install-carbonblack-integration.hbs.md
@@ -220,6 +220,8 @@ To verify the integration with Carbon Black, apply the following `ImageScan` and
     kind: ScanPolicy
     metadata:
       name: carbonblack-scan-policy
+      labels:
+        'app.kubernetes.io/part-of': 'component-a'
     spec:
       regoFile: |
         package main

--- a/scst-scan/install-snyk-integration.hbs.md
+++ b/scst-scan/install-snyk-integration.hbs.md
@@ -200,6 +200,8 @@ To verify the integration with Snyk, apply the following `ImageScan` and its `Sc
     kind: ScanPolicy
     metadata:
       name: snyk-scan-policy
+      labels:
+        'app.kubernetes.io/part-of': 'component-a'
     spec:
       regoFile: |
         package main

--- a/scst-scan/observing.hbs.md
+++ b/scst-scan/observing.hbs.md
@@ -205,3 +205,14 @@ configurations to deactivate the Store:
   #### <a id="supply-chain-stops"></a> Supply Chain not progressing
 
   If the Supply Chain is not progressing due to CVEs found in either the SourceScan or ImageScan, see the CVE triage workflow in [Out of the Box Supply Chain with Testing and Scanning](../scc/ootb-supply-chain-testing-scanning.hbs.md#a-idcve-triage-workflowa-cve-triage-workflow).
+
+  #### <a id="gui-miss-policy"></a> Policy not defined in the Tanzu Application Platform GUI
+
+  If you encounter `No policy has been defined`, it could be because the TAP GUI is unable to view the Scan Policy resource.
+  - Confirm that the Scan Policy associated with a SourceScan or ImageScan exists (i.e. the `scanPolicy` in the scan matches the name of the Scan Policy)
+    ```
+    kubectl describe sourcescan <NAME> -n <DEV_NAMESPACE>
+    kubectl describe imagescan <NAME> -n <DEV_NAMESPACE>
+    kubectl get scanpolicy <NAME> -n <DEV_NAMESPACE>
+    ```
+  - Add the `app.kubernetes.io/part-of` label to the Scan Policy. See [Enable Tanzu Application Platform GUI to view ScanPolicy Resource](policies.hbs.md#a-idgui-view-scan-policyaenable-tanzu-application-platform-gui-to-view-scanpolicy-resource) for more detail.

--- a/scst-scan/policies.hbs.md
+++ b/scst-scan/policies.hbs.md
@@ -29,6 +29,8 @@ Follow these steps to define a Rego file for policy enforcement that you can reu
     kind: ScanPolicy
     metadata:
       name: scanpolicy-sample
+      labels:
+        'app.kubernetes.io/part-of': 'component-a'
     spec:
       regoFile: |
         package main
@@ -108,6 +110,8 @@ apiVersion: scanning.apps.tanzu.vmware.com/v1alpha1
 kind: ScanPolicy
 metadata:
   name: v1alpha1-scan-policy
+  labels:
+    'app.kubernetes.io/part-of': 'component-a'
 spec:
   regoFile: |
     package policies

--- a/scst-scan/samples/public-image-compliance.hbs.md
+++ b/scst-scan/samples/public-image-compliance.hbs.md
@@ -24,6 +24,8 @@ apiVersion: scanning.apps.tanzu.vmware.com/v1beta1
 kind: ScanPolicy
 metadata:
   name: sample-scan-policy
+  labels:
+    'app.kubernetes.io/part-of': 'component-a'
 spec:
   regoFile: |
     package main

--- a/scst-scan/samples/public-source-compliance.hbs.md
+++ b/scst-scan/samples/public-source-compliance.hbs.md
@@ -30,6 +30,8 @@ SourceScan:
     kind: ScanPolicy
     metadata:
       name: sample-scan-policy
+      labels:
+        'app.kubernetes.io/part-of': 'component-a'
     spec:
       regoFile: |
         package main

--- a/scst-scan/upgrading.hbs.md
+++ b/scst-scan/upgrading.hbs.md
@@ -131,6 +131,8 @@ If you're upgrading from a previous version of Supply Chain Security Tools - Sca
     kind: ScanPolicy
     metadata:
       name: scanpolicy-sample
+      labels:
+        'app.kubernetes.io/part-of': 'component-a'
     spec:
       regoFile: |
         package main


### PR DESCRIPTION
 Updated sample scan policies to include a "part-of" label and added troubleshooting section adding in the label if 'Policy not defined" is encountered in the GUI' 

Which other branches should this be merged with (if any)? main and cherry-pick to 1.2 docs please
