### PR TITLE
Policy Controller 1.1.0

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -237,7 +237,7 @@ This release has the following breaking changes, listed by area and component.
 
 #### <a id="scst-scan-resolved"></a>Supply Chain Security Tools - Policy Controller
 
-- Pods deployed through `kubectl run` in non-default namespace now are able to build the neccessary keychain for validation.
+- Pods deployed through `kubectl run` in non-default namespace now are able to build the neccessary keychain for registry access during validation.
 
 #### <a id="scst-scan-resolved"></a>Supply Chain Security Tools - Scan
 

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -45,6 +45,8 @@ This release includes the following changes, listed by component and area.
 - `AuthServer.spec.issuerURI` is deprecated and marked for removal in the next release. Please, migrate
   to `AuthServer.spec.tls`.
 
+- [Supply Chain Security Tools - Sign](scst-sign/overview.md) is deprecated. For migration information, see [Migration From Supply Chain Security Tools - Sign](./scst-policy/migration.hbs.md).
+
 ##### Bug fixes
 
 - Emit the audit `TOKEN_REQUEST_REJECTED` event when the `refresh_token` grant fails.
@@ -153,15 +155,10 @@ part of upgrading [Tanzu Application Platform as a whole](./upgrading.hbs.md).
 - Feature 1
 - Feature 2
 
-#### <a id="scst-sign-features"></a>Supply Chain Security Tools - Sign
-
-- Feature 1
-- Feature 2
-
 #### <a id="scst-policy-features"></a>Supply Chain Security Tools - Policy Controller
 
-- Feature 1
-- Feature 2
+- Added ClusterImagePolicy [`warn` and `enforce` mode](./scst-policy/configuring.hbs.md#cip-mode)
+- Added ClusterImagePolicy [authority static actions](./scst-policy/configuring.hbs.md#cip-static-action)
 
 #### <a id="scst-store-features"></a>Supply Chain Security Tools - Store
 

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -157,6 +157,7 @@ part of upgrading [Tanzu Application Platform as a whole](./upgrading.hbs.md).
 
 #### <a id="scst-policy-features"></a>Supply Chain Security Tools - Policy Controller
 
+- Update Policy Controller version from v0.2.0 to v0.3.0
 - Added ClusterImagePolicy [`warn` and `enforce` mode](./scst-policy/configuring.hbs.md#cip-mode)
 - Added ClusterImagePolicy [authority static actions](./scst-policy/configuring.hbs.md#cip-static-action)
 
@@ -233,6 +234,10 @@ This release has the following breaking changes, listed by area and component.
 
 - Resolved issue 1
 - Resolved issue 2
+
+#### <a id="scst-scan-resolved"></a>Supply Chain Security Tools - Policy Controller
+
+- Pods deployed through `kubectl run` in non-default namespace now are able to build the neccessary keychain for validation.
 
 #### <a id="scst-scan-resolved"></a>Supply Chain Security Tools - Scan
 

--- a/scst-policy/configuring.hbs.md
+++ b/scst-policy/configuring.hbs.md
@@ -64,7 +64,7 @@ A sample of a ClusterImagePolicy which has `warn` mode configured.
 apiVersion: policy.sigstore.dev/v1beta1
 kind: ClusterImagePolicy
 metadata:
-  name: warn-tap-packages
+  name: <POLICY_NAME>
 spec:
   mode: warn
 ```
@@ -208,7 +208,7 @@ failed policy: <POLICY_NAME>: spec.template.spec.containers[1].image
 
 Images that are unsigned in a namespace with validation enabled can be admitted with an authority with static action `pass`.
 
-A scenario where this is desirable would be configuring a policy with `static.action` `pass` for `tap-packages` images while another policy is configured to validate signed images produced by Tanzu Build Service. This will allow images from `tap-packages`, which are currently unsigned and required by the platform, while validating signed built images.
+A scenario where this is desirable would be configuring a policy with `static.action` `pass` for `tap-packages` images. Another policy is then configured to validate signed images produced by Tanzu Build Service. This will allow images from `tap-packages`, which are currently unsigned and required by the platform, to be admitted while still validating signed built images from Tanzu Build Service.
 
 If `Warning` messages are desirable for admitted images where validation failed, it is possible to configure a policy with `warn` mode and valid authorities.
 For information on ClusterImagePolicy modes, see the [Mode](#cip-mode) documentation.

--- a/scst-policy/configuring.hbs.md
+++ b/scst-policy/configuring.hbs.md
@@ -180,6 +180,39 @@ each have at least one valid signature obtained using the authorities specified.
 If an image does not match any policy, the Policy Controller
 does not admit the image.
 
+#### <a id="cip-static-action"></a> `static.action`
+
+ClusterImagePolicy authorities can be configured to always `pass` or `fail` with `static.action`.
+
+Sample `ClusterImagePolicy` with static action `fail`.
+
+```yaml
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: <POLICY_NAME>
+spec:
+  authorities:
+  - static:
+      action: fail
+```
+
+A sample output of static action `fail`:
+
+```
+error: failed to patch: admission webhook "policy.sigstore.dev" denied the request: validation failed: failed policy: <POLICY_NAME>: spec.template.spec.containers[0].image
+<IMAGE_REFERENCE> disallowed by static policy
+failed policy: <POLICY_NAME>: spec.template.spec.containers[1].image
+<IMAGE_REFERENCE> disallowed by static policy
+```
+
+Images that are unsigned in a namespace with validation enabled can be admitted with an authority with static action `pass`.
+
+A scenario where this is desirable would be configuring a policy with `static.action` `pass` for `tap-packages` images while another policy is configured to validate signed images produced by Tanzu Build Service. This will allow images from `tap-packages`, which are currently unsigned and required by the platform, while validating signed built images.
+
+If `Warning` messages are desirable for admitted images where validation failed, it is possible to configure a policy with `warn` mode and valid authorities.
+For information on ClusterImagePolicy modes, see the [Mode](#cip-mode) documentation.
+
 ## <a id='provide-creds-for-package'></a> Provide credentials for the package
 
 There are three ways the package reads credentials to authenticate to registries


### PR DESCRIPTION
This is for TAP 1.3.0

- Added release notes (features, version update, resolved issues)
- Added documentation on `static.action` `pass` and `fail` authorities
- Added documentation on `mode`s `warn` and `enforce`.