### PR TITLE
Add AWS Install Documents

### DIFF
--- a/aws/aws-resources.hbs.md
+++ b/aws/aws-resources.hbs.md
@@ -1,0 +1,305 @@
+# Creating AWS Resources for Tanzu Application Platform
+
+To install the Tanzu Application Platform within the AWS Ecosystem, several AWS resources need to be created.  This guide will walk you through creating the following resources:
+
+- An EKS Cluster to install Tanzu Application Platform
+- IAM Roles to allow authentication and authorization to read and write from ECR
+- ECR Repositories for the Tanzu Application Platform container images
+
+Creating these resources will enable the Tanzu Application Platform to use an [IAM role bound to a Kubernetes service account](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) for authentication rather than the typical username and password stored in a kubernetes secret strategy.  This is important when using the Elastic Container Registry (ECR) because authenticating to ECR is a two step process:  
+
+1. Retrieve a token using your AWS credentials
+1. Use the token to authenticate to the registry  
+
+To increase security posture, the token has a lifetime of 12 hours.  This makes storing it as a secret for a service impracticle, as it would have to be refereshed every 12 hours.
+
+Leveraging an IAM role on a service account mitigates the need to retrieve the token at all, as it is handled by credential helpers within the services.
+
+# Prerequisites
+
+## AWS Account
+
+We will be creating all of our resources within Amazon Web Services, so therefore we will need an Amazon account.
+
+To create an Amazon account, use the [following guide](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/).
+
+Note that you will need your account ID during the guide.
+
+## AWS CLI
+
+This walkthrough will use the AWS CLI to both query and configure resources in AWS such as IAM roles.
+
+To install the AWS CLI, use the [following guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
+
+## EKSCTL
+
+The EKSCTL command line makes managing the lifecycle of EKS clusters very simple.  This guide will use it to create clusters.
+
+To install the eksctl cli, use the [following guide](https://eksctl.io/introduction/#installation).
+
+# Export Environment Variables
+
+Some variables are used throughout the guide, to simplify the process and minimize the opportunity for errors, let's export these variables.
+
+```
+export AWS_ACCOUNT_ID=012345678901
+export AWS_REGION=us-west-2
+export EKS_CLUSTER_NAME=tap-on-aws
+```
+
+Where:
+
+| Variable | Description |
+| -------- | ----------- |
+| AWS_ACCOUNT_ID | Your AWS account ID |
+| AWS_REGION | The AWS region you are going to deploy to |
+| EKS_CLUSTER_NAME | The name of your EKS Cluster |
+
+
+# Create an EKS Cluster
+
+Create an EKS cluster in the specified region using the following command.  Creating the control plane and node group can take  take anywhere from 30-60 minutes. 
+
+```
+eksctl create cluster --name $EKS_CLUSTER_NAME --managed --region $AWS_REGION --instance-types t3.large --version 1.22 --with-oidc -N 5
+```
+
+Note: This step is optional if you already have an existing EKS Cluster.  Note, however that it has to be at least version 1.22 and have the OIDC authentication enabled.  To enable the OIDC provider, use the [following guide](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html).
+
+# Create the Container Repositories
+
+ECR requires the container repositories to be precreated.
+
+For the Tanzu Application Platform, we need to create two repositories.
+
+- A repository to store the Tanzu Application Platform service container images
+- A repository to store Tanzu Build Service Base OS and Buildpack container images
+
+To create these repositories, run the following commands:
+
+```
+aws ecr create-repository --repository-name tap-images --region $AWS_REGION
+aws ecr create-repository --repository-name tap-build-service --region $AWS_REGION
+```
+
+You can name the repositories any name you would like, just note them for when we build the configuration later.
+
+# Create IAM Roles
+
+By default, the EKS cluster will be provisioned with an [EC2 instance profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) that provides read-only access for the entire EKS cluster to the ECR registery within your AWS account.
+
+However, some of the services within the Tanzu Application Platform require write access to the container repositories. In order to provide that access, we will create IAM roles and add the ARN to the K8S service accounts that those services use.  This will ensure that only the required services have access to write container images to ECR, rather than a blanket policy that applies to the entire cluster.
+
+We'll create two IAM Roles.
+
+1.  Tanzu Build Service: Gives write access to the repository to allow the service to automatically upload new images.  This is limited in scope to the service account for kpack and the dependency updater.
+2.  Workload:  Gives write access to the entire ECR registry with a prepended path.  This prevents you from having to update the policy for each new workload created.  
+
+In order to create the roles, we need to establish two policys:
+
+1. Trust Policy: Limits the scope to the OIDC endpoint for the Kubernetes Cluster and the Kubernetes service account we'll attach the role to
+1. Permission Policy:  Limits the scope of what actions can be taken on what resources by the role.  
+
+**Note** Both of these policies are best effort at a least privledge model, but be sure to review to ensure if they adhere to your organizations policies.
+
+In order to simplify this guide, we'll use a script to create these policy documents and create the roles.  This script will output the files, then create the IAM roles using the policy documents.  
+
+To run the script, do the following:
+
+```console
+oidcProvider=$(aws eks describe-cluster --name $EKS_CLUSTER_NAME --region $AWS_REGION | jq '.cluster.identity.oidc.issuer' | tr -d '"' | sed 's/https:\/\///')
+cat << EOF > build-service-trust-policy.json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/${oidcProvider}"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringEquals": {
+                    "${oidcProvider}:aud": "sts.amazonaws.com"
+                },
+                "StringLike": {
+                    "${oidcProvider}:sub": [
+                        "system:serviceaccount:kpack:controller",
+                        "system:serviceaccount:build-service:dependency-updater-controller-serviceaccount"
+                    ]
+                }
+            }
+        }
+    ]
+}
+EOF
+
+cat << EOF > build-service-policy.json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "ecr:DescribeRegistry",
+                "ecr:GetAuthorizationToken",
+                "ecr:GetRegistryPolicy",
+                "ecr:PutRegistryPolicy",
+                "ecr:PutReplicationConfiguration",
+                "ecr:DeleteRegistryPolicy"
+            ],
+            "Resource": "*",
+            "Effect": "Allow",
+            "Sid": "TAPEcrBuildServiceGlobal"
+        },
+        {
+            "Action": [
+                "ecr:DescribeImages",
+                "ecr:ListImages",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:BatchGetImage",
+                "ecr:BatchGetRepositoryScanningConfiguration",
+                "ecr:DescribeImageReplicationStatus",
+                "ecr:DescribeImageScanFindings",
+                "ecr:DescribeRepositories",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:GetLifecyclePolicy",
+                "ecr:GetLifecyclePolicyPreview",
+                "ecr:GetRegistryScanningConfiguration",
+                "ecr:GetRepositoryPolicy",
+                "ecr:ListTagsForResource",
+                "ecr:TagResource",
+                "ecr:UntagResource",
+                "ecr:BatchDeleteImage",
+                "ecr:BatchImportUpstreamImage",
+                "ecr:CompleteLayerUpload",
+                "ecr:CreatePullThroughCacheRule",
+                "ecr:CreateRepository",
+                "ecr:DeleteLifecyclePolicy",
+                "ecr:DeletePullThroughCacheRule",
+                "ecr:DeleteRepository",
+                "ecr:InitiateLayerUpload",
+                "ecr:PutImage",
+                "ecr:PutImageScanningConfiguration",
+                "ecr:PutImageTagMutability",
+                "ecr:PutLifecyclePolicy",
+                "ecr:PutRegistryScanningConfiguration",
+                "ecr:ReplicateImage",
+                "ecr:StartImageScan",
+                "ecr:StartLifecyclePolicyPreview",
+                "ecr:UploadLayerPart",
+                "ecr:DeleteRepositoryPolicy",
+                "ecr:SetRepositoryPolicy"
+            ],
+            "Resource": [
+                "arn:aws:ecr:${AWS_REGION}:${AWS_ACCOUNT_ID}:repository/tap-build-service",
+                "arn:aws:ecr:${AWS_REGION}:${AWS_ACCOUNT_ID}:repository/tap-images"
+            ],
+            "Effect": "Allow",
+            "Sid": "TAPEcrBuildServiceScoped"
+        }
+    ]
+}
+EOF
+
+cat << EOF > workload-policy.json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "ecr:DescribeRegistry",
+                "ecr:GetAuthorizationToken",
+                "ecr:GetRegistryPolicy",
+                "ecr:PutRegistryPolicy",
+                "ecr:PutReplicationConfiguration",
+                "ecr:DeleteRegistryPolicy"
+            ],
+            "Resource": "*",
+            "Effect": "Allow",
+            "Sid": "TAPEcrWorkloadGlobal"
+        },
+        {
+            "Action": [
+                "ecr:DescribeImages",
+                "ecr:ListImages",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:BatchGetImage",
+                "ecr:BatchGetRepositoryScanningConfiguration",
+                "ecr:DescribeImageReplicationStatus",
+                "ecr:DescribeImageScanFindings",
+                "ecr:DescribeRepositories",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:GetLifecyclePolicy",
+                "ecr:GetLifecyclePolicyPreview",
+                "ecr:GetRegistryScanningConfiguration",
+                "ecr:GetRepositoryPolicy",
+                "ecr:ListTagsForResource",
+                "ecr:TagResource",
+                "ecr:UntagResource",
+                "ecr:BatchDeleteImage",
+                "ecr:BatchImportUpstreamImage",
+                "ecr:CompleteLayerUpload",
+                "ecr:CreatePullThroughCacheRule",
+                "ecr:CreateRepository",
+                "ecr:DeleteLifecyclePolicy",
+                "ecr:DeletePullThroughCacheRule",
+                "ecr:DeleteRepository",
+                "ecr:InitiateLayerUpload",
+                "ecr:PutImage",
+                "ecr:PutImageScanningConfiguration",
+                "ecr:PutImageTagMutability",
+                "ecr:PutLifecyclePolicy",
+                "ecr:PutRegistryScanningConfiguration",
+                "ecr:ReplicateImage",
+                "ecr:StartImageScan",
+                "ecr:StartLifecyclePolicyPreview",
+                "ecr:UploadLayerPart",
+                "ecr:DeleteRepositoryPolicy",
+                "ecr:SetRepositoryPolicy"
+            ],
+            "Resource": [
+                "arn:aws:ecr:${AWS_REGION}:${AWS_ACCOUNT_ID}:repository/tap-build-service",
+                "arn:aws:ecr:${AWS_REGION}:${AWS_ACCOUNT_ID}:repository/tanzu-application-platform/tanzu-java-web-app",
+                "arn:aws:ecr:${AWS_REGION}:${AWS_ACCOUNT_ID}:repository/tanzu-application-platform/tanzu-java-web-app-bundle",
+                "arn:aws:ecr:${AWS_REGION}:${AWS_ACCOUNT_ID}:repository/tanzu-application-platform",
+                "arn:aws:ecr:${AWS_REGION}:${AWS_ACCOUNT_ID}:repository/tanzu-application-platform/*"
+            ],
+            "Effect": "Allow",
+            "Sid": "TAPEcrWorkloadScoped"
+        }
+    ]
+}
+EOF
+
+cat << EOF > workload-trust-policy.json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/${oidcProvider}"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringEquals": {
+                    "${oidcProvider}:sub": "system:serviceaccount:default:default",
+                    "${oidcProvider}:aud": "sts.amazonaws.com"
+                }
+            }
+        }
+    ]
+}
+EOF
+
+
+# Create the Build Service Role
+aws iam create-role --role-name tap-build-service --assume-role-policy-document file://build-service-trust-policy.json
+# Attach the Policy to the Build Role
+aws iam put-role-policy --role-name tap-build-service --policy-name tapBuildServicePolicy --policy-document file://build-service-policy.json
+
+# Create the Workload Role
+aws iam create-role --role-name tap-workload --assume-role-policy-document file://workload-trust-policy.json
+# Attach the Policy to the Workload Role
+aws iam put-role-policy --role-name tap-workload --policy-name tapWorkload --policy-document file://workload-policy.json
+```

--- a/aws/install.hbs.md
+++ b/aws/install.hbs.md
@@ -1,0 +1,412 @@
+# Installing Tanzu Application Platform package and profiles on AWS
+
+This topic describes how to install Tanzu Application Platform packages
+from the Tanzu Application Platform package repository on to AWS.
+
+Before installing the packages, ensure you have:
+
+- Completed the [Prerequisites](../prerequisites.hbs.md).
+- Created [AWS Resources](aws-resources.hbs.md)
+- [Accepted Tanzu Application Platform EULA and installed Tanzu CLI](../install-tanzu-cli.hbs.md) with any required plug-ins.
+- Installed [Cluster Essentials for Tanzu](https://docs.vmware.com/en/Cluster-Essentials-for-VMware-Tanzu/1.2/cluster-essentials/)
+
+## <a id='add-tap-package-repo'></a> Relocate images to a registry
+
+VMware recommends relocating the images from VMware Tanzu Network registry to your own container image registry before
+attempting installation. If you don't relocate the images, Tanzu Application Platform will depend on
+VMware Tanzu Network for continued operation, and VMware Tanzu Network offers no uptime guarantees.
+The option to skip relocation is documented for evaluation and proof-of-concept only.
+
+This guide is for deploying Tanzu Application Platform on Amazon Web Services, so it will specify relocating images to the `tap-images` repository created in [Amazon ECR](https://aws.amazon.com/ecr/) in [Creating AWS Resources](aws-resources.hbs.md) section.
+
+To relocate images from the VMware Tanzu Network registry to the ECR Registry registry:
+
+1. Install Docker if it is not already installed.
+
+1. Log in to your ECR image registry by following the [AWS Guide](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html).  This is a one time copy of images from the VMware Tanzu Network to ECR, so the ECR token expiring in 12 hours is not a concern.
+
+1. Log in to the VMware Tanzu Network registry with your VMware Tanzu Network credentials by running:
+
+    ```console
+    docker login registry.tanzu.vmware.com
+    ```
+
+1. Set up environment variables for installation use by running:
+
+    ```console
+    export AWS_ACCOUNT_ID=MY-AWS-ACCOUNT-ID
+    export AWS_REGION=TARGET-AWS-REGION
+    export TAP_VERSION=VERSION-NUMBER
+    export INSTALL_REGISTRY_HOSTNAME=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+    export INSTALL_REPO=tap-images
+    ```
+
+    Where:
+
+    - `MY-AWS-ACCOUNT-ID` is the account ID you are depoloying Tanzu Application Platform in.  No Dashes.  Should be in the format 012345678901.
+    - `TARGET-AWS-REGION` is the region you are deploying the Tanzu Application Platform to. 
+    - `VERSION-NUMBER` is your Tanzu Application Platform version. For example, `{{ vars.tap_version }}`.
+
+1. [Install the Carvel tool `imgpk` CLI](https://docs.vmware.com/en/Cluster-Essentials-for-VMware-Tanzu/1.2/cluster-essentials/GUID-deploy.html#optionally-install-clis-onto-your-path-6). 
+
+1. Relocate the images with the `imgpkg` CLI by running:
+
+    ```console
+    imgpkg copy --concurrency 1 -b registry.tanzu.vmware.com/tanzu-application-platform/tap-packages:${TAP_VERSION} --to-repo ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}
+    ```
+
+1. Create a namespace called `tap-install` for deploying any component packages by running:
+
+    ```console
+    kubectl create ns tap-install
+    ```
+
+    This namespace keeps the objects grouped together logically.
+
+1. Add the Tanzu Application Platform package repository to the cluster by running:
+
+    ```console
+    tanzu package repository add tanzu-tap-repository \
+      --url ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}:$TAP_VERSION \
+      --namespace tap-install
+    ```
+
+1. Get the status of the Tanzu Application Platform package repository, and ensure the status updates to `Reconcile succeeded` by running:
+
+    ```console
+    tanzu package repository get tanzu-tap-repository --namespace tap-install
+    ```
+
+    For example:
+
+    ```console
+    $ tanzu package repository get tanzu-tap-repository --namespace tap-install
+    - Retrieving repository tap...
+    NAME:          tanzu-tap-repository
+    VERSION:       16253001
+    REPOSITORY:    123456789012.dkr.ecr.us-west-2.amazonaws.com/tap-images
+    TAG:           {{ vars.tap_version }}
+    STATUS:        Reconcile succeeded
+    REASON:
+    ```
+
+    > **Note:** The `VERSION` and `TAG` numbers differ from the earlier example if you are on
+    > Tanzu Application Platform v1.0.2 or earlier.
+
+1. List the available packages by running:
+
+    ```console
+    tanzu package available list --namespace tap-install
+    ```
+
+    For example:
+
+    ```console
+    $ tanzu package available list --namespace tap-install
+    / Retrieving available packages...
+      NAME                                                 DISPLAY-NAME                                                              SHORT-DESCRIPTION
+      accelerator.apps.tanzu.vmware.com                    Application Accelerator for VMware Tanzu                                  Used to create new projects and configurations.
+      apis.apps.tanzu.vmware.com                           API Auto Registration for VMware Tanzu                                    A TAP component to automatically register API exposing workloads as API entities in TAP GUI.
+      api-portal.tanzu.vmware.com                          API portal                                                                A unified user interface to enable search, discovery and try-out of API endpoints at ease.
+      backend.appliveview.tanzu.vmware.com                 Application Live View for VMware Tanzu                                    App for monitoring and troubleshooting running apps
+      connector.appliveview.tanzu.vmware.com               Application Live View Connector for VMware Tanzu                          App for discovering and registering running apps
+      conventions.appliveview.tanzu.vmware.com             Application Live View Conventions for VMware Tanzu                        Application Live View convention server
+      buildservice.tanzu.vmware.com                        Tanzu Build Service                                                       Tanzu Build Service enables the building and automation of containerized software workflows securely and at scale.
+      cartographer.tanzu.vmware.com                        Cartographer                                                              Kubernetes native Supply Chain Choreographer.
+      cnrs.tanzu.vmware.com                                Cloud Native Runtimes                                                     Cloud Native Runtimes is a serverless runtime based on Knative
+      controller.conventions.apps.tanzu.vmware.com         Convention Service for VMware Tanzu                                       Convention Service enables app operators to consistently apply desired runtime configurations to fleets of workloads.
+      controller.source.apps.tanzu.vmware.com              Tanzu Source Controller                                                   Tanzu Source Controller enables workload create/update from source code.
+      developer-conventions.tanzu.vmware.com               Tanzu App Platform Developer Conventions                                  Developer Conventions
+      grype.scanning.apps.tanzu.vmware.com                 Grype Scanner for Supply Chain Security Tools - Scan                      Default scan templates using Anchore Grype
+      image-policy-webhook.signing.apps.tanzu.vmware.com   Image Policy Webhook                                                      The Image Policy Webhook allows platform operators to define a policy that will use cosign to verify signatures of container images
+      learningcenter.tanzu.vmware.com                      Learning Center for Tanzu Application Platform                            Guided technical workshops
+      ootb-supply-chain-basic.tanzu.vmware.com             Tanzu App Platform Out of The Box Supply Chain Basic                      Out of The Box Supply Chain Basic.
+      ootb-supply-chain-testing-scanning.tanzu.vmware.com  Tanzu App Platform Out of The Box Supply Chain with Testing and Scanning  Out of The Box Supply Chain with Testing and Scanning.
+      ootb-supply-chain-testing.tanzu.vmware.com           Tanzu App Platform Out of The Box Supply Chain with Testing               Out of The Box Supply Chain with Testing.
+      ootb-templates.tanzu.vmware.com                      Tanzu App Platform Out of The Box Templates                               Out of The Box Templates.
+      scanning.apps.tanzu.vmware.com                       Supply Chain Security Tools - Scan                                        Scan for vulnerabilities and enforce policies directly within Kubernetes native Supply Chains.
+      metadata-store.apps.tanzu.vmware.com                 Tanzu Supply Chain Security Tools - Store                                 The Metadata Store enables saving and querying image, package, and vulnerability data.
+      service-bindings.labs.vmware.com                     Service Bindings for Kubernetes                                           Service Bindings for Kubernetes implements the Service Binding Specification.
+      services-toolkit.tanzu.vmware.com                    Services Toolkit                                                          The Services Toolkit enables the management, lifecycle, discoverability and connectivity of Service Resources (databases, message queues, DNS records, etc.).
+      spring-boot-conventions.tanzu.vmware.com             Tanzu Spring Boot Conventions Server                                      Default Spring Boot convention server.
+      sso.apps.tanzu.vmware.com                            AppSSO                                                                    Application Single Sign-On for Tanzu
+      tap-gui.tanzu.vmware.com                             Tanzu Application Platform GUI                                            web app graphical user interface for Tanzu Application Platform
+      tap.tanzu.vmware.com                                 Tanzu Application Platform                                                Package to install a set of TAP components to get you started based on your use case.
+      workshops.learningcenter.tanzu.vmware.com            Workshop Building Tutorial                                                Workshop Building Tutorial
+    ```
+
+## <a id='install-profile'></a> Install your Tanzu Application Platform profile
+
+The `tap.tanzu.vmware.com` package installs predefined sets of packages based on your profile settings.
+This is done by using the package manager installed by Tanzu Cluster Essentials.
+
+For more information about profiles, see [About Tanzu Application Platform components and profiles](about-package-profiles.md).
+
+To prepare to install a profile:
+
+1. List version information for the package by running:
+
+    ```console
+    tanzu package available list tap.tanzu.vmware.com --namespace tap-install
+    ```
+
+1. Create a `tap-values.yaml` file by using the
+[Full Profile AWS sample](#full-profile) in the following section as a guide.
+These samples have the minimum configuration required to deploy Tanzu Application Platform on AWS.
+
+The sample values file contains the necessary defaults for:
+
+    - The meta-package, or parent Tanzu Application Platform package.
+    - Subordinate packages, or individual child packages.
+
+    >**Important:** Keep the values file for future configuration use.
+
+
+1. [View possible configuration settings for your package](view-package-config.hbs.md)
+
+### <a id='full-profile'></a> Full profile
+
+The follow command will generate the YAML file sample for the full-profile on AWS using the ECR repositories we created:
+
+>**Note:** The `profile:` field takes `full` as the default value, but you can also set it to `iterate`, `build`, `run` or `view`. 
+Refer to [Install multicluster Tanzu Application Platform profiles](multicluster/installing-multicluster.html) for more information.
+
+```console
+cat << EOF > tap-values.yaml
+shared:
+  ingress_domain: "INGRESS-DOMAIN"
+
+ceip_policy_disclosed: true 
+
+#The above keys are minimum numbers of entries needed in tap-values.yaml to get a functioning TAP Full profile installation.
+
+#Below are the keys which may have default values set, but can be overridden.
+
+profile: full # Can take iterate, build, run, view. 
+supply_chain: basic # Can take testing, testing_scanning.
+
+ootb_supply_chain_basic: # Based on supply_chain set above, can be changed to ootb_supply_chain_testing, ootb_supply_chain_testing_scanning.
+  registry:
+    server: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com
+    # The prefix of the ECR repository.  Workloads will need 
+    # two repositories created:
+    #
+    # tanzu-application-platform/<workloadname>-<namespace> 
+    # tanzu-application-platform/<workloadname>-<namespace>-bundle
+    repository: tanzu-application-platform
+  
+contour:
+  envoy:
+    service:
+      type: LoadBalancer # This is set by default, but can be overridden by setting a different value.
+
+buildservice:
+  kp_default_repository: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/tap-build-service
+  # Enable the build service k8s service account to bind to the AWS IAM Role
+  kp_default_repository_aws_iam_role_arn: "arn:aws:iam::${AWS_ACCOUNT_ID}:role/tap-build-service"
+
+ootb_templates:
+  # Enable the config writer service to use cloud based iaas authentication
+  # which are retrieved from the developer namespace service account by
+  # default
+  iaas_auth: true
+
+tap_gui:
+  service_type: ClusterIP # If the shared.ingress_domain is set as above, this must be set to ClusterIP.
+  app_config:
+    catalog:
+      locations:
+        - type: url
+          target: https://GIT-CATALOG-URL/catalog-info.yaml
+
+metadata_store:
+  ns_for_export_app_cert: "MY-DEV-NAMESPACE"
+  app_service_type: ClusterIP
+
+scanning:
+  metadataStore:
+    url: "" # Deactivate embedded integration since it's deprecated.
+
+tap_telemetry:
+  customer_entitlement_account_number: "CUSTOMER-ENTITLEMENT-ACCOUNT-NUMBER" # (optional) identify data for creation of TAP usage reports
+EOF
+```
+
+Where:
+
+- `INGRESS-DOMAIN` is the subdomain for the host name that you point at the `tanzu-shared-ingress`
+service's External IP address.
+- `kp_default_repository_aws_iam_role_arn` is the ARN that was created for to write to the ECR repository for the build service.  This value is automatically generated by the script, but can be modified manually in needed.
+- `GIT-CATALOG-URL` is the path to the `catalog-info.yaml` catalog definition file. You can download either a blank or populated catalog file from the [Tanzu Application Platform product page](https://network.pivotal.io/products/tanzu-application-platform/#/releases/1043418/file_groups/6091). Otherwise, you can use a Backstage-compliant catalog you've already built and posted on the Git infrastructure.
+- `MY-DEV-NAMESPACE` is the namespace where you want to deploy the `ScanTemplates`.
+This is the namespace where the scanning feature runs.
+- `CUSTOMER-ENTITLEMENT-ACCOUNT-NUMBER` (optional) refers to the Entitlement Account Number (EAN), which is a unique identifier VMware assigns to its customers. Tanzu Application Platform telemetry uses this number to identify data that belongs to a particular customers and prepare usage reports. See [Kubernetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-cluster-lifecycle-ceip.html#identify-the-entitlement-account-number-2) for more information about identifying the Entitlement Account Number.
+
+For AWS, the default settings creates a classic LoadBalancer.
+To use the Network LoadBalancer instead of the classic LoadBalancer for ingress, add the
+following to your `tap-values.yaml`:
+
+```yaml
+contour:
+  infrastructure_provider: aws
+  envoy:
+    service:
+      aws:
+        LBType: nlb
+```
+
+### <a id='light-profile'></a> Light profile
+
+The Light profile is deprecated. Although existing values files might still refer to the Light profile, VMware recommends to migrate to one of the new profiles described in [Install your Tanzu Application Platform profile](#install-profile) by following the procedures in [Migrate Tanzu Application Platform profiles](migrate-profile.md).
+
+### <a id='full-dependencies'></a> (Optional) Configure your profile with full dependencies
+
+When you install a profile that includes Tanzu Build Service,
+Tanzu Application Platform is installed with the `lite` set of dependencies.
+These dependencies consist of [buildpacks](https://docs.vmware.com/en/VMware-Tanzu-Buildpacks/services/tanzu-buildpacks/GUID-index.html)
+and [stacks](https://docs.vmware.com/en/VMware-Tanzu-Buildpacks/services/tanzu-buildpacks/GUID-stacks.html)
+required for application builds.
+
+The `lite` set of dependencies do not contain all buildpacks and stacks.
+To use all buildpacks and stacks, you must install the `full` dependencies.
+For more information about the differences between `lite` and `full` dependencies, see
+[About lite and full dependencies](tanzu-build-service/dependencies.html#lite-vs-full).
+
+To configure `full` dependencies, add the key-value pair
+`exclude_dependencies: true` to your `tap-values.yaml` file under the `buildservice` section.
+For example:
+
+```yaml
+buildservice:
+  kp_default_repository: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/tap-build-service
+  exclude_dependencies: true
+```
+
+After configuring `full` dependencies, you must install the dependencies after
+you have finished installing your Tanzu Application Platform package. 
+See [Install the full dependencies package](#tap-install-full-deps) for more information.
+
+## <a id="install-package"></a>Install your Tanzu Application Platform package
+
+Follow these steps to install the Tanzu Application Platform package:
+
+1. Install the package by running:
+
+    ```console
+    tanzu package install tap -p tap.tanzu.vmware.com -v $TAP_VERSION --values-file tap-values.yaml -n tap-install
+    ```
+
+1. Verify the package install by running:
+
+    ```console
+    tanzu package installed get tap -n tap-install
+    ```
+
+    This can take 5-10 minutes because it installs several packages on your cluster.
+
+2. Verify that the necessary packages in the profile are installed by running:
+
+    ```console
+    tanzu package installed list -A
+    ```
+
+3. If you configured `full` dependencies in your `tbs-values.yaml` file, install the `full` dependencies
+by following the procedure in [Install full dependencies](#tap-install-full-deps).
+
+After installing the Full profile on your cluster, you can install the
+Tanzu Developer Tools for VS Code Extension to help you develop against it.
+For instructions, see [Installing Tanzu Developer Tools for VS Code](vscode-extension/install.md).
+
+>**Note:** You can run the following command after reconfiguring the profile to reinstall the Tanzu Application Platform:
+
+```
+tanzu package installed update tap -p tap.tanzu.vmware.com -v $TAP_VERSION  --values-file tap-values.yaml -n tap-install
+``` 
+
+## <a id="tap-install-full-deps"></a> Install the full dependencies package
+
+If you configured `full` dependencies in your `tap-values.yaml` file in
+[Configure your profile with full dependencies](#full-dependencies) earlier,
+you must install the `full` dependencies package.
+
+For more information about the differences between `lite` and `full` dependencies, see
+[About lite and full dependencies](tanzu-build-service/dependencies.html#lite-vs-full).
+
+To install the `full` dependencies package:
+
+1. If you have not done so already, add the key-value pair `exclude_dependencies: true`
+ to your `tap-values.yaml` file under the `buildservice` section. For example:
+
+    ```yaml
+    buildservice:
+      kp_default_repository: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/tap-build-service
+      exclude_dependencies: true
+    ...
+    ```
+
+1. Get the latest version of the `buildservice` package by running:
+
+    ```console
+    tanzu package available list buildservice.tanzu.vmware.com --namespace tap-install
+    ```
+
+1. Relocate the Tanzu Build Service full dependencies package repository by running:
+
+    ```console
+    imgpkg copy -b registry.tanzu.vmware.com/tanzu-application-platform/full-tbs-deps-package-repo:VERSION \
+      --to-repo ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/tbs-full-deps
+    ```
+
+    Where `VERSION` is the version of the `buildservice` package you retrieved in the previous step.
+
+1. Add the Tanzu Build Service full dependencies package repository by running:
+
+    ```console
+    tanzu package repository add tbs-full-deps-repository \
+      --url ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/tbs-full-deps:VERSION \
+      --namespace tap-install
+    ```
+
+    Where `VERSION` is the version of the `buildservice` package you retrieved earlier.
+
+1. Install the full dependencies package by running:
+
+    ```console
+    tanzu package install full-tbs-deps -p full-tbs-deps.tanzu.vmware.com -v VERSION -n tap-install
+    ```
+
+    Where `VERSION` is the version of the `buildservice` package you retrieved earlier.
+
+## <a id='access-tap-gui'></a> Access Tanzu Application Platform GUI
+
+To access Tanzu Application Platform GUI, you can use the host name that you configured earlier. This host name is pointed at the shared ingress. To configure LoadBalancer for Tanzu Application Platform GUI, see [Accessing Tanzu Application Platform GUI](../tap-gui/accessing-tap-gui.md).
+
+You're now ready to start using Tanzu Application Platform GUI.
+Proceed to the [Getting Started](../getting-started.md) topic or the
+[Tanzu Application Platform GUI - Catalog Operations](../tap-gui/catalog/catalog-operations.md) topic.
+
+## <a id='exclude-packages'></a> Exclude packages from a Tanzu Application Platform profile
+
+To exclude packages from a Tanzu Application Platform profile:
+
+1. Find the full subordinate (child) package name:
+
+    ```console
+    tanzu package available list --namespace tap-install
+    ```
+
+2. Update your `tap-values` file with a section listing the exclusions:
+
+    ```console
+    profile: PROFILE-VALUE
+    excluded_packages:
+      - tap-gui.tanzu.vmware.com
+      - service-bindings.lab.vmware.com
+    ```
+
+>**Important:** If you exclude a package after performing a profile installation including that package, you cannot see the accurate package states immediately after running `tap package installed list -n tap-install`. Also, you can break package dependencies by removing a package. Allow 20 minutes to verify that all packages have reconciled correctly while troubleshooting.
+
+## <a id='next-steps'></a>Next steps
+
+- (Optional) [Installing Individual Packages](../install-components.html)
+- [Setting up developer namespaces to use installed packages](set-up-namespaces.html)

--- a/aws/set-up-namespaces.hbs.md
+++ b/aws/set-up-namespaces.hbs.md
@@ -1,0 +1,188 @@
+# Set up developer namespaces to use installed packages
+
+You can choose either one of the following two approaches to create a `Workload` 
+for your application by using the registry credentials specified, 
+add credentials and Role-Based Access Control (RBAC) rules to the namespace
+that you plan to create the `Workload` in:
+
+- [Enable single user access](#single-user-access).
+- [Enable additional users access with Kubernetes RBAC](#additional-user-access).
+
+## <a id='single-user-access'></a>Enable single user access
+
+Follow these steps to enable your current user to submit jobs to the Supply Chain:
+
+1. Gather the ARN created for workloads in the [Create AWS Resources](aws-resources.hbs.md)
+
+1. To add secrets, a service account to execute the supply chain, and RBAC rules to authorize the service account to the developer namespace, update the namespace and role arn and run:
+
+    ```console
+    cat <<EOF | kubectl -n YOUR-NAMESPACE apply -f -
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: tap-registry
+      annotations:
+        secretgen.carvel.dev/image-pull-secret: ""
+    type: kubernetes.io/dockerconfigjson
+    data:
+      .dockerconfigjson: e30K
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: default
+      annotations:
+        eks.amazonaws.com/role-arn: <Role ARN>
+    imagePullSecrets:
+      - name: tap-registry
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: default-permit-deliverable
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: deliverable
+    subjects:
+      - kind: ServiceAccount
+        name: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: default-permit-workload
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: workload
+    subjects:
+      - kind: ServiceAccount
+        name: default
+    EOF
+    ```
+
+## <a id='additional-user-access'></a>Enable additional users access with Kubernetes RBAC
+
+Follow these steps to enable additional users by using Kubernetes RBAC to submit jobs to the Supply Chain:
+
+1. [Enable single user access](#single-user-access).
+
+1. Choose either of the following options to give developers namespace-level access and view access to appropriate cluster-level resources:
+
+    - **Option 1:** Use the [Tanzu Application Platform RBAC CLI plug-in (beta)](authn-authz/binding.hbs.md#install).
+
+        To use the `tanzu rbac` plug-in to grant `app-viewer` and `app-editor` roles to an identity provider group, run:
+
+        ```console
+        tanzu rbac binding add -g GROUP-FOR-APP-VIEWER -n YOUR-NAMESPACE -r app-viewer
+        tanzu rbac binding add -g GROUP-FOR-APP-EDITOR -n YOUR-NAMESPACE -r app-editor
+        ```
+
+        Where:
+
+        - `YOUR-NAMESPACE` is the name you give to the developer namespace.
+        - `GROUP-FOR-APP-VIEWER` is the user group from the upstream identity provider that requires access to `app-viewer` resources on the current namespace and cluster.
+        - `GROUP-FOR-APP-EDITOR` is the user group from the upstream identity provider that requires access to `app-editor` resources on the current namespace and cluster.
+
+        For more information about `tanzu rbac`, see
+        [Bind a user or group to a default role](authn-authz/binding.html).
+
+        VMware recommends creating a user group in your identity provider's grouping system for each
+        developer namespace and then adding the users accordingly.
+
+        Depending on your identity provider, you might need to take further action to
+        federate user groups appropriately with your cluster.
+        For an example of how to set up Azure Active Directory (AD) with your cluster, see
+        [Integrating Azure Active Directory](authn-authz/azure-ad.html).
+
+    - **Option 2:** Use the native Kubernetes YAML.
+
+        To apply the RBAC policy, run:
+
+        ```console
+        cat <<EOF | kubectl -n YOUR-NAMESPACE apply -f -
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: dev-permit-app-viewer
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: app-viewer
+        subjects:
+          - kind: Group
+            name: GROUP-FOR-APP-VIEWER
+            apiGroup: rbac.authorization.k8s.io
+        ---
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: YOUR-NAMESPACE-permit-app-viewer
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: app-viewer-cluster-access
+        subjects:
+          - kind: Group
+            name: GROUP-FOR-APP-VIEWER
+            apiGroup: rbac.authorization.k8s.io
+        ---
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: dev-permit-app-editor
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: app-editor
+        subjects:
+          - kind: Group
+            name: GROUP-FOR-APP-EDITOR
+            apiGroup: rbac.authorization.k8s.io
+        ---
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: YOUR-NAMESPACE-permit-app-editor
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: app-editor-cluster-access
+        subjects:
+          - kind: Group
+            name: GROUP-FOR-APP-EDITOR
+            apiGroup: rbac.authorization.k8s.io
+        EOF
+        ```
+
+        Where:
+
+        - `YOUR-NAMESPACE` is the name you give to the developer namespace.
+        - `GROUP-FOR-APP-VIEWER` is the user group from the upstream identity provider that requires access to `app-viewer` resources on the current namespace and cluster.
+        - `GROUP-FOR-APP-EDITOR` is the user group from the upstream identity provider that requires access to `app-editor` resources on the current namespace and cluster.
+
+        VMware recommends creating a user group in your identity provider's grouping system for each
+        developer namespace and then adding the users accordingly.
+
+        Depending on your identity provider, you might need to take further action to
+        federate user groups appropriately with your cluster.
+        For an example of how to set up Azure Active Directory (AD) with your cluster, see
+        [Integrating Azure Active Directory](authn-authz/azure-ad.html).
+
+        Rather than granting roles directly to individuals, VMware recommends using your identity provider's user groups system to grant access to a group of developers.
+        For an example of how to set up Azure AD with your cluster, see
+        [Integrating Azure Active Directory](authn-authz/azure-ad.html).
+
+1. (Optional) Log in as a non-admin user, such as a developer, to see the effects of RBAC after the bindings are applied.
+
+## <a id='next-steps'></a>Next steps
+
+For online installation:
+
+- [Installing Tanzu Developer Tools for VS Code](vscode-extension/install.html)
+
+For air-gapped installation:
+
+- [Deploy your first air-gapped workload (beta)](getting-started/air-gap-workload.html)

--- a/aws/set-up-namespaces.hbs.md
+++ b/aws/set-up-namespaces.hbs.md
@@ -16,52 +16,40 @@ Follow these steps to enable your current user to submit jobs to the Supply Chai
 
 1. To add secrets, a service account to execute the supply chain, and RBAC rules to authorize the service account to the developer namespace, update the namespace and role arn and run:
 
-    ```console
-    cat <<EOF | kubectl -n YOUR-NAMESPACE apply -f -
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: tap-registry
-      annotations:
-        secretgen.carvel.dev/image-pull-secret: ""
-    type: kubernetes.io/dockerconfigjson
-    data:
-      .dockerconfigjson: e30K
-    ---
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
+  ```console
+  cat <<EOF | kubectl -n YOUR-NAMESPACE apply -f -
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: default
+    annotations:
+      eks.amazonaws.com/role-arn: <Role ARN>
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: default-permit-deliverable
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: deliverable
+  subjects:
+    - kind: ServiceAccount
       name: default
-      annotations:
-        eks.amazonaws.com/role-arn: <Role ARN>
-    imagePullSecrets:
-      - name: tap-registry
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-      name: default-permit-deliverable
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: deliverable
-    subjects:
-      - kind: ServiceAccount
-        name: default
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-      name: default-permit-workload
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: workload
-    subjects:
-      - kind: ServiceAccount
-        name: default
-    EOF
-    ```
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: default-permit-workload
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: workload
+  subjects:
+    - kind: ServiceAccount
+      name: default
+  EOF
+  ```
 
 ## <a id='additional-user-access'></a>Enable additional users access with Kubernetes RBAC
 

--- a/cartographer-conventions/troubleshooting.hbs.md
+++ b/cartographer-conventions/troubleshooting.hbs.md
@@ -118,7 +118,6 @@ An unmanaged error occurs in the `convention server` when processing a request.
     Normal   Started    13m (x2 over 14m)     kubelet            Started container webhook
     Warning  Unhealthy  13m (x9 over 14m)     kubelet            Readiness probe failed: Get "https://10.52.2.74:8443/healthz": http: server gave HTTP response to HTTPS client
     Warning  Unhealthy  13m (x6 over 14m)     kubelet            Liveness probe failed: Get "https://10.52.2.74:8443/healthz": http: server gave HTTP response to HTTPS client
-    Normal   Killing    13m (x2 over 13m)     kubelet            Container webhook failed liveness probe, will be restarted
     Normal   Pulled     9m13s (x6 over 13m)   kubelet            Container image "awesome-repo/awesome-user/awesome-convention" already present on machine
     Warning  BackOff    4m22s (x32 over 11m)  kubelet            Back-off restarting failed container
     ```

--- a/fluxcd-source-controller/about.hbs.md
+++ b/fluxcd-source-controller/about.hbs.md
@@ -3,5 +3,5 @@
 The fluxcd-source-controller is a Kubernetes Operator, specialised in artifacts acquisition
 from external sources such as Git, Helm repositories and S3 buckets.
 The source-controller implements the
-[source.toolkit.fluxcd.io](https://github.com/fluxcd/source-controller/tree/master/docs/spec/v1beta1) API in GitHub
+[source.toolkit.fluxcd.io](https://github.com/fluxcd/source-controller/tree/main/docs/spec/v1beta1) API in GitHub
 and is a core component of the [GitOps toolkit](https://toolkit.fluxcd.io).

--- a/fluxcd-source-controller/install-fluxcd-source-controller.hbs.md
+++ b/fluxcd-source-controller/install-fluxcd-source-controller.hbs.md
@@ -141,9 +141,9 @@ To install FluxCD source-controller from the Tanzu Application Platform package 
           name: gitrepository-sample
         spec:
           interval: 1m
-          url: https://github.com/stefanprodan/podinfo
+          url: https://github.com/sample-accelerators/tanzu-java-web-app
           ref:
-            branch: master
+            branch: main
         ```
 
     2. Apply the created conf:
@@ -157,8 +157,8 @@ To install FluxCD source-controller from the Tanzu Application Platform package 
 
         ```
         kubectl get GitRepository
-        NAME                   URL                                       READY   STATUS                                                              AGE
-        gitrepository-sample   https://github.com/stefanprodan/podinfo   True    Fetched revision: master/132f4e719209eb10b9485302f8593fc0e680f4fc   4s
+        NAME                   URL                                                         READY   STATUS                                                              AGE
+        gitrepository-sample   https://github.com/sample-accelerators/tanzu-java-web-app   True    Fetched revision: main/132f4e719209eb10b9485302f8593fc0e680f4fc   4s
         ```
 
     For more examples, see the samples directory on [fluxcd/source-controller/samples](https://github.com/fluxcd/source-controller/tree/main/config/samples) in GitHub.

--- a/install-intro.hbs.md
+++ b/install-intro.hbs.md
@@ -4,6 +4,7 @@ You can install Tanzu Application Platform by using one of the following methods
 
 - [Installing Tanzu Application Platform online](#install-online). For Tanzu Application Platform on a Kubernetes cluster with internet access.
 - [Installing Tanzu Application Platform in an air-gapped environment](#install-air-gap). For Tanzu Application Platform on a Kubernetes cluster air-gapped from external traffic.
+- [Installing Tanzu Application Platform in AWS](#install-on-aws). For installing Tanzu Application platform using AWS Cloud Services.
 - [Deploying Tanzu Application Platform through AWS Quick Start on Amazon EKS](https://aws.amazon.com/quickstart/architecture/vmware-tanzu-application-platform/). For a reference deployment of Tanzu Application Platform on Amazon Elastic Kubernetes Service (Amazon EKS) using AWS CloudFormation.
 
 ## <a id='install-online'></a>Installing Tanzu Application Platform online
@@ -44,3 +45,22 @@ To install Tanzu Application Platform on your Kubernetes clusters in an air-gapp
 
 After installing Tanzu Application Platform on to your air-gapped cluster, you can start creating workloads that run in your air-gapped containers.
 For instructions, see [Deploy your first air-gapped workload](getting-started/air-gap-workload.html).
+
+## <a id='install-on-aws'></a>Installing Tanzu Application Platform on AWS Cloud
+
+The process of installing Tanzu Application Platform on [Amazon Elastic Kubernetes Services (EKS)](https://aws.amazon.com/eks/) [using Amazon Elastic Container Registry (ECR)](https://aws.amazon.com/ecr/).
+
+This will produce a deployment similar to the outcome of the [VMware Tanzu Application Platform on AWS Cloud Quick Start](https://aws.amazon.com/quickstart/architecture/vmware-tanzu-application-platform/) but gives the user the flexibility to customize the deployment.
+
+|Step|Task|Link|
+|----|----|----|
+|1.| Review the prerequisites to ensure that you have set up everything required before beginning the installation |[Prerequisites](prerequisites.html)|
+|2.| Accept Tanzu Application Platform EULAs and install the Tanzu CLI |[Accepting Tanzu Application Platform EULAs and installing the Tanzu CLI](install-tanzu-cli.html)|
+|3.| Create AWS Resources (EKS Cluster, roles, etc)|[Create AWS Resources](aws/aws-resources.hbs.md)|
+|4.| Install Cluster Essentials for Tanzu |[Deploying Cluster Essentials](https://docs.vmware.com/en/Cluster-Essentials-for-VMware-Tanzu/1.2/cluster-essentials/GUID-deploy.html)|
+|5.| Add the Tanzu Application Platform package repository, prepare your Tanzu Application Platform profile, and install the profile to the cluster |[Installing the Tanzu Application Platform package and profiles](aws/install.hbs.md)|
+|6.| (Optional) Install any additional packages that were not in the profile |[Installing Individual Packages](install-components.html)|
+|7.| Set up developer namespaces to use installed packages |[Setting up developer namespaces to use installed packages](aws/set-up-namespaces.hbs.md)|
+|8.| Install developer tools into your integrated development environment (IDE) |[Installing Tanzu Developer Tools for VSCode](vscode-extension/installation.html)|
+
+After installing Tanzu Application Platform on to your Kubernetes clusters, proceed with [Getting started with the Tanzu Application Platform](getting-started.html).


### PR DESCRIPTION
This PR will add installation docs that are specific to installing TAP on AWS.

Fully realizing this is duplicating a lot of documentation.  Has been agreed upon with the docs team and have ideas for resolving this with future doc enhancements. 
