### PR TITLE
update pod intent labels

### DIFF
--- a/spring-boot-conventions/reference/CONVENTIONS.hbs.md
+++ b/spring-boot-conventions/reference/CONVENTIONS.hbs.md
@@ -440,12 +440,12 @@ When you apply the `Pod Intent` and the image contains a dependency, for example
 output of the convention is:
 
 ```yaml
-  apiVersion: conventions.apps.tanzu.vmware.com/v1alpha1
+  apiVersion: conventions.carto.run/v1alpha1
   kind: PodIntent
   metadata:
     annotations:
       kubectl.kubernetes.io/last-applied-configuration: |
-        {"apiVersion":"conventions.apps.tanzu.vmware.com/v1alpha1","kind":"PodIntent","metadata":{"annotations":{},"name":"spring-sample","namespace":"default"},"spec":{"template":{"spec":{"containers":[{"image":"springio/petclinic","name":"workload"}]}}}}
+        {"apiVersion":"conventions.carto.run/v1alpha1","kind":"PodIntent","metadata":{"annotations":{},"name":"spring-sample","namespace":"default"},"spec":{"template":{"spec":{"containers":[{"image":"springio/petclinic","name":"workload"}]}}}}
     creationTimestamp: "..."
     generation: 1
     name: spring-sample
@@ -475,7 +475,7 @@ output of the convention is:
         annotations:
           boot.spring.io/actuator: http://:8080/actuator
           boot.spring.io/version: 2.3.3.RELEASE
-          conventions.apps.tanzu.vmware.com/applied-conventions: |-
+          conventions.carto.run/applied-conventions: |-
             spring-boot-convention/spring-boot
             spring-boot-convention/spring-boot-web
             spring-boot-convention/spring-boot-actuator


### PR DESCRIPTION
For  `PodIntent` we expect applied conventions to reference the group `conventions.carto.run` 
```metadata:
  annotations:
    apps.tanzu.vmware.com/debug: "true"
    apps.tanzu.vmware.com/live-update: "true"
    autoscaling.knative.dev/maxScale: "1"
    autoscaling.knative.dev/minScale: "1"
    boot.spring.io/version: 2.7.3
    conventions.carto.run/applied-conventions: |-
      developer-conventions/debug-convention
      developer-conventions/live-update-convention
      developer-conventions/add-source-image-label
      spring-boot-convention/spring-boot
      spring-boot-convention/spring-boot-web
      spring-boot-convention/service-intent-rabbitmq
      appliveview-sample/app-live-view-appflavour-check
    developer.apps.tanzu.vmware.com/image-source-digest: dev.registry.pivotal.io/app-live-view/test/kdv-smtp-gateway-source:latest@sha256:7ec4eb40b3e8fba7a4e63455f90e4e917301fc382e14f77b5a25765d8da747d2
    developer.conventions/target-containers: workload
    kubernetes.io/psp: eks.privileged
    services.conventions.apps.tanzu.vmware.com/rabbitmq: amqp-client/5.14.2
 ...
    services.conventions.apps.tanzu.vmware.com/rabbitmq: workload
```
and the API group  resource to be `conventions.carto.run`

```
apiVersion: conventions.carto.run/v1alpha1
  kind: PodIntent
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"conventions.carto.run/v1alpha1","kind":"PodIntent","metadata":{"annotations":{},"name":"spring-sample","namespace":"default"},"spec":{"template":{"spec":{"containers":[{"image":"springio/petclinic","name":"workload"}]}}}}
    creationTimestamp: "..."
```