### PR TITLE
Remove the Migrate from 1.3.0 Docs

### DIFF
--- a/migrate-profile.hbs.md
+++ b/migrate-profile.hbs.md
@@ -52,4 +52,4 @@ To complete the Tanzu Application Platform profile migration, do the following:
 tanzu package installed update tap -p tap.tanzu.vmware.com -v TAP-VERSION  --values-file tap-values.yaml -n tap-install
 ```
 
-Where `TAP-VERSION` is your Tanzu Application Platform version. For example, `{{ vars.tap_version }}`.
+Where `TAP-VERSION` is your Tanzu Application Platform version. For example, `{{ vars.tap_version }}` .


### PR DESCRIPTION
I am not sure on how to remove all the references to migrate documentation from TAP Docs. Hence creating this PR to request for the removal.

Which other branches should this be merged with (if any)?
Docs for 1.2 as well should not have the migration documents. It was supposed only in TAP 1.1 when the new profiles were introduced to support for the customers to migrate from light to iterate profile after an upgrade from TAP 1.0 to 1.1.