### PR TITLE
Add details about prereqs for EKS on k8s 1.23

### DIFF
--- a/prerequisites.hbs.md
+++ b/prerequisites.hbs.md
@@ -85,6 +85,8 @@ providers:
 
 - Azure Kubernetes Service.
 - Amazon Elastic Kubernetes Service.
+    - EKS clusters on Kubernetes version 1.23 require the [Amazon EBS CSI Driver](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) due to the [CSIMigrationAWS in this version](https://aws.amazon.com/blogs/containers/amazon-eks-now-supports-kubernetes-1-23/).
+      - Users currently on EKS Kubernetes version 1.22 will need to install the Amazon EBS CSI Driver [before upgrading to Kubernetes version 1.23](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi-migration-faq.html).
 - Google Kubernetes Engine.
     - GKE Autopilot clusters do not have the required features enabled.
     - GKE clusters that are set up in zonal mode might detect Kubernetes API errors when the GKE


### PR DESCRIPTION
- In order to use the default storage class on EKS for K8s 1.23, users need
  the EBS CSI Driver installed.
- TAP leverages the default storage class in multiple places

Which other branches should this be merged with (if any)?

This should be added to TAP 1.2 branch as well as TAP 1.2 supports K8s 1.23