### PR TITLE
Removed reference to k8s 1.24 in SCST-Store doc for TAP 1.2.2 release

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -24,7 +24,6 @@ The following issues, listed by area and component, are resolved in this release
 
 #### <a id="1-2-2-scst-store-issues"></a>Supply Chain Security Tools - Store
 
-* Added secret for metadata-store-read-write-client to support K8s 1.24.
 * Resolved an issue where Store could not handle new method types.
 * Resolved an issue where Store could not handle blob URLS in component names.
 


### PR DESCRIPTION
Which other branches should this be merged with (if any)?
None

Related Slack Thread: https://vmware.slack.com/archives/C02P2UZHJ4F/p1662973008126479