### PR TITLE
Removes old extra ca-certs docs from TAP GUI section

### DIFF
--- a/tap-gui/non-standard-certs.hbs.md
+++ b/tap-gui/non-standard-certs.hbs.md
@@ -4,8 +4,49 @@ This topic describes how to configure Tanzu Application Platform GUI to trust un
 authorities (CA) when making outbound connections.
 You do this by using overlays with PackageInstalls. There are two ways to implement this workaround:
 
-- [Deactivate all SSL verification](#deactivate-ssl)
 - [Add a custom CA](#add-custom-ca)
+- [Deactivate all SSL verification](#deactivate-ssl)
+
+## <a id='add-custom-ca'></a> Add a custom CA
+
+note: The overlay previously available in this section is no longer necessary.
+
+As of TAP 1.3 the TAP GUI team supports the value `ca_cert_data` at the top
+level of its values file. Which takes any number of newline delimited certs in
+PEM format.
+```yaml
+# tap-gui-values.yaml
+ca_cert_data: |
+  -----BEGIN CERTIFICATE-----
+  cert data here
+  -----END CERTIFICATE-----
+
+  -----BEGIN CERTIFICATE-----
+  other cert data here
+  -----END CERTIFICATE-----
+app_config:
+  # ...
+```
+
+TAP GUI will also inherit `shared.ca_cert_data` from your TAP values file.
+`shared.ca_cert_data` will be newline concatenated with ca_certs given directly
+to TAP GUI.
+
+```yaml
+shared:
+  ca_cert_data: |
+    -----BEGIN CERTIFICATE-----
+    cert data here
+    -----END CERTIFICATE-----
+
+tap_gui:
+  ca_cert_data: |
+    -----BEGIN CERTIFICATE-----
+    other cert data here
+    -----END CERTIFICATE-----
+  app_config:
+    # ...
+```
 
 ## <a id='deactivate-ssl'></a> Deactivate all SSL verification
 
@@ -20,7 +61,6 @@ The following is an example overlay to deactivate TLS:
 
 ```yaml
 #@ load("@ytt:overlay", "overlay")
-
 #@overlay/match by=overlay.subset({"kind":"Deployment", "metadata": {"name": "server", "namespace": "NAMESPACE"}}),expects="1+"
 ---
 spec:
@@ -36,79 +76,6 @@ spec:
 
 Where `NAMESPACE` is the namespace in which your Tanzu Application Platform GUI instance is deployed.
 For example, `tap-gui`.
-
-## <a id='add-custom-ca'></a> Add a custom CA
-
-If you want to keep verification enabled, you can add a custom CA and mount it to the
-Tanzu Application Platform GUI pod, and then set the pod's environment variable as
-`NODE_EXTRA_CA_CERTS=PATH-TO-MOUNTED-FILE`.
-
-To do so:
-
-1. Encode the extra CA certificates you want to trust in base64.
-You can provide many certificates in PEM format in the same file.
-Get the output you need for the next step by running:
-
-    ```console
-    cat FILENAME | base64 -w0
-    ```
-
-    Where `FILENAME` is your filename. For example, `cert-chain.pem`.
-
-1. Copy the output from the previous command into the example field `tap-gui-certs.crt` into the
-following example `secret.yaml`:
-
-    ```yaml
-    ---
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: tap-gui-extra-certs
-      namespace: tap-gui
-    type: Opaque
-    data:
-      tap-gui-certs.crt: "ENCODED-LIST-OF-CERTS"
-    ```
-
-    Adjust metadata and naming from this example accordingly.
-
-1. Apply the secret to your cluster by running:
-
-    ```console
-    kubectl apply -f secret.yaml
-    ```
-
-1. To set the environment variable `NODE_EXTRA_CA_CERTS`, use the `package_overlays` key in the
-Tanzu Application Platform values file.
-For instructions, see [Customizing Package Installation](../customize-package-installation.md).
-
-    The following is an example overlay to add a custom CA.
-    It assumes that your Tanzu Application Platform GUI instance is deployed in the namespace `tap-gui`.
-    Adjust all names accordingly.
-
-    ```yaml
-    #@ load("@ytt:overlay", "overlay")
-
-    #@overlay/match by=overlay.subset({"kind": "Deployment", "metadata": {"name": "server", "namespace": "tap-gui"}}), expects="1+"
-    ---
-    spec:
-      template:
-        spec:
-          containers:
-            #@overlay/match by=overlay.subset({"name": "backstage"}),expects="1+"
-            #@overlay/match-child-defaults missing_ok=True
-            - env:
-                - name: NODE_EXTRA_CA_CERTS
-                  value: /etc/tap-gui-certs/tap-gui-certs.crt
-              volumeMounts:
-                - name: tap-gui-extra-certs
-                  mountPath: /etc/tap-gui-certs
-                  readOnly: true
-            volumes:
-              - name: tap-gui-extra-certs
-                secret:
-                  secretName: tap-gui-extra-certs
-    ```
 
 ## <a id='next-steps'></a>Next steps
 


### PR DESCRIPTION
I elected to update the instructions as well, including how TAP GUI certs
interact with TAP certs. We could probably have these docs in a more centralized
place though.

Signed-off-by: Michael Stergianis <mstergianis@vmware.com>

Which other branches should this be merged with (if any)?
Just 1.3