### PR TITLE
fixing incorrect recommendation to use annotation

### DIFF
--- a/workloads/web.hbs.md
+++ b/workloads/web.hbs.md
@@ -30,7 +30,7 @@ Applications using the `web` workload type have the following features:
 When creating a workload with `tanzu apps workload create`, you can use the
 `--type=web` argument to select the `web` workload type.
 For more information, see the [Use the `web` Workload Type](#using) later in this topic.
-You can also use the `apps.tanzu.vmware.com/workload-type:web` annotation in the
+You can also use the `apps.tanzu.vmware.com/workload-type:web` label in the
 YAML workload description to support this deployment type.
 
 ## <a id="using"></a> Use the `web` workload type


### PR DESCRIPTION
The workload type is set via label. Setting an annotation will not work.

Which other branches should this be merged with (if any)?

This change should be applied as far back as this file existed in a Docs-tap TAP release.
In other words - an annotation has never been used to set the workload type. It's always been a label.