### PR TITLE
VSEE-754 | Moved CVE triage and remediation section to scst-scan

### DIFF
--- a/scc/ootb-supply-chain-testing-scanning.hbs.md
+++ b/scc/ootb-supply-chain-testing-scanning.hbs.md
@@ -354,54 +354,7 @@ Create workload:
 ```
 ## <a id="cve-triage-workflow"></a> CVE triage workflow
 
-The Supply Chain halts progression if either a SourceScan (`sourcescans.scanning.apps.tanzu.vmware.com`) or an ImageScan (`imagescans.scanning.apps.tanzu.vmware.com`) fails policy enforcement through the [ScanPolicy](../scst-scan/policies.hbs.md#define-a-rego-file-for-policy-enforcement) (`scanpolicies.scanning.apps.tanzu.vmware.com`). This can prevent source code from being built or images from being deployed that contain vulnerabilities that are in violation of the user-defined scan policy. If you triaged these vulnerabilities and identified any false positives, see this section to unblock your deployment from these CVEs.
-
-### <a id="sc-stop"></a>Confirming Supply Chain stopped due failed policy enforcement
-
-1. Verify if the status of the workload is `MissingValueAtPath` due to waiting on a `.status.compliantArtifact` from either the SourceScan or ImageScan:
-
-  ```console
-  kubectl describe workload WORKLOAD-NAME -n DEVELOPER-NAMESPACE
-  ```
-
-1. Describe the SourceScan or ImageScan to determine what CVE(s) violated the ScanPolicy:
-
-  ```
-  kubectl describe sourcescan NAME -n DEVELOPER-NAMESPACE
-  kubectl describe imagescan NAME -n DEVELOPER-NAMESPACE
-  ```
-
-### <a id="triage-cve"></a>Triage
-
-The goal of triage is to analyze and prioritize the reported vulnerability data to discover the appropriate course of action to take at the remediation step. To remediate efficiently and appropriately, you need context on the vulnerabilities that are blocking your supply chain, the packages that are affected, and the impact they can have.
-
-During triage, review which packages are impacted by the CVEs that violated your scan policy. If the [Tanzu Insight CLI plug-in](../cli-plugins/insight/cli-overview.hbs.md) is configured, you can query the database for the packages and their corresponding CVEs in your source code or image using these commands:
-
-```console
-tanzu insight source get --repo REPO --org ORG
-tanzu insight image get --digest DIGEST
-```
-
-See [Query using the Tanzu Insight CLI plug-in](../cli-plugins/insight/query-data.hbs.md) for more details.
-
-During this stage, VMware recommends reviewing information pertaining to the CVEs from sources such as the [National Vulnerability Database](https://nvd.nist.gov/vuln) or the release page of a package.
-
-### <a id="remediation"></a>Remediation
-After triage is complete, the next step is to remediate the blocking vulnerabilities quickly. Some common methods for CVE remediation are as follows:
-
-- Updating the affected component to remove the CVE
-- Amending the scan policy with an exception if you decide to accept the CVE and unblock your supply chain
-
-#### <a id="update-component"></a>Updating the affected component
-
-Vulnerabilities that occur in older versions of a package might be resolved in newer versions. Apply a patch by upgrading to a later
-In addition to the earlier, you can further adopt security best practices by using your project's package manager tools (e.g. `go mod graph` for projects in Go) to identify transitive or indirect dependencies that can also be affect CVEs.
-
-#### <a id="amend-scan-policy"></a>Amending the scan policy
-
-If you decide to proceed without remediating the CVE, for example, when a CVE is evaluated to be a false positive or when a fix is not currently available, you can amend the ScanPolicy to ignore one or more CVEs. For information about common scanner limitations, see [Note on Vulnerability Scanners](../scst-scan/overview.hbs.md#a-idscst-scan-noteaa-note-on-vulnerability-scanners). For information about templates, see [Writing Policy Templates](../scst-scan/policies.md).
-
-Under RBAC, users with the `app-operator-scanning` role that is part of the `app-operator` aggregate role, have permission to edit the ScanPolicy. See [Detailed role permissions breakdown](../authn-authz/permissions-breakdown.hbs.md).
+The Supply Chain halts progression if either a SourceScan (`sourcescans.scanning.apps.tanzu.vmware.com`) or an ImageScan (`imagescans.scanning.apps.tanzu.vmware.com`) fails policy enforcement through the [ScanPolicy](../scst-scan/policies.hbs.md#define-a-rego-file-for-policy-enforcement) (`scanpolicies.scanning.apps.tanzu.vmware.com`). This can prevent source code from being built or images from being deployed that contain vulnerabilities that are in violation of the user-defined scan policy. Refer to the guidelines provided in [Triaging and Remediating CVEs](../scst-scan/triaging-and-remediating-cves.hbs.md) to learn how to handle these vulnerabilities and unblock your Supply Chain.
 
 ## <a id="scan-images-using-different-scanner"></a> Scan Images using a different scanner
 

--- a/scst-scan/observing.hbs.md
+++ b/scst-scan/observing.hbs.md
@@ -213,7 +213,7 @@ status:
 
 #### <a id="supply-chain-stops"></a> Resolving failing scans that block a Supply Chain 
 
-If the Supply Chain is not progressing due to CVEs found in either the SourceScan or ImageScan, see the CVE triage workflow in [Out of the Box Supply Chain with Testing and Scanning](../scc/ootb-supply-chain-testing-scanning.hbs.md#a-idcve-triage-workflowa-cve-triage-workflow).
+If the Supply Chain is not progressing due to CVEs found in either the SourceScan or ImageScan, see the CVE triage workflow in [Triaging and Remediating CVEs](triaging-and-remediating-cves.hbs.md).
 
 #### <a id="gui-miss-policy"></a> Policy not defined in the Tanzu Application Platform GUI
 

--- a/scst-scan/policies.hbs.md
+++ b/scst-scan/policies.hbs.md
@@ -68,7 +68,7 @@ Follow these steps to define a Rego file for policy enforcement that you can reu
         }
     ```
 
-    You can modify the following fields of the Rego file as part of the [CVE triage workflow](../scc/ootb-supply-chain-testing-scanning.hbs.md#cve-triage-workflow):
+    You can modify the following fields of the Rego file as part of the [CVE triage workflow](../scst-scan/triaging-and-remediating-cves.hbs.md#amend-scan-policy):
     
     - `notAllowedSeverities` contains the categories of CVEs that result in the SourceScan or ImageScan failing policy enforcement. Below is an example of how an `app-operator` might decide to only block "Critical", "High" and "UnknownSeverity" CVEs.
 
@@ -103,7 +103,7 @@ Follow these steps to define a Rego file for policy enforcement that you can reu
     kubectl apply -f <path_to_scan_policy>/<scan_policy_filename>.yaml -n <desired_namespace>
     ```
 
-See how scan policies are used in the CVE triage workflow in the [Out of the Box Supply Chain with Testing and Scanning](../scc/ootb-supply-chain-testing-scanning.hbs.md#a-idcve-triage-workflowa-cve-triage-workflow)
+See how scan policies are used in the CVE triage workflow in the [Triaging and Remediating CVEs](../scst-scan/triaging-and-remediating-cves.hbs.md#amend-scan-policy)
 
 ## <a id="gui-view-scan-policy"></a>Enable Tanzu Application Platform GUI to view ScanPolicy Resource
 

--- a/scst-scan/triaging-and-remediating-cves.hbs.md
+++ b/scst-scan/triaging-and-remediating-cves.hbs.md
@@ -1,0 +1,48 @@
+# Triaging and Remediating CVEs
+
+## <a id="sc-stop"></a>Confirming Supply Chain stopped due failed policy enforcement
+
+1. Verify if the status of the workload is `MissingValueAtPath` due to waiting on a `.status.compliantArtifact` from either the SourceScan or ImageScan:
+
+  ```console
+  kubectl describe workload WORKLOAD-NAME -n DEVELOPER-NAMESPACE
+  ```
+
+1. Describe the SourceScan or ImageScan to determine what CVE(s) violated the ScanPolicy:
+
+  ```
+  kubectl describe sourcescan NAME -n DEVELOPER-NAMESPACE
+  kubectl describe imagescan NAME -n DEVELOPER-NAMESPACE
+  ```
+
+## <a id="triage-cve"></a>Triage
+
+The goal of triage is to analyze and prioritize the reported vulnerability data to discover the appropriate course of action to take at the remediation step. To remediate efficiently and appropriately, you need context on the vulnerabilities that are blocking your supply chain, the packages that are affected, and the impact they can have.
+
+During triage, review which packages are impacted by the CVEs that violated your scan policy. If the [Tanzu Insight CLI plug-in](../cli-plugins/insight/cli-overview.hbs.md) is configured, you can query the database for the packages and their corresponding CVEs in your source code or image using these commands:
+
+```console
+tanzu insight source get --repo REPO --org ORG
+tanzu insight image get --digest DIGEST
+```
+
+See [Query using the Tanzu Insight CLI plug-in](../cli-plugins/insight/query-data.hbs.md) for more details.
+
+During this stage, VMware recommends reviewing information pertaining to the CVEs from sources such as the [National Vulnerability Database](https://nvd.nist.gov/vuln) or the release page of a package.
+
+## <a id="remediation"></a>Remediation
+After triage is complete, the next step is to remediate the blocking vulnerabilities quickly. Some common methods for CVE remediation are as follows:
+
+- Updating the affected component to remove the CVE
+- Amending the scan policy with an exception if you decide to accept the CVE and unblock your supply chain
+
+### <a id="update-component"></a>Updating the affected component
+
+Vulnerabilities that occur in older versions of a package might be resolved in newer versions. Apply a patch by upgrading to a later
+In addition to the earlier, you can further adopt security best practices by using your project's package manager tools (e.g. `go mod graph` for projects in Go) to identify transitive or indirect dependencies that can also be affect CVEs.
+
+### <a id="amend-scan-policy"></a>Amending the scan policy
+
+If you decide to proceed without remediating the CVE, for example, when a CVE is evaluated to be a false positive or when a fix is not currently available, you can amend the ScanPolicy to ignore one or more CVEs. For information about common scanner limitations, see [Note on Vulnerability Scanners](overview.hbs.md#a-idscst-scan-noteaa-note-on-vulnerability-scanners). For information about templates, see [Writing Policy Templates](policies.md).
+
+Under RBAC, users with the `app-operator-scanning` role that is part of the `app-operator` aggregate role, have permission to edit the ScanPolicy. See [Detailed role permissions breakdown](../authn-authz/permissions-breakdown.hbs.md).

--- a/toc.md
+++ b/toc.md
@@ -399,6 +399,7 @@ docs.vmware.com is built.
             - [Private source scan](scst-scan/samples/private-source.md)
             - [Public source scan of a blob/tar file](scst-scan/samples/blob.md)
         - [Using Grype in offline and air-gapped environments](scst-scan/offline-airgap.md)
+        - [Triaging and Remediating CVEs](scst-scan/triaging-and-remediating-cves.hbs.md)
         - [Observing and troubleshooting](scst-scan/observing.md)
         - [Additional scan resources](scst-scan/scan-crs.md)
             - [Configure code repositories and image artifacts to be scanned](scst-scan/scan-crs.md)


### PR DESCRIPTION
Which other branches should this be merged with (if any)? main and 1.2.x branches

- If there are any merge conflicts, the purpose of this pull request was to move the "CVE triage workflow" from `scc-ootb-supply-chain-testing-scanning` to `scst-scan` as well as update links.