### PR TITLE
remove odd spacing in convention resources

### DIFF
--- a/cartographer-conventions/reference/convention-resources.hbs.md
+++ b/cartographer-conventions/reference/convention-resources.hbs.md
@@ -55,6 +55,6 @@ For example:
 + [PodConventionContextSpec](pod-convention-context-spec.md)
 + [PodConventionContextStatus](pod-convention-context-status.md)
 + [PodConventionContext](pod-convention-context.md)
-+ [Cluster Pod Convention](cluster-pod-convention.md)
++ [ClusterPodConvention](cluster-pod-convention.md)
 + [PodIntent](pod-intent.md)
 + [BOM](bom.md)


### PR DESCRIPTION
Minor change to remove odd spacing on text to be linked to resource.
