### PR TITLE
Containerd must be used in place of docker as the runtime on eks

### DIFF
--- a/prerequisites.hbs.md
+++ b/prerequisites.hbs.md
@@ -85,6 +85,7 @@ providers:
 
 - Azure Kubernetes Service.
 - Amazon Elastic Kubernetes Service.
+    - containerd must be used as the CRI. Some versions of EKS default to Docker as the container runtime and must be changed to containerd.
     - EKS clusters on Kubernetes version 1.23 require the [Amazon EBS CSI Driver](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) due to the [CSIMigrationAWS](https://aws.amazon.com/blogs/containers/amazon-eks-now-supports-kubernetes-1-23/) is enabled by default in Kubernetes 1.23.
         - Users currently on EKS Kubernetes version 1.22 must install the Amazon EBS CSI Driver before upgrading to Kubernetes version 1.23. See [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi-migration-faq.html) for more information.
 - Google Kubernetes Engine.


### PR DESCRIPTION
Which other branches should this be merged with (if any)?

This should be added to 1.2 branches and up