### PR TITLE
Remove metadata store ingress values from example for Air gap install

### DIFF
--- a/install-air-gap.hbs.md
+++ b/install-air-gap.hbs.md
@@ -296,9 +296,7 @@ tap_gui:
 
 metadata_store:
   ns_for_export_app_cert: "MY-DEV-NAMESPACE"
-  ingress_domain: INGRESS-DOMAIN
   app_service_type: ClusterIP
-  ingress_enabled: "true"
 grype:
   namespace: "MY-DEV-NAMESPACE"
   targetImagePullSecret: "TARGET-REGISTRY-CREDENTIALS-SECRET"


### PR DESCRIPTION
Because Store takes its values from shared TLK

This is related https://jira.eng.vmware.com/browse/TANZUSC-2045

Merge into main branch, this only applies 1.3