### PR TITLE
Add docs for service-operator role

### DIFF
--- a/authn-authz/overview.hbs.md
+++ b/authn-authz/overview.hbs.md
@@ -1,18 +1,19 @@
 # Overview
 
-Tanzu Application Platform v1.2 includes:
+Tanzu Application Platform v1.3 includes:
 
-- Five new default roles to help you set up permissions for users and [service accounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) within a namespace on a cluster that runs one of the Tanzu Application Platform profiles.
+- Six default roles to help you set up permissions for users and [service accounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) within a namespace on a cluster that runs one of the Tanzu Application Platform profiles.
 - A Tanzu CLI RBAC (role-based access control) plug-in for role binding. For more information, see [Bind a user or group to a default role](binding.md).
 - Documentation for [integrating with your existing identity management solution](integrating-identity.md).
 
 ## <a id="default-roles"></a> Default roles
 
-Three roles are for users:
+Four roles are for users:
 
 - app-editor
 - app-viewer
 - app-operator
+- service-operator
 
 Two roles are for service accounts associated with the Tanzu Supply Chain:
 

--- a/authn-authz/role-descriptions.hbs.md
+++ b/authn-authz/role-descriptions.hbs.md
@@ -32,6 +32,12 @@ Assign this role to a user who defines the activities within a supply chain or t
 
 If this person must create Tanzu workloads, you can bind the user with the app-editor role as well.
 
+## <a id="service-operator"></a>service-operator
+
+The service-operator role can create, edit, and delete service instances, service instance classes, and resource claim policies to permit the claimability of service instances across one or more namespaces.
+
+Assign this role to a user who is responsible for the life cycle (create, edit and delete) of service instances. This role can also view resource claims across all namespaces as well as query for the list of claimable service instances in a given namespace.
+
 ## <a id="workload"></a>workload
 
 This role provides the service account associated with the Tanzu workload the permissions needed to execute the activities in the supply chain. This role is for a "robot” versus a user.  

--- a/getting-started/about-consuming-services.hbs.md
+++ b/getting-started/about-consuming-services.hbs.md
@@ -72,13 +72,13 @@ each user role.
   <th><strong>Responsibilities</strong></th>
   <tr>
     <td>Service operator</td>
-    <td>No (might be introduced in a future release)</td>
+    <td>Yes - <a href="../authn-authz/role-descriptions.md#service-operator">service-operator</a></td>
     <td>
       <ul>
-        <li>Namespace and cluster topology design</li>
-        <li>Life cycle management (CRUD) of Kubernetes operators</li>
         <li>Life cycle management (CRUD) of service instances</li>
+        <li>Life cycle management (CRUD) of service instance classes</li>
         <li>Life cycle management (CRUD) of resource claim policies</li>
+        <li>View and query for resource claims across namespaces</li>
       </ul>
     </td>
   </tr>

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -206,6 +206,7 @@ part of upgrading [Tanzu Application Platform as a whole](./upgrading.hbs.md).
   - [Azure Flexible Server (Postgres) by using Crossplane](https://docs-staging.vmware.com/en/draft/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.8/svc-tlk/GUID-usecases-consuming_azure_database_with_crossplane.html).
   - [Google Cloud SQL (Postgres) by using Config Connector](https://docs-staging.vmware.com/en/draft/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.8/svc-tlk/GUID-usecases-consuming_gcp_sql_with_config_connector.html).
   - [Google Cloud SQL (Postgres) by using Crossplane](https://docs-staging.vmware.com/en/draft/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.8/svc-tlk/GUID-usecases-consuming_gcp_sql_with_crossplane.html).
+- Formally defined the Service Operator user role (see [Role descriptions](./authn-authz/role-descriptions.hbs.md))
 - **`tanzu services` CLI plug-in:** Improved information messages for deprecated commands.
 
 ### <a id='1-3-breaking-changes'></a> Breaking changes


### PR DESCRIPTION
This PR adds information about the new "Service Operator" user role, which is available as of TAP 1.3. Note that I have not included updates to the [Detailed role permissions breakdown](https://github.com/pivotal/docs-tap/blob/main/authn-authz/permissions-breakdown.hbs.md) page as I believe this page is due to be either reworked or removed in the near future (cc @dherbrich).

Which other branches should this be merged with (if any)? None
