### PR TITLE
Added windows support in overview for IntelliJ plugin

### DIFF
--- a/intellij-extension/about.hbs.md
+++ b/intellij-extension/about.hbs.md
@@ -5,7 +5,7 @@ you develop with the Tanzu Application Platform.
 This extension enables you to rapidly iterate on your workloads on supported Kubernetes clusters that
 have Tanzu Application Platform installed.
 
-The extension currently only supports Java apps.
+Tanzu Developer Tools for IntelliJ currently supports Java application on macOS and Windows.
 
 ## <a id="extension-features"></a> Extension features
 


### PR DESCRIPTION
Which other branches should this be merged with (if any)? None, windows support was only added on Tap 1.3
