### PR TITLE
Add troubleshooting doc for max message error

### DIFF
--- a/tanzu-build-service/troubleshooting.hbs.md
+++ b/tanzu-build-service/troubleshooting.hbs.md
@@ -3,45 +3,6 @@
 This topic provides information to help troubleshoot Tanzu Build Service when used with
 Tanzu Application Platform.
 
-## <a id="tbs-1-2-breaking-change"></a> Builds fail after upgrading to Tanzu Application Platform v1.2
-
-### Symptom
-
-After upgrading to Tanzu Application Platform v1.2, you see failing builds.
-
-### Explanation
-
-After the upgrade, Tanzu Build Service image resources automatically run a build
-that fails due to a missing dependency.
-
-This error does not persist and any subsequent builds will resolve this error.
-
-### Solution
-
-You can safely wait for the next build of the workloads, which is triggered by new source code changes.
-
-If you do not want to wait for subsequent builds to run automatically, you can use the open source
-[kp](https://github.com/vmware-tanzu/kpack-cli) CLI to re-run failing builds:
-
-1. List the image resources in the developer namespace by running:
-
-    ```console
-    kp image list -n DEVELOPER-NAMESPACE
-    ```
-
-    Where `DEVELOPER-NAMESPACE` is the namespace where workloads are created.
-
-1. Manually trigger the image resources to re-run builds for each failing image by running:
-
-    ```console
-    kp image trigger IMAGE-NAME -n DEVELOPER-NAMESPACE
-    ```
-
-    Where:
-
-    - `IMAGE-NAME` is the name of the failing image.
-    - `DEVELOPER-NAMESPACE` is the namespace where workloads are created.
-
 ## <a id="eks-1-23-volume"></a> Builds fail due to volume errors on EKS running Kubernetes v1.23
 
 ### Symptom
@@ -114,3 +75,21 @@ For OpenShift, see:
 
 * The [Red Hat Hybrid Cloud blog](https://cloud.redhat.com/blog/containerd-support-for-windows-containers-in-openshift)
 * The [Red Hat Openshift documentation](https://docs.openshift.com/container-platform/3.11/crio/crio_runtime.html)
+
+## <a id="max-message-size"></a> Nodes fail due to "trying to send message larger than max" error
+
+### Symptom
+
+You are seeing the following or similar error in a node status:
+
+```console
+Warning ContainerGCFailed 119s (x2523 over 42h) kubelet rpc error: code = ResourceExhausted desc = grpc: trying to send message larger than max (16779959 vs. 16777216)
+```
+
+### Explanation
+
+This is due to the way that CRI handles garbage collection for unused images and containers.
+
+### Solution
+
+Ensure you are not using docker as the CRI, as it is not supported. Some versions of EKS default to docker as the runtime.


### PR DESCRIPTION
- Remove troubleshooting doc related to tap 1.2

Which other branches should this be merged with (if any)?
