### PR TITLE
Match docs to actual parameters

### DIFF
--- a/scc/install-ootb-sc-basic.hbs.md
+++ b/scc/install-ootb-sc-basic.hbs.md
@@ -114,8 +114,8 @@ To install Out of the Box Supply Chain Basic:
       server_address: https://github.com/
       repository_owner: vmware-tanzu
       branch: main
-      user_name: supplychain
-      user_email: supplychain
+      username: supplychain
+      email: supplychain
       commit_message: supplychain@cluster.local
       ssh_secret: git-ssh
       commit_strategy: direct

--- a/scc/install-ootb-sc-wtest-scan.hbs.md
+++ b/scc/install-ootb-sc-wtest-scan.hbs.md
@@ -153,8 +153,8 @@ To install Out of the Box Supply Chain with Testing and Scanning:
       server_address: https://github.com/
       repository_owner: vmware-tanzu
       branch: main
-      user_name: supplychain
-      user_email: supplychain
+      username: supplychain
+      email: supplychain
       commit_message: supplychain@cluster.local
       ssh_secret: git-ssh
       commit_strategy: direct

--- a/scc/install-ootb-sc-wtest.hbs.md
+++ b/scc/install-ootb-sc-wtest.hbs.md
@@ -145,8 +145,8 @@ Install by following these steps:
       server_address: https://github.com/
       repository_owner: vmware-tanzu
       branch: main
-      user_name: supplychain
-      user_email: supplychain
+      username: supplychain
+      email: supplychain
       commit_message: supplychain@cluster.local
       ssh_secret: git-ssh
       commit_strategy: direct


### PR DESCRIPTION
TAP does not read the fields gitops.user_name or gitops.user_email This replaces those references with the proper TAP values gitops.username and gitops.email

Which other branches should this be merged with (if any)?
