### PR TITLE
VSEE-739 Added notes about private source scan template not being ins…

### DIFF
--- a/scst-scan/install-scst-scan.hbs.md
+++ b/scst-scan/install-scst-scan.hbs.md
@@ -189,6 +189,8 @@ To install Supply Chain Security Tools - Scan (Scan controller):
       targetSourceSshSecret      <EMPTY>  string  Reference to the secret containing SSH credentials for cloning private repositories.
     ```
 
+**NOTE:** If `targetSourceSshSecret` is not set, then the private source scan template will not be installed.
+
 1. Install the package by running:
 
     ```console

--- a/scst-scan/observing.hbs.md
+++ b/scst-scan/observing.hbs.md
@@ -93,6 +93,12 @@ kubectl rollout restart deployment scan-link-controller-manager -n scan-link-sys
 
 ### <a id="troubleshooting-issues"></a> Troubleshooting issues
 
+#### <a id="miss-src-ps"></a> Missing target SSH secret
+
+Scanning source code from a private source repository requires an SSH secret to be present in the namespace and referenced as `grype.targetSourceSshSecret` in `tap-values.yaml`. See [Installing the Tanzu Application Platform Package and Profiles](../install.md).
+
+If a private source scan is triggered and the secret cannot be found, the scan pod will include a `FailedMount` Warning in Events with the message `MountVolume.SetUp failed for volume "ssh-secret" : secret "secret-ssh-auth" not found`, where `secret-ssh-auth` will be the value specified in `grype.targetSourceSshSecret`.
+
 #### <a id="miss-img-ps"></a> Missing target image pull secret
 
 Scanning an image from a private registry requires an image pull secret to exist in the Scan CRs namespace and be referenced as `grype.targetImagePullSecret` in `tap-values.yaml`. See [Installing the Tanzu Application Platform Package and Profiles](../install.md).


### PR DESCRIPTION
…talled if ssh secret has not been configured. Added troubleshooting info if ssh secret configured but cannot find secret during runtime.

Which other branches should this be merged with (if any)?
none