### PR TITLE
fix: getting the AUTH_TOKEN fails if there are multiple secrets with the same annotation

### DIFF
--- a/scst-store/ingress-multicluster.hbs.md
+++ b/scst-store/ingress-multicluster.hbs.md
@@ -85,7 +85,7 @@ kubectl apply -f store_ca.yaml
 To get the Supply Chain Security Tools - Store's Auth token, run:
 
 ```bash
-AUTH_TOKEN=$(kubectl get secrets -n metadata-store -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='metadata-store-read-write-client')].data.token}" | base64 -d)
+AUTH_TOKEN=$(kubectl get secret $(kubectl get sa -n metadata-store metadata-store-read-write-client -o json | jq -r '.secrets[0].name') -n metadata-store -o json | jq -r '.data.token' | base64 -d)
 ```
 
 Create the corresponding secret on the second cluster. Run:


### PR DESCRIPTION
On an existing cluster, getting the AUTH_TOKEN fails with invalid base64 input as there can be more than one secret with the specified annotation, this change uses the secret referenced in the service account.

This should also be merged with the 1.2 branch.


