### PR TITLE
Small formatting changes

### DIFF
--- a/install.hbs.md
+++ b/install.hbs.md
@@ -220,6 +220,7 @@ shared:
     project_path: "SERVER-NAME/REPO-NAME"
     username: "KP-DEFAULT-REPO-USERNAME"
     password: "KP-DEFAULT-REPO-PASSWORD"
+  kubernetes_distribution: "openshift" # To be passed only for OpenShift. Defaults to "".
 
 ceip_policy_disclosed: FALSE-OR-TRUE-VALUE # Installation fails if this is not set to true. Not a string.
 
@@ -242,9 +243,6 @@ contour:
     service:
       type: LoadBalancer # This is set by default, but can be overridden by setting a different value.
 
-shared:
-  kubernetes_distribution: "openshift" # To be passed only for OpenShift. Defaults to "".
-
 buildservice:
   kp_default_repository: "KP-DEFAULT-REPO"
   kp_default_repository_username: "KP-DEFAULT-REPO-USERNAME"
@@ -256,7 +254,6 @@ tap_gui:
       locations:
         - type: url
           target: https://GIT-CATALOG-URL/catalog-info.yaml
-
 
 metadata_store:
   ns_for_export_app_cert: "MY-DEV-NAMESPACE"

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -183,9 +183,12 @@ This release includes the following changes, listed by component and area.
 
 This release has the following breaking changes, listed by area and component.
 
-#### <a id="scst-scan-changes"></a> Supply Chain Security Tools - Scan
+#### <a id="scst-sign-changes"></a> Supply Chain Security Tools - Sign
 
 - [Supply Chain Security Tools - Sign](scst-sign/overview.md) is deprecated. For migration information, see [Migration From Supply Chain Security Tools - Sign](./scst-policy/migration.hbs.md).
+
+#### <a id="scst-scan-changes"></a> Supply Chain Security Tools - Scan
+
 - Alpha version scan CRDs have been removed.
 - Deprecated path, invoked when `ScanTemplates` shipped with versions prior to Supply Chain Security Tools - Scan `v1.2.0` are used, now logs a message directing users to update the scanner integration to the latest version. The migration path is to use `ScanTemplates` shipped with Supply Chain Security Tools - Scan `v1.3.0`.
 


### PR DESCRIPTION
- Combine "kubernetes_distribution" key with the other shared keys
- fix SCST - Sign deprecation notice to be under it's own header instead of inside Scan's section