### PR TITLE
Draft: Adds back in TAP GUI app_config key in install

### DIFF
--- a/install.hbs.md
+++ b/install.hbs.md
@@ -252,6 +252,7 @@ buildservice:
 
 tap_gui:
   service_type: ClusterIP # If the shared.ingress_domain is set as above, this must be set to ClusterIP.
+  app_config:
     catalog:
       locations:
         - type: url


### PR DESCRIPTION
It got removed some time ago when we went down to fewer required values.

Signed-off-by: Michael Stergianis <mstergianis@vmware.com>

Which other branches should this be merged with (if any)?
