### PR TITLE
Add release notes for STK 0.8 (TAP 1.3)

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -101,8 +101,14 @@ This release includes the following changes, listed by component and area.
 
 #### <a id="srvc-toolkit-features"></a> Services Toolkit
 
-- Feature 1
-- Feature 2
+- Added support for Openshift
+- Added support for Kubernetes 1.24
+- Created documentation and reference Service Instance Packages for new Cloud Service Provider integrations:
+  - [Azure Flexible Server (Postgres) using the Azure Service Operator](https://docs-staging.vmware.com/en/draft/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.8/svc-tlk/GUID-usecases-consuming_azure_flexibleserver_psql_with_azure_operator.html)
+  - [Azure Flexible Server (Postgres) using Crossplane](https://docs-staging.vmware.com/en/draft/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.8/svc-tlk/GUID-usecases-consuming_azure_database_with_crossplane.html)
+  - [Google Cloud SQL (Postgres) using Config Connector](https://docs-staging.vmware.com/en/draft/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.8/svc-tlk/GUID-usecases-consuming_gcp_sql_with_config_connector.html)
+  - [Google Cloud SQL (Postgres) using Crossplane](https://docs-staging.vmware.com/en/draft/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.8/svc-tlk/GUID-usecases-consuming_gcp_sql_with_crossplane.html)
+- `tanzu services` CLI plug-in - improved info messages for deprecated commands
 
 ### <a id='1-3-breaking-changes'></a> Breaking changes
 


### PR DESCRIPTION
Hi!

This PR adds the release notes for Services Toolkit for TAP 1.3.

NB: The release notes contain links to the Services Toolkit component documentation. I've used the staging links for now - is there a process for ensuring those staging links become production links once the TAP docs go live? Or will we need to open another PR for that?

Thanks!
Ed

Which other branches should this be merged with (if any)? None
