### PR TITLE
Update sample command to setup CLUSTER_CA_CERTIFICATES

### DIFF
--- a/tap-gui/cluster-view-setup.hbs.md
+++ b/tap-gui/cluster-view-setup.hbs.md
@@ -153,7 +153,7 @@ To do so:
 API server. To do this, discover `CLUSTER_CA_CERTIFICATES` by running:
 
     ```console
-    CLUSTER_CA_CERTIFICATES=$(kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
+    CLUSTER_CA_CERTIFICATES=$(kubectl config view --raw -o jsonpath='{.clusters[?(@.name=="**PROVIDE CLUSTER NAME**")].cluster.certificate-authority-data}')
 
     echo CLUSTER_CA_CERTIFICATES: $CLUSTER_CA_CERTIFICATES
     ```


### PR DESCRIPTION
instead of assuming the run cluster being configured is at index 0, the updated command will grab the CA data from the correct cluster by specifying the cluster name

Which other branches should this be merged with (if any)?
