### PR TITLE
SCST-Store/Insight: Fix access token retrieval command for Kubernetes 1.24

### DIFF
--- a/scst-store/create-service-account-access-token.hbs.md
+++ b/scst-store/create-service-account-access-token.hbs.md
@@ -258,15 +258,27 @@ To create a read-write service account, run the following command. The command c
 ## <a id='get-access-token'></a>Getting the Access Token
 To retrieve the read-only access token, run:
 
-```console
-kubectl get secret $(kubectl get sa -n metadata-store metadata-store-read-client -o json | jq -r '.secrets[0].name') -n metadata-store -o json | jq -r '.data.token' | base64 -d
-```
+* Kubernetes version before 1.24
+  ```console
+  kubectl get secret $(kubectl get sa -n metadata-store metadata-store-read-client -o json | jq -r '.secrets[0].name') -n metadata-store -o json | jq -r '.data.token' | base64 -d
+  ```
+
+* Kubernetes v1.24 or later
+  ```console
+  kubectl get secrets metadata-store-read-client -n metadata-store -o jsonpath="{.data.token}" | base64 -d
+  ```
 
 To retrieve the read-write access token run:
 
-```console
-kubectl get secret $(kubectl get sa -n metadata-store metadata-store-read-write-client -o json | jq -r '.secrets[0].name') -n metadata-store -o json | jq -r '.data.token' | base64 -d
-```
+* Kubernetes version before 1.24
+  ```console
+  kubectl get secret $(kubectl get sa -n metadata-store metadata-store-read-write-client -o json | jq -r '.secrets[0].name') -n metadata-store -o json | jq -r '.data.token' | base64 -d
+  ```
+
+* Kubernetes v1.24 or later
+  ```console
+  kubectl get secrets metadata-store-read-write-client -n metadata-store -o jsonpath="{.data.token}" | base64 -d
+  ```
 
 The access token is a "Bearer" token used in the http request header "Authorization." (ex. `Authorization: Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IjhMV0...`)
 


### PR DESCRIPTION
Signed-off-by: Garry Ing <ging@vmware.com>

Context: I've been stepping through 1.3 installation and got to the [access token retrieval step](https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Application-Platform/1.3/tap/GUID-scst-store-create-service-account-access-token.html#getting-the-access-token-3). Currently, the command returns the following on Kubernetes 1.24:
```
Error from server (NotFound): secrets "null" not found
```

This is a temporary solution, replicating the segmented blocks of before 1.24 and 1.24 (and later).

@Manifaust @julia-pu
