### PR TITLE
docs: Update supply chain docs to include the new maven flags

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -58,7 +58,6 @@ This release includes the following changes, listed by component and area.
 
 #### <a id="apps-plugin"></a> Tanzu CLI - Apps plug-in
 
-
 - `tanzu apps *` improvements:
   - auto-complete now works for all sub-command names and their positional argument values, flag names, and flag values.
 - `tanzu apps workload create/apply` improvements:
@@ -96,11 +95,6 @@ This release includes the following changes, listed by component and area.
 - Added routine to reset `ImageRepository` condition status between reconciles.
 - Added support for OpenShift.
 - Added support for Kubernetes 1.24.
-
-#####<a id="src-cont-bugfixes"></a>Bug Fixes
-
-- Added checks to ensure SNAPSHOT has versioning enabled.
-- Fixed resource status conditions when metadata or metadata element is not found.
 
 #### <a id="snyk-scanner"></a> Snyk Scanner (beta)
 
@@ -240,6 +234,11 @@ This release has the following breaking changes, listed by area and component.
 - When creating a workload from local source in Windows, the image was created with unstructured directories and flattened all file names. This is now fixed with an `imgpkg` upgrade.
 - When uploading a source image, if the namespace provided is not valid or doesn't exist, the image isn't uploaded and the workload isn't created.
 - Due to a Tanzu Framework upgrade, the autocompletion for flag names in all commands is now working.
+
+#### <a id="source-controller-resolved"></a> Source Controller
+
+- Added checks to ensure SNAPSHOT has versioning enabled.
+- Fixed resource status conditions when metadata or metadata element is not found.
 
 #### <a id="srvc-toolkit-resolved"></a> Services Toolkit
 

--- a/scc/building-from-source.hbs.md
+++ b/scc/building-from-source.hbs.md
@@ -482,9 +482,21 @@ spec:
       classifier: sources   # optional
 ```
 
-The `tanzu` CLI is used for creating workloads that define Maven artifacts as source.
+There are two ways to create a workload that defines a specific version of a maven artifact as source in the `tanzu` CLI.
 
-To create a workload that defines a specific version of a maven artifact as source, run:
+The first way would be defining the source through CLI flags, such as this:
+
+```bash
+tanzu apps workload apply my-workload \
+      --maven-artifact springboot-initial \
+      --maven-version 2.6.0 \
+      --maven-group com.example \
+      --type web --app spring-boot-initial -y
+```
+
+Another flag that can be used alongside the others in this type of command is `--maven-type`, which refers to the maven packaging type and defaults to `jar` if not specified.
+
+The second one is through complex params (in JSON or YAML format). To specify the maven info with this method, run:
 
 ```bash
 tanzu apps workload apply my-workload \
@@ -501,8 +513,7 @@ tanzu apps workload apply my-workload \
 ```
 
 The Maven repository URL and required credentials are defined in the supply
-chain, not the workload. For more information, see [Installing OOTB
-Basic](install-ootb-sc-basic.md).
+chain, not the workload. For more information, see [Installing OOTB Basic](./install-ootb-sc-basic.hbs.md).
 
 ### <a id="maven-repository-secret"></a> Maven Repository Secret
 


### PR DESCRIPTION
Which other branches should this be merged with (if any)?
Just for TAP v1.3
