### PR TITLE
Fix the header links

### DIFF
--- a/api-auto-registration/about.hbs.md
+++ b/api-auto-registration/about.hbs.md
@@ -9,6 +9,8 @@ A Kubernetes controller will reconcile the CR and update the API entity in TAP G
 registration from origin workloads. You may also use API Auto Registration without supply chain automation with other GitOps 
 processes or by directly applying an `APIDescriptor` CR to the cluster.
 
+![API Auto Registration](./images/autoregistering-api-entities-stages.png)
+
 ## <a id='getting-started'></a> Getting Started
 
 Learn more about APIDescriptor CR and API entities in TAP GUI in the [Key Concepts section](key-concepts.md)

--- a/api-auto-registration/key-concepts.hbs.md
+++ b/api-auto-registration/key-concepts.hbs.md
@@ -34,7 +34,7 @@ Many of the above fields will result in specific behavior within TAP GUI.
 - To explicitly use a system or owner in a different namespace, you can specify that in the respective field `system: my-namespace/my-other-system` or `owner: my-namespace/my-other-team`.
 - If the system or owner you are trying to link doesn't have explicit namespace specified, you can qualify them with `default` namespace, e.g.: `system: default/my-default-system`
 
-### <a id='absolute-url'></a>With an Absolute URL
+## <a id='absolute-url'></a>With an Absolute URL
 
 To create an APIDescriptor with a static `baseURL.url`, you need to apply the following yaml to your cluster.
 
@@ -54,11 +54,11 @@ spec:
       url: https://myservice.com
 ```
 
-### <a id='with-ref'></a>With an Object Ref
+## <a id='with-ref'></a>With an Object Ref
 
 You can also use an object reference instead of hard coding the url. This can point to a HTTPProxy, Knative Service, or Ingress.
 
-#### <a id='with-httpproxy-ref'></a>With an HTTPPRoxy Object Ref
+### <a id='with-httpproxy-ref'></a>With an HTTPPRoxy Object Ref
 
 Below is an example yaml that points to an HTTPProxy from which our controller extracts the `.spec.virtualhost.fqdn` as the baseURL.
 
@@ -82,7 +82,7 @@ spec:
         namespace: my-namespace # optional
 ```
 
-#### <a id='with-knative-ref'></a>With a Knative Service Object Ref
+### <a id='with-knative-ref'></a>With a Knative Service Object Ref
 
 If you want to use a Knative Service instead, here is an example from which our controller reads the `status.url` as the baseURL
 
@@ -96,7 +96,7 @@ If you want to use a Knative Service instead, here is an example from which our 
         namespace: my-namespace # optional
 ```
 
-#### <a id='with-ingress-ref'></a>With an Ingress Object Ref
+### <a id='with-ingress-ref'></a>With an Ingress Object Ref
 
 If you want to use an Ingress instead, here is an example from which our controller reads the URL from the jsonPath specified. When jsonPath is left empty, our controller will read the `"{.spec.rules[0].host}"` as the URL
 

--- a/api-auto-registration/usage.hbs.md
+++ b/api-auto-registration/usage.hbs.md
@@ -49,14 +49,11 @@ How to create APIDescriptor CR
     --values-file api-auto-registration-values.yaml
 
 ## <a id='using-app-accelerator-template'></a>Using App Accelerator Template
-
-
 If you are creating a new application exposing an API, you might use the ["java-rest-service"](https://github.com/vmware-tanzu/application-accelerator-samples/tree/main/java-rest-service)
 App Accelerator template to get an out-of-the-box app that includes an already written workload.yaml with a basic REST API.
 From your Tanzu Application Platform GUIs Accelerators tab, you can search for the accelerator and scaffold it according to your needs.
 
 ## <a id='using-ootb-supply-chain'></a>Using Out Of The Box (OOTB) Supply Chains
-
 All the Out-Of-The-Box (OOTB) supply chains have been modified so that they can utilize API Auto Registration. If you want your Workload to be auto registered, you need to make a couple of modifications to your workload yaml as described below
 
 1. Add the label `apis.apps.tanzu.vmware.com/register-api: "true"`.
@@ -147,7 +144,6 @@ The APIDescriptor will need all the required fields to successfully reconcile.
 For more info on APIDescriptors, check out the [Key Concepts section](key-concepts.md).
 
 ## <a id='cors'></a>Setting up CORS for OpenAPI specs
-
 The agent, usually a browser, uses the [CORS](https://fetch.spec.whatwg.org/#http-cors-protocol) protocol to verify whether the current origin uses an API. 
 To use the Try it out feature for OpenAPI specifications from the API Docs plug-in<, you must configure CORS to allow successful requests. 
 Your API must be configured to allow CORS Requests from Tanzu Application Platform GUI. How you accomplish this varies based on the programming language and framework you are using. 


### PR DESCRIPTION
Any ideas why the "Using App Accelerator Template" header [in this page](https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Application-Platform/1.3/tap/GUID-api-auto-registration-usage.html) is not being formatted correctly? I don't see any syntax error.