### PR TITLE
Exclude image policy webhook

### DIFF
--- a/about-package-profiles.hbs.md
+++ b/about-package-profiles.hbs.md
@@ -114,6 +114,13 @@ Tanzu Application Platform is a modular, composable platform that comprises the 
   This is an established industry best practice for reducing security risk and ensuring more
   efficient remediation.
 
+- **[Supply Chain Security Tools - Sign (Deprecated)](scst-sign/overview.md)**
+
+  Supply Chain Security Tools - Sign provides an admission controller that allows a cluster operator
+  to specify a policy that allows or denies images from running based on signature verification
+  against public keys. It works with
+  [cosign signature format](https://github.com/sigstore/cosign#quick-start) and allows for fine-tuned
+  configuration based on image source patterns.
 
 - **[Supply Chain Security Tools - Policy Controller](scst-policy/overview.md)**
 
@@ -173,12 +180,12 @@ Tanzu Application Platform is a modular, composable platform that comprises the 
   Tekton is a powerful and flexible open-source framework for creating CI/CD systems, enabling
   developers to build, test, and deploy across cloud providers and on-premise systems.
 
-- **[Tanzu Application Platform Telemetry](telemetry/overview.hbs.md)** 
+- **[Tanzu Application Platform Telemetry](telemetry/overview.hbs.md)**
 
-  Tanzu Application Platform Telemetry is a set of objects that collect data about the usage of Tanzu Application Platform and send it back to VMware for product improvements. A benefit of remaining enrolled in telemetry and identifying your company during Tanzu Application Platform installation is that VMware can provide your 
+  Tanzu Application Platform Telemetry is a set of objects that collect data about the usage of Tanzu Application Platform and send it back to VMware for product improvements. A benefit of remaining enrolled in telemetry and identifying your company during Tanzu Application Platform installation is that VMware can provide your
   organization with usage reports about Tanzu Application Platform. See [Tanzu Application Platform usage reports](telemetry/overview.hbs.md#usage-reports) for more information about enrolling in telemetry reports.
 
-  >**Note:** You can opt out of telemetry collection by following the 
+  >**Note:** You can opt out of telemetry collection by following the
   instructions in [Opting out of telemetry collection](opting-out-telemetry.hbs.md).
 
 ## <a id='profiles-and-packages'></a> Installation profiles in Tanzu Application Platform v1.3
@@ -487,20 +494,6 @@ The following table lists the packages contained in each profile:
    </td>
   </tr>
   <tr>
-   <td>Policy Controller
-   </td>
-   <td>&check;
-   </td>
-   <td>&check;
-   </td>
-   <td>
-   </td>
-   <td>&check;
-   </td>
-   <td>
-   </td>
-  </tr>
-  <tr>
    <td>Service Bindings
    </td>
    <td>&check;
@@ -594,6 +587,20 @@ The following table lists the packages contained in each profile:
    <td>&check;
    </td>
    <td>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Supply Chain Security Tools - Sign (deprecated)
+   </td>
+   <td>&check;
+   </td>
+   <td>&check;
+   </td>
+   <td>
+   </td>
+   <td>&check;
    </td>
    <td>
    </td>

--- a/install.hbs.md
+++ b/install.hbs.md
@@ -356,6 +356,19 @@ excluded_packages:
 
 See [Exclude packages from a Tanzu Application Platform profile](#exclude-packages) for more information.
 
+### <a id='exclude-ipw'></a> (Optional) Exclude Image Policy Webhook
+
+Image Policy Webhook has been deprecated and will be removed in TAP v1.4.0. To exclude this package, update your `tap-values` file with a section listing the exclusion:
+
+```yaml
+...
+excluded_packages:
+  - image-policy-webhook.signing.apps.tanzu.vmware.com
+...
+```
+
+See [Exclude packages from a Tanzu Application Platform profile](#exclude-packages) for more information.
+
 ## <a id="install-package"></a>Install your Tanzu Application Platform package
 
 Follow these steps to install the Tanzu Application Platform package:

--- a/scst-policy/migration.hbs.md
+++ b/scst-policy/migration.hbs.md
@@ -191,3 +191,27 @@ spec:
   images:
   - glob: gcr.io/projectsigstore/cosign*
 ```
+
+## <a id="uninstall-ipw"></a> Uninstall Image Policy Webhook
+
+After Policy Controller has been correctly configured and you have verified that
+is working as expected, you can proceed to uninstall the Image Policy Webhook:
+
+
+```console
+tanzu package installed delete image-policy-webhook --namespace tap-install
+```
+
+If you installed Image Policy Webhook using a profile, exclude it using your
+`tap-values.yaml` file:
+
+```yaml
+excluded_packages:
+  - image-policy-webhook.signing.apps.tanzu.vmware.com
+```
+
+Then update your TAP installation:
+
+```console
+tanzu package installed update tap -n tap-install --values-file tap-values.yaml
+```


### PR DESCRIPTION
Which other branches should this be merged with (if any)?
This change is intended for TAP 1.3.0 and 1.2.2.