### PR TITLE
cnr known issue on openshift

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -296,6 +296,19 @@ This release has the following known issues, listed by area and component.
 - Known issue 1
 - Known issue 2
 
+#### <a id="cnrs-issues"></a> Cloud Native Runtimes
+
+- **Failure to successfully deploy workloads on Openshift**
+  When creating a workload from a Deliverable resource, it may not create successfully, and an error might be seen with the text
+  ```
+  pods "<pod name>" is forbidden: unable to validate against any security context constraint: 
+  [provider "anyuid": Forbidden: not usable by user or serviceaccount, spec.containers[0].securityContext.runAsUser:
+  Invalid value: 1000: must be in the ranges: [1000740000, 1000749999]
+  ```
+  This may be due to ServiceAccounts or Users bound to overly restrictive SecurityContextConstraints.
+
+  See the Cloud Native Runtimes [troubleshooting documentation](https://docs.vmware.com/en/Cloud-Native-Runtimes-for-VMware-Tanzu/2.0/tanzu-cloud-native-runtimes/GUID-troubleshooting.html) for how to resolve this issue.
+
 #### <a id="functions-issues"></a> Functions (beta)
 
 - Known issue 1


### PR DESCRIPTION
There can be an issue with workloads not deploying correctly on Openshift due to SecurityContextConstraints. It was discovered as part of TANZUSC-2003, and we are trying to get out a workaround for TAP 1.3.0.

The appropriate troubleshooting steps to resolve are getting [added to the CNR docs themselves](https://gitlab.eng.vmware.com/daisy/cloud-native-runtimes-for-vmware-tanzu/-/merge_requests/131), and the link should work once the docs are published.

Is it okay to link to CNR docs through here? Or should I have the troubleshooting steps in this repo as well?

Side note: is it okay to link TANZUSC and vmware gitlab repos in here?


Which other branches should this be merged with (if any)? None, just main, to eventually become 1.3
