### PR TITLE
Update tap docs and release notes for new contour default

### DIFF
--- a/cert-mgr-contour-fcd/install-cert-mgr.hbs.md
+++ b/cert-mgr-contour-fcd/install-cert-mgr.hbs.md
@@ -301,9 +301,15 @@ To install Contour from the Tanzu Application Platform package repository:
             infrastructure_provider: aws
         ```
 
-        The LoadBalancer type is appropriate for most installations, but local clusters
-        such as `kind` or `minikube` can fail to complete the package install if LoadBalancer
-        services are not supported.
+        The LoadBalancer type is appropriate for most installations, but local
+        clusters such as `kind` or `minikube` can fail to complete the package
+        install if LoadBalancer services are not supported.
+        
+        For local clusters, you can configure `contour.evnoy.service.type` to be
+        `NodePort`.  Depending on your cluster set up, you may also need
+        configure `envoy.service.nodePorts.http` and
+        `envoy.service.nodePorts.https` to match the port mappings from your
+        local machine into one of the nodes of your local cluster.
 
         Contour provides an Ingress implementation by default. If you have another Ingress
         implementation in your cluster, you must explicitly specify an

--- a/cert-mgr-contour-fcd/install-cert-mgr.hbs.md
+++ b/cert-mgr-contour-fcd/install-cert-mgr.hbs.md
@@ -306,10 +306,12 @@ To install Contour from the Tanzu Application Platform package repository:
         install if LoadBalancer services are not supported.
         
         For local clusters, you can configure `contour.evnoy.service.type` to be
-        `NodePort`.  Depending on your cluster set up, you may also need
-        configure `envoy.service.nodePorts.http` and
-        `envoy.service.nodePorts.https` to match the port mappings from your
-        local machine into one of the nodes of your local cluster.
+        `NodePort`. If your local cluster is set up with extra port mappings on
+        the nodes, you may also need configure `envoy.service.nodePorts.http`
+        and `envoy.service.nodePorts.https` to match the port mappings from your
+        local machine into one of the nodes of your local cluster. This pattern
+        is seen when using the [Learning Center on
+        Kind](../learning-center/local-install-guides/deploying-to-kind.hbs.md).
 
         Contour provides an Ingress implementation by default. If you have another Ingress
         implementation in your cluster, you must explicitly specify an

--- a/learning-center/local-install-guides/deploying-to-kind.hbs.md
+++ b/learning-center/local-install-guides/deploying-to-kind.hbs.md
@@ -59,6 +59,8 @@ If you have created a contour ingress controller, verify all pods have a running
 kubectl get pods -n projectcontour -o wide
 ```
 
+For information on installing the Contour that comes with TAP, see [here](../../cert-mgr-contour-fcd/install-cert-mgr.hbs.md#a-idinstall-contourainstall-contour).
+
 ## <a id="install-carvel-tools"></a> Install carvel tools
 
 You must install the kapp controller and secret-gen controller carvel tools in order to properly install VMware tanzu packages.

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -265,8 +265,7 @@ This release has the following known issues, listed by area and component.
 
 #### <a id="tap-known-issues"></a>Tanzu Application Platform
 
-- Known issue 1
-- Known issue 2
+- New default Contour configuration causes ingress on Kind cluster on Mac to break. The config value `contour.envoy.service.type` now defaults to `LoadBalancer`. For more information, see [Troubleshooting Install Guide](troubleshooting-tap/troubleshoot-install-tap.hbs.md#a-idcontour-error-kinda-ingress-is-broken-on-kind-cluster).
 
 #### <a id="alv-known-issues"></a>Application Live View
 

--- a/troubleshooting-tap/troubleshoot-install-tap.hbs.md
+++ b/troubleshooting-tap/troubleshoot-install-tap.hbs.md
@@ -279,3 +279,23 @@ VMware Tanzu Network before accepting the relevant EULA in VMware Tanzu Network.
 
 Follow the steps in [Accept the End User License Agreements](../install-tanzu-cli.md#accept-eulas) in
 _Installing the Tanzu CLI_.
+
+## <a id='contour-error-kind'></a> Ingress is broken on Kind cluster
+
+Your the Contour installation cannot provide ingress to workloads when installed on a Kind cluster without a loadbalancer solution.
+Your Kind cluster was created with port mappings, as described in the [Kind install guide](../learning-center/local-install-guides/deploying-to-kind.hbs.md).
+
+**Explanation**
+
+In TAP 1.3.0, the default configuration for `contour.envoy.service.type` now
+defaults to `LoadBalancer`. However, in order to for the Envoy pods to be
+accessed through the port mappings on your Kind cluster, the service must be of
+type `NodePort`.
+
+**Solution**
+
+Configure `contour.evnoy.service.type` to be `NodePort`. Then, configure
+`envoy.service.nodePorts.http` and `envoy.service.nodePorts.https` to the
+corresponding port mappings on your Kind node. Otherwise, the NodePort service
+will be assigned random ports, which won't be accessible through your Kind
+cluster.

--- a/troubleshooting-tap/troubleshoot-install-tap.hbs.md
+++ b/troubleshooting-tap/troubleshoot-install-tap.hbs.md
@@ -282,13 +282,13 @@ _Installing the Tanzu CLI_.
 
 ## <a id='contour-error-kind'></a> Ingress is broken on Kind cluster
 
-Your the Contour installation cannot provide ingress to workloads when installed on a Kind cluster without a loadbalancer solution.
+Your Contour installation cannot provide ingress to workloads when installed on a Kind cluster without a loadbalancer solution.
 Your Kind cluster was created with port mappings, as described in the [Kind install guide](../learning-center/local-install-guides/deploying-to-kind.hbs.md).
 
 **Explanation**
 
 In TAP 1.3.0, the default configuration for `contour.envoy.service.type` now
-defaults to `LoadBalancer`. However, in order to for the Envoy pods to be
+defaults to `LoadBalancer`. However, in order for the Envoy pods to be
 accessed through the port mappings on your Kind cluster, the service must be of
 type `NodePort`.
 


### PR DESCRIPTION
* a default parameter in TAP for Contour has changed in TAP 1.3.0, which can cause some issues when installing on Kind

Which other branches should this be merged with (if any)?
