### PR TITLE
Update links to use new accelerator repository

### DIFF
--- a/app-live-view/configuring-apps/convention-server.hbs.md
+++ b/app-live-view/configuring-apps/convention-server.hbs.md
@@ -94,7 +94,8 @@ spec:
     git:
       ref:
         branch: main
-      url: https://github.com/sample-accelerators/tanzu-java-web-app
+      url: https://github.com/vmware-tanzu/application-accelerator-samples.git
+    subPath: tanzu-java-web-app
 ```
 
 ## <a id="desc-metadata"></a> Description of metadata labels

--- a/app-live-view/configuring-apps/steeltoe-enablement.hbs.md
+++ b/app-live-view/configuring-apps/steeltoe-enablement.hbs.md
@@ -82,7 +82,7 @@ To enable Application Live View on the Steeltoe Tanzu Application Platform workl
 Here's an example of creating a workload for a Steeltoe Application:
 
 ```console
-tanzu apps workload create steeltoe-app --type web --git-repo https://github.com/sample-accelerators/steeltoe-weatherforecast --git-branch main --annotation autoscaling.knative.dev/min-scale=1 --yes --label app.kubernetes.io/part-of=sample-app
+tanzu apps workload create steeltoe-app --type web --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path weatherforecast-steeltoe --git-branch main --annotation autoscaling.knative.dev/min-scale=1 --yes --label app.kubernetes.io/part-of=sample-app
 ```
 
 If your application image is NOT built with Tanzu Build Service, to enable Application Live View on Steeltoe Tanzu Application Platform workload, use the following command. For example:

--- a/application-accelerator/configuration.hbs.md
+++ b/application-accelerator/configuration.hbs.md
@@ -33,27 +33,28 @@ Where:
 
 A minimal example could look like the following manifest:
 
-> hello-fun.yaml
+> spring-cloud-serverless.yaml
 
 ```yaml
 apiVersion: accelerator.apps.tanzu.vmware.com/v1alpha1
 kind: Accelerator
 metadata:
-  name: hello-fun
+  name: spring-cloud-serverless
 spec:
   git:
-    url: https://github.com/sample-accelerators/hello-fun
+    url: https://github.com/vmware-tanzu/application-accelerator-samples
+    subPath: spring-cloud-serverless
     ref:
       branch: main
 ```
 
-This minimal example creates an accelerator named `hello-fun`. The `displayName`, `description`, `iconUrl`, and `tags` fields are populated based on the content under the `accelerator` key in the `accelerator.yaml` file found in the `main` branch of the Git repository at https://github.com/sample-accelerators/hello-fun. For example:
+This minimal example creates an accelerator named `spring-cloud-serverless`. The `displayName`, `description`, `iconUrl`, and `tags` fields are populated based on the content under the `accelerator` key in the `accelerator.yaml` file found in the `main` branch of the Git repository at https://github.com/vmware-tanzu/application-accelerator-samples under the sub-path `spring-cloud-serverless`. For example:
 
 > accelerator.yaml
 
 ```yaml
 accelerator:
-  displayName: Hello Fun
+  displayName: Spring Cloud Serverless
   description: A simple Spring Cloud Function serverless app
   iconUrl: https://raw.githubusercontent.com/simple-starters/icons/master/icon-cloud.png
   tags:
@@ -69,30 +70,30 @@ accelerator:
 To create this accelerator with `kubectl` run:
 
 ```sh
-kubectl apply --namespace --accelerator-system --filename hello-fun.yaml
+kubectl apply --namespace --accelerator-system --filename spring-cloud-serverless.yaml
 ```
 
 Or, you could use the Tanzu CLI and run:
 
 ```sh
-tanzu accelerator create hello-fun --git-repo https://github.com/sample-accelerators/hello-fun --git-branch main
+tanzu accelerator create spring-cloud-serverless --git-repo https://github.com/vmware-tanzu/application-accelerator-samples.git --git-branch main --git-sub-path spring-cloud-serverless
 ```
 
 ### <a id="examples-custom"></a> An example for creating an accelerator with customized properties
 
 You can also explicitly specify the `displayName`, `description`, `iconUrl`, and `tags` fields and this overrides any values provided in the accelerator's Git repository. The following example explicitly sets those fields and the `ignore` field:
 
-> my-hello-fun.yaml
+> my-spring-cloud-serverless.yaml
 
 ```yaml
 apiVersion: accelerator.apps.tanzu.vmware.com/v1alpha1
 kind: Accelerator
 metadata:
-  name: my-hello-fun
+  name: my-spring-cloud-serverless
 spec:
-  displayName: My Hello Fun
+  displayName: My Spring Cloud Serverless
   description: My own Spring Cloud Function serverless app
-  iconUrl: https://raw.githubusercontent.com/sample-accelerators/icons/master/icon-tanzu-light.png
+  iconUrl: https://raw.githubusercontent.com/simple-starters/icons/master/icon-cloud.png
   tags:
     - spring
     - cloud
@@ -100,7 +101,8 @@ spec:
     - serverless
   git:
     ignore: ".git/, bin/"
-    url: https://github.com/sample-accelerators/hello-fun
+    url: https://github.com/vmware-tanzu/application-accelerator-samples
+    subPath: spring-cloud-serverless
     ref:
       branch: test
 ```
@@ -108,16 +110,16 @@ spec:
 To create this accelerator with `kubectl` you could run:
 
 ```sh
-kubectl apply --namespace --accelerator-system --filename my-hello-fun.yaml
+kubectl apply --namespace --accelerator-system --filename my-spring-cloud-serverless.yaml
 ```
 
 Or, you could use the Tanzu CLI and run:
 
 ```sh
-tanzu accelerator create my-hello-fun --git-repo https://github.com/sample-accelerators/hello-fun --git-branch main \
+tanzu accelerator create my-spring-cloud-serverless --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --git-branch main --git-sub-path spring-cloud-serverless \
   --description "My own Spring Cloud Function serverless app" \
-  --display-name "My Hello Fun" \
-  --icon-url https://raw.githubusercontent.com/sample-accelerators/icons/master/icon-tanzu-light.png \
+  --display-name "My Spring Cloud Serverless" \
+  --icon-url https://raw.githubusercontent.com/simple-starters/icons/master/icon-cloud.png \
   --tags "spring,cloud,function,serverless"
 ```
 

--- a/application-accelerator/creating-accelerators/accelerator-yaml.hbs.md
+++ b/application-accelerator/creating-accelerators/accelerator-yaml.hbs.md
@@ -166,7 +166,7 @@ options:
 
 The screenshot and `accelerator.yaml` file snippet that follows demonstrates each `inputType`.
 You can also see the sample
-[demo-input-types](https://github.com/sample-accelerators/demo-input-types) on GitHub.
+[demo-input-types](https://github.com/vmware-tanzu/application-accelerator-samples/tree/main/demo-input-types) on GitHub.
 
 ![Screenshot of option inputs for sample accelerator demo-input-types](../images/demo-input-types-2.png)
 
@@ -174,7 +174,7 @@ You can also see the sample
 accelerator:
   displayName: Demo Input Types
   description: "Accelerator with options for each inputType"
-  iconUrl: https://raw.githubusercontent.com/sample-accelerators/icons/master/icon-tanzu-light.png
+  iconUrl: https://raw.githubusercontent.com/simple-starters/icons/master/icon-cloud.png
   tags: ["demo", "options"]
 
   options:

--- a/application-accelerator/creating-accelerators/creating-accelerators.hbs.md
+++ b/application-accelerator/creating-accelerators/creating-accelerators.hbs.md
@@ -105,7 +105,7 @@ The accelerator should now reflect the new content after ~10s wait since we spec
 
 Accelerator fragments are reusable accelerator components that can provide options, files or transforms. They may be imported to accelerators using an `import` entry and the transforms from the fragment may be referenced in an `InvokeFragment` transform in the accelerator that is declaring the import. For additional details see [InvokeFragment transform](transforms/invoke-fragment.md).
 
-The accelerator samples include three fragments - `java-version`, `tap-initialize`, and `live-update`. See the [sample-accelerators/fragments](https://github.com/sample-accelerators/fragments/tree/tap-1.2) Git repository for the content of these fragments.
+The accelerator samples include three fragments - `java-version`, `tap-initialize`, and `live-update`. See the [vmware-tanzu/application-accelerator-samples/fragments](https://github.com/vmware-tanzu/application-accelerator-samples/tree/tap-1.3/fragments) Git repository for the content of these fragments.
 
 To discover what fragments are available to use, you can run the following command:
 
@@ -178,9 +178,9 @@ spec:
   displayName: Select Java Version
   git:
     ref:
-      branch: tap-1.2
-    url: https://github.com/sample-accelerators/fragments.git
-    subPath: java-version
+      tag: tap-1.3
+    url: https://github.com/vmware-tanzu/application-accelerator-samples.git
+    subPath: fragments/java-version
 ```
 
 To create the fragment (we can save the above manifest in a `java-version.yaml` file) and use:
@@ -195,10 +195,9 @@ To avoid having to create a separate manifest file, you can use the following co
 
 ```
 tanzu accelerator fragment create java-version \
-  --git-repo https://github.com/sample-accelerators/fragments.git \
-  --git-branch main \
-  --git-tag tap-1.2 \
-  --git-sub-path java-version
+  --git-repo https://github.com/vmware-tanzu/application-accelerator-samples.git \
+  --git-tag tap-1.3 \
+  --git-sub-path fragments/java-version
 ```
 
 Now you can use this `java-version` fragment in an accelerator:

--- a/application-accelerator/troubleshooting.hbs.md
+++ b/application-accelerator/troubleshooting.hbs.md
@@ -224,7 +224,7 @@ cause of failure. For example:
       address:
         url: http://accelerator-engine.accelerator-system.svc.cluster.local/invocations
       artifact:
-        message: 'unable to clone ''https://github.com/sample-accelerators/hello-fun'',
+        message: 'unable to clone ''https://github.com/vmware-tanzu/application-accelerator-samples'',
           error: couldn''t find remote ref "refs/heads/test"'
         ready: false
         url: ""
@@ -232,7 +232,7 @@ cause of failure. For example:
       - lastTransitionTime: "2021-11-18T21:05:47Z"
         message: |-
           failed to resolve GitRepository
-          unable to clone 'https://github.com/sample-accelerators/hello-fun', error: couldn't find remote ref "refs/heads/test"
+          unable to clone 'https://github.com/vmware-tanzu/application-accelerator-samples', error: couldn't find remote ref "refs/heads/test"
         reason: GitRepositoryResolutionFailed
         status: "False"
         type: Ready
@@ -251,7 +251,7 @@ cause of failure. For example:
       address:
         url: http://accelerator-engine.accelerator-system.svc.cluster.local/invocations
       artifact:
-        message: 'unable to clone ''https://github.com/sample-accelerators/hello-funk'',
+        message: 'unable to clone ''https://github.com/vmware-tanzu/application-accelerator-sampl'',
           error: authentication required'
         ready: false
         url: ""
@@ -259,7 +259,7 @@ cause of failure. For example:
       - lastTransitionTime: "2021-11-18T21:09:52Z"
         message: |-
           failed to resolve GitRepository
-          unable to clone 'https://github.com/sample-accelerators/hello-funk', error: authentication required
+          unable to clone 'https://github.com/vmware-tanzu/application-accelerator-sampl', error: authentication required
         reason: GitRepositoryResolutionFailed
         status: "False"
         type: Ready
@@ -271,7 +271,7 @@ cause of failure. For example:
     exist. For example:
 
     ```console
-    unable to clone 'https://github.com/sample-accelerators/hello-funk', error: authentication required
+    unable to clone 'https://github.com/vmware-tanzu/application-accelerator-sampl', error: authentication required
     ```
 
 #### <a id="reason-GitRepositoryResolutionPending"></a> REASON: `GitRepositoryResolutionPending`

--- a/cli-plugins/apps/command-reference/commands-details/workload_create_update_apply.hbs.md
+++ b/cli-plugins/apps/command-reference/commands-details/workload_create_update_apply.hbs.md
@@ -9,7 +9,7 @@ In the output of the `workload apply command`, the specification for the workloa
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-tag tap-1.1 --type web
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-tag tap-1.3 --type web
 
 Create workload:
     1 + |---
@@ -18,20 +18,21 @@ Create workload:
     4 + |metadata:
     5 + |  labels:
     6 + |    apps.tanzu.vmware.com/workload-type: web
-    7 + |  name: pet-clinic
+    7 + |  name: tanzu-java-web-app
     8 + |  namespace: default
     9 + |spec:
    10 + |  source:
    11 + |    git:
    12 + |      ref:
-   13 + |        tag: tap-1.1
-   14 + |      url: https://github.com/sample-accelerators/spring-petclinic
+   13 + |        tag: tap-1.3
+   14 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+   15 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload? Yes
-Created workload "pet-clinic"
+Created workload "tanzu-java-web-app"
 
-To see logs:   "tanzu apps workload tail pet-clinic"
-To get status: "tanzu apps workload get pet-clinic"
+To see logs:   "tanzu apps workload tail tanzu-java-web-app"
+To get status: "tanzu apps workload get tanzu-java-web-app"
 
 ```
 </details>
@@ -46,7 +47,7 @@ Set the annotations to be applied to the workload, to specify more than one anno
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-tag tap-1.1 --type web --annotation tag=tap-1.1 --annotation name="Spring pet clinic"
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-tag tap-1.3 --type web --annotation tag=tap-1.3 --annotation name="Tanzu Java Web"
 Create workload:
     1 + |---
     2 + |apiVersion: carto.run/v1alpha1
@@ -54,19 +55,20 @@ Create workload:
     4 + |metadata:
     5 + |  labels:
     6 + |    apps.tanzu.vmware.com/workload-type: web
-    7 + |  name: spring-pet-clinic
+    7 + |  name: tanzu-java-web-app
     8 + |  namespace: default
     9 + |spec:
    10 + |  params:
    11 + |  - name: annotations
    12 + |    value:
-   13 + |      name: Spring pet clinic
-   14 + |      tag: tap-1.1
+   13 + |      name: Tanzu Java Web
+   14 + |      tag: tap-1.3
    15 + |  source:
    16 + |    git:
    17 + |      ref:
-   18 + |        tag: tap-1.1
-   19 + |      url: https://github.com/sample-accelerators/spring-petclinic
+   18 + |        tag: tap-1.3
+   19 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+   20 + |    subPath: tanzu-java-web-app
 ```
 </details>
 
@@ -75,21 +77,21 @@ To delete an annotation, use `-` after it's name.
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --annotation tag-
+tanzu apps workload apply tanzu-java-web-app --annotation tag-
 Update workload:
 ...
 10, 10   |  params:
 11, 11   |  - name: annotations
 12, 12   |    value:
-13, 13   |      name: Spring pet clinic
-14     - |      tag: tap-1.1
+13, 13   |      name: Tanzu Java Web
+14     - |      tag: tap-1.3
 15, 14   |  source:
 16, 15   |    git:
 17, 16   |      ref:
-18, 17   |        tag: tap-1.1
+18, 17   |        tag: tap-1.3
 ...
 
-? Really update the workload "spring-pet-clinic"? (y/N)
+? Really update the workload "tanzu-java-web-app"? (y/N)
 ```
 </details>
 
@@ -100,7 +102,7 @@ The app of which the workload is part of. This is part of the workload metadata 
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-tag tap-1.1 --type web --app spring-petclinic
+tanzu apps workload apply tanzu-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-tag tap-1.3 --type web --app tanzu-java-web-app
 
 Create workload:
     1 + |---
@@ -108,22 +110,23 @@ Create workload:
     3 + |kind: Workload
     4 + |metadata:
     5 + |  labels:
-    6 + |    app.kubernetes.io/part-of: spring-petclinic
+    6 + |    app.kubernetes.io/part-of: tanzu-java-web-app
     7 + |    apps.tanzu.vmware.com/workload-type: web
-    8 + |  name: pet-clinic
+    8 + |  name: tanzu-app
     9 + |  namespace: default
    10 + |spec:
    11 + |  source:
    12 + |    git:
    13 + |      ref:
-   14 + |        tag: tap-1.1
-   15 + |      url: https://github.com/sample-accelerators/spring-petclinic
+   14 + |        tag: tap-1.3
+   15 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+   16 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload? Yes
-Created workload "pet-clinic"
+Created workload "tanzu-app"
 
-To see logs:   "tanzu apps workload tail pet-clinic"
-To get status: "tanzu apps workload get pet-clinic"
+To see logs:   "tanzu apps workload tail tanzu-app"
+To get status: "tanzu apps workload get tanzu-app"
 
 ```
 </details>
@@ -135,7 +138,7 @@ Sets environment variables to be used in the **build** phase by the build resour
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-tag tap-1.1 --type web --build-env JAVA_VERSION=1.8
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-tag tap-1.3 --type web --build-env JAVA_VERSION=1.8
 Create workload:
       1 + |---
       2 + |apiVersion: carto.run/v1alpha1
@@ -143,7 +146,7 @@ Create workload:
       4 + |metadata:
       5 + |  labels:
       6 + |    apps.tanzu.vmware.com/workload-type: web
-      7 + |  name: spring-pet-clinic
+      7 + |  name: tanzu-java-web-app
       8 + |  namespace: default
       9 + |spec:
      10 + |  build:
@@ -153,8 +156,9 @@ Create workload:
      14 + |  source:
      15 + |    git:
      16 + |      ref:
-     17 + |        tag: tap-1.1
-     18 + |      url: https://github.com/sample-accelerators/spring-petclinic
+     17 + |        tag: tap-1.3
+     18 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+     19 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload?
 ```
@@ -165,11 +169,11 @@ To delete a build environment variable, use `-` after its name.
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --build-env JAVA_VERSION-
+tanzu apps workload apply tanzu-java-web-app --build-env JAVA_VERSION-
 Update workload:
 ...
    6,  6   |    apps.tanzu.vmware.com/workload-type: web
-   7,  7   |  name: spring-pet-clinic
+   7,  7   |  name: tanzu-java-web-app
    8,  8   |  namespace: default
    9,  9   |spec:
   10     - |  build:
@@ -179,10 +183,10 @@ Update workload:
   14, 10   |  source:
   15, 11   |    git:
   16, 12   |      ref:
-  17, 13   |        tag: tap-1.1
+  17, 13   |        tag: tap-1.3
 ...
 
-? Really update the workload "spring-pet-clinic"? (y/N)
+? Really update the workload "tanzu-java-web-app"? (y/N)
 ```
 </details>
 
@@ -193,7 +197,7 @@ Sets the parameter variable debug to true in the workload.
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-branch main --type web --debug
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-branch main --type web --debug
 Create workload:
       1 + |---
       2 + |apiVersion: carto.run/v1alpha1
@@ -201,7 +205,7 @@ Create workload:
       4 + |metadata:
       5 + |  labels:
       6 + |    apps.tanzu.vmware.com/workload-type: web
-      7 + |  name: spring-pet-clinic
+      7 + |  name: tanzu-java-web-app
       8 + |  namespace: default
       9 + |spec:
      10 + |  params:
@@ -211,7 +215,8 @@ Create workload:
      14 + |    git:
      15 + |      ref:
      16 + |        branch: main
-     17 + |      url: https://github.com/sample-accelerators/spring-petclinic
+     17 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+     18 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload? (y/N)
 ```
@@ -224,7 +229,7 @@ Prepares all the steps to submit the workload to the cluster and stops before se
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-tag tap-1.1 --type web --build-env JAVA_VERSION=1.8 --param-yaml server=$'port: 8080\nmanagement-port: 8181' --dry-run
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-tag tap-1.3 --type web --build-env JAVA_VERSION=1.8 --param-yaml server=$'port: 8080\nmanagement-port: 8181' --dry-run
 ---
 apiVersion: carto.run/v1alpha1
 kind: Workload
@@ -232,7 +237,7 @@ metadata:
   creationTimestamp: null
   labels:
     apps.tanzu.vmware.com/workload-type: web
-  name: spring-pet-clinic
+  name: tanzu-java-web-app
   namespace: default
 spec:
   build:
@@ -247,8 +252,9 @@ spec:
   source:
     git:
       ref:
-        tag: tap-1.1
-      url: https://github.com/sample-accelerators/spring-petclinic
+        tag: tap-1.3
+      url: https://github.com/vmware-tanzu/application-accelerator-samples
+    subPath: tanzu-java-web-app
 status:
   supplyChainRef: {}
 ```
@@ -261,7 +267,7 @@ status:
  <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-tag tap-1.1 --type web --env NAME="Spring Pet Clinic"
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-tag tap-1.3 --type web --env NAME="Tanzu Java App"
 Create workload:
       1 + |---
       2 + |apiVersion: carto.run/v1alpha1
@@ -269,17 +275,18 @@ Create workload:
       4 + |metadata:
       5 + |  labels:
       6 + |    apps.tanzu.vmware.com/workload-type: web
-      7 + |  name: spring-pet-clinic
+      7 + |  name: tanzu-java-web-app
       8 + |  namespace: default
       9 + |spec:
      10 + |  env:
      11 + |  - name: NAME
-     12 + |    value: Spring Pet Clinic
+     12 + |    value: Tanzu Java App
      13 + |  source:
      14 + |    git:
      15 + |      ref:
-     16 + |        tag: tap-1.1
-     17 + |      url: https://github.com/sample-accelerators/spring-petclinic
+     16 + |        tag: tap-1.3
+     17 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+     18 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload?
 ```
@@ -287,23 +294,23 @@ Create workload:
 To unset an environment variable, use `-` after its name.
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --env NAME-
+tanzu apps workload apply tanzu-java-web-app --env NAME-
 Update workload:
 ...
    6,  6   |    apps.tanzu.vmware.com/workload-type: web
-   7,  7   |  name: spring-pet-clinic
+   7,  7   |  name: tanzu-java-web-app
    8,  8   |  namespace: default
    9,  9   |spec:
   10     - |  env:
   11     - |  - name: NAME
-  12     - |    value: Spring Pet Clinic
+  12     - |    value: Tanzu Java App
   13, 10   |  source:
   14, 11   |    git:
   15, 12   |      ref:
-  16, 13   |        tag: tap-1.1
+  16, 13   |        tag: tap-1.3
 ...
 
-? Really update the workload "spring-pet-clinic"? (y/N)
+? Really update the workload "tanzu-java-web-app"? (y/N)
 ```
 </details>
 
@@ -314,7 +321,7 @@ Sets the workload specification file to create the workload, from any other work
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic -f pet-clinic.yaml --param-yaml server=$'port: 9090\nmanagement-port: 9190'
+tanzu apps workload apply tanzu-java-web-app -f java-app-workload.yaml --param-yaml server=$'port: 9090\nmanagement-port: 9190'
 Create workload:
        1 + |---
        2 + |apiVersion: carto.run/v1alpha1
@@ -322,7 +329,7 @@ Create workload:
        4 + |metadata:
        5 + |  labels:
        6 + |    apps.tanzu.vmware.com/workload-type: web
-       7 + |  name: spring-pet-clinic
+       7 + |  name: tanzu-java-web-app
        8 + |  namespace: default
        9 + |spec:
       10 + |  build:
@@ -337,8 +344,9 @@ Create workload:
       19 + |  source:
       20 + |    git:
       21 + |      ref:
-      22 + |        tag: tap-1.1
-      23 + |      url: https://github.com/sample-accelerators/spring-petclinic
+      22 + |        tag: tap-1.3
+      23 + |      url: url: https://github.com/vmware-tanzu/application-accelerator-samples
+      24 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload? (y/N)
 ```
@@ -355,7 +363,7 @@ Branch in a Git repository from where the workload is created. This is specified
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-branch main --type web
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-branch main --type web
 Create workload:
     1 + |---
     2 + |apiVersion: carto.run/v1alpha1
@@ -363,14 +371,15 @@ Create workload:
     4 + |metadata:
     5 + |  labels:
     6 + |    apps.tanzu.vmware.com/workload-type: web
-    7 + |  name: spring-pet-clinic
+    7 + |  name: tanzu-java-web-app
     8 + |  namespace: default
     9 + |spec:
    10 + |  source:
    11 + |    git:
    12 + |      ref:
    13 + |        branch: main
-   14 + |      url: https://github.com/sample-accelerators/spring-petclinic
+   14 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+   15 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload?
 ```
@@ -387,7 +396,7 @@ Commit in Git repository| from where the workload is resolved. Can be used with 
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-tag tap-1.2 --git-commit 207852f1e8ed239b6ec51a559c6e0f93a5cf54d1 --type web
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-tag tap-1.3 --git-commit 1c4cf82e499f7e46da182922d4097908d4817320 --type web
 Create workload:
     1 + |---
     2 + |apiVersion: carto.run/v1alpha1
@@ -395,15 +404,16 @@ Create workload:
     4 + |metadata:
     5 + |  labels:
     6 + |    apps.tanzu.vmware.com/workload-type: web
-    7 + |  name: spring-pet-clinic
+    7 + |  name: tanzu-java-web-app
     8 + |  namespace: default
     9 + |spec:
    10 + |  source:
    11 + |    git:
    12 + |      ref:
-   13 + |        commit: 207852f1e8ed239b6ec51a559c6e0f93a5cf54d1
-   14 + |        tag: tap-1.2
-   15 + |      url: https://github.com/sample-accelerators/spring-petclinic
+   13 + |        commit: 1c4cf82e499f7e46da182922d4097908d4817320
+   14 + |        tag: tap-1.3
+   15 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+   16 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload?
 ```
@@ -416,7 +426,7 @@ Sets the OSI image to be used as the workload application source instead of a Gi
  <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --image private.repo.domain.com/spring-pet-clinic --type web
+tanzu apps workload apply tanzu-java-web-app --image private.repo.domain.com/tanzu-java-web-app --type web
 Create workload:
        1 + |---
        2 + |apiVersion: carto.run/v1alpha1
@@ -424,7 +434,7 @@ Create workload:
        4 + |metadata:
        5 + |  labels:
        6 + |    apps.tanzu.vmware.com/workload-type: web
-       7 + |  name: spring-pet-clinic
+       7 + |  name: tanzu-java-web-app
        8 + |  namespace: default
        9 + |spec:
       10 + |  build:
@@ -439,8 +449,9 @@ Create workload:
       19 + |  source:
       20 + |    git:
       21 + |      ref:
-      22 + |        tag: tap-1.1
-      23 + |      url: https://github.com/sample-accelerators/spring-petclinic
+      22 + |        tag: tap-1.3
+      23 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+      24 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload? (y/N)
 ```
@@ -453,7 +464,7 @@ Set the label to be applied to the workload, to specify more than one label set 
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-branch main --type web --label stage=production
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-branch main --type web --label stage=production
 Create workload:
       1 + |---
       2 + |apiVersion: carto.run/v1alpha1
@@ -462,14 +473,15 @@ Create workload:
       5 + |  labels:
       6 + |    apps.tanzu.vmware.com/workload-type: web
       7 + |    stage: production
-      8 + |  name: spring-pet-clinic
+      8 + |  name: tanzu-java-web-app
       9 + |  namespace: default
      10 + |spec:
      11 + |  source:
      12 + |    git:
      13 + |      ref:
      14 + |        branch: main
-     15 + |      url: https://github.com/sample-accelerators/spring-petclinic
+     15 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+     16 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload? (y/N)
 ```
@@ -480,7 +492,7 @@ Create workload:
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --label stage-
+tanzu apps workload apply tanzu-java-web-app --label stage-
 Update workload:
 ...
    3,  3   |kind: Workload
@@ -488,13 +500,13 @@ Update workload:
    5,  5   |  labels:
    6,  6   |    apps.tanzu.vmware.com/workload-type: web
    7     - |    stage: production
-   8,  7   |  name: spring-pet-clinic
+   8,  7   |  name: tanzu-java-web-app
    9,  8   |  namespace: default
   10,  9   |spec:
   11, 10   |  source:
 ...
 
-? Really update the workload "spring-pet-clinic"? (y/N)
+? Really update the workload "tanzu-java-web-app"? (y/N)
 ```
 </details>
 
@@ -505,7 +517,7 @@ Update workload:
  <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-branch main --type web --limit-cpu .2
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-branch main --type web --limit-cpu .2
 Create workload:
     1 + |---
     2 + |apiVersion: carto.run/v1alpha1
@@ -513,7 +525,7 @@ Create workload:
     4 + |metadata:
     5 + |  labels:
     6 + |    apps.tanzu.vmware.com/workload-type: web
-    7 + |  name: spring-pet-clinic
+    7 + |  name: tanzu-java-web-app
     8 + |  namespace: default
     9 + |spec:
    10 + |  resources:
@@ -523,7 +535,8 @@ Create workload:
    14 + |    git:
    15 + |      ref:
    16 + |        branch: main
-   17 + |      url: https://github.com/sample-accelerators/spring-petclinic
+   17 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+   18 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload? (y/N)
 ```
@@ -536,7 +549,7 @@ Refers to the maximum memory the workload pods are allowed to use.
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-branch main --type web --limit-memory 200Mi
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-branch main --type web --limit-memory 200Mi
 Create workload:
     1 + |---
     2 + |apiVersion: carto.run/v1alpha1
@@ -544,7 +557,7 @@ Create workload:
     4 + |metadata:
     5 + |  labels:
     6 + |    apps.tanzu.vmware.com/workload-type: web
-    7 + |  name: spring-pet-clinic
+    7 + |  name: tanzu-java-web-app
     8 + |  namespace: default
     9 + |spec:
    10 + |  resources:
@@ -554,7 +567,8 @@ Create workload:
    14 + |    git:
    15 + |      ref:
    16 + |        branch: main
-   17 + |      url: https://github.com/sample-accelerators/spring-petclinic
+   17 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+   18 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload? (y/N)
 ```
@@ -566,8 +580,9 @@ Enable to deploy the workload once, save changes to the code, and see those chan
 
 <details><summary>Example</summary>
 
-  - A uuse example with a spring boot application.
-    - Clone repository in https://github.com/sample-accelerators/tanzu-java-web-app
+  - A usage example with a spring boot application.
+    - Clone repository in https://github.com/vmware-tanzu/application-accelerator-samples
+    - Change into the `tanzu-java-web-app` directory
     - In `Tiltfile`, first change the `SOURCE_IMAGE` variable to use your registry and project. After that, at the very end of the file add
     ```bash
     allow_k8s_contexts('your-cluster-name')
@@ -721,7 +736,7 @@ Specifies the namespace in which the workload is to be created or updated.
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-branch main --type web --namespace my-namespace
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-branch main --type web --namespace my-namespace
 Create workload:
     1 + |---
     2 + |apiVersion: carto.run/v1alpha1
@@ -729,14 +744,15 @@ Create workload:
     4 + |metadata:
     5 + |  labels:
     6 + |    apps.tanzu.vmware.com/workload-type: web
-    7 + |  name: spring-pet-clinic
+    7 + |  name: tanzu-java-web-app
     8 + |  namespace: my-namespace
     9 + |spec:
    10 + |  source:
    11 + |    git:
    12 + |      ref:
    13 + |        branch: main
-   14 + |      url: https://github.com/sample-accelerators/spring-petclinic
+   14 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+  15 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload? (y/N)
 ```
@@ -749,7 +765,7 @@ Additional parameters to be sent to the supply chain, the value is sent as a str
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-branch main --type web --param port=9090 --param management-port=9190
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-branch main --type web --param port=9090 --param management-port=9190
 Create workload:
       1 + |---
       2 + |apiVersion: carto.run/v1alpha1
@@ -757,7 +773,7 @@ Create workload:
       4 + |metadata:
       5 + |  labels:
       6 + |    apps.tanzu.vmware.com/workload-type: web
-      7 + |  name: spring-pet-clinic
+      7 + |  name: tanzu-java-web-app
       8 + |  namespace: default
       9 + |spec:
      10 + |  params:
@@ -769,7 +785,8 @@ Create workload:
      16 + |    git:
      17 + |      ref:
      18 + |        branch: main
-     19 + |      url: https://github.com/sample-accelerators/spring-petclinic
+     19 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+     20 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload? (y/N)
 ```
@@ -780,10 +797,10 @@ To unset parameters, use `-` after their name.
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --param port-
+tanzu apps workload apply tanzu-java-web-app --param port-
 Update workload:
 ...
-   7,  7   |  name: spring-pet-clinic
+   7,  7   |  name: tanzu-java-web-app
    8,  8   |  namespace: default
    9,  9   |spec:
   10, 10   |  params:
@@ -795,7 +812,7 @@ Update workload:
   16, 14   |    git:
 ...
 
-? Really update the workload "spring-pet-clinic"? (y/N)
+? Really update the workload "tanzu-java-web-app"? (y/N)
 ```
 </details>
 
@@ -806,7 +823,7 @@ Additional parameters to be sent to the supply chain, the value is sent as a com
  <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-branch main --type web --param-yaml server=$'port: 9090\nmanagement-port: 9190'
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-branch main --type web --param-yaml server=$'port: 9090\nmanagement-port: 9190'
 Create workload:
       1 + |---
       2 + |apiVersion: carto.run/v1alpha1
@@ -814,7 +831,7 @@ Create workload:
       4 + |metadata:
       5 + |  labels:
       6 + |    apps.tanzu.vmware.com/workload-type: web
-      7 + |  name: spring-pet-clinic
+      7 + |  name: tanzu-java-web-app
       8 + |  namespace: default
       9 + |spec:
      10 + |  params:
@@ -826,7 +843,8 @@ Create workload:
      16 + |    git:
      17 + |      ref:
      18 + |        branch: main
-     19 + |      url: https://github.com/sample-accelerators/spring-petclinic
+     19 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+     20 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload? (y/N)
 ```
@@ -837,11 +855,11 @@ To unset parameters, use `-` after their name.
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --param-yaml server-
+tanzu apps workload apply tanzu-java-web-app --param-yaml server-
 Update workload:
 ...
    6,  6   |    apps.tanzu.vmware.com/workload-type: web
-   7,  7   |  name: spring-pet-clinic
+   7,  7   |  name: tanzu-java-web-app
    8,  8   |  namespace: default
    9,  9   |spec:
   10     - |  params:
@@ -855,7 +873,7 @@ Update workload:
   18, 13   |        branch: main
 ...
 
-? Really update the workload "spring-pet-clinic"? (y/N)
+? Really update the workload "tanzu-java-web-app"? (y/N)
 ```
 </details>
 
@@ -908,7 +926,7 @@ Refers to the minimum CPU the workload pods are requesting to use.
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-branch main --type web --request-cpu .3
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-branch main --type web --request-cpu .3
 Create workload:
     1 + |---
     2 + |apiVersion: carto.run/v1alpha1
@@ -916,7 +934,7 @@ Create workload:
     4 + |metadata:
     5 + |  labels:
     6 + |    apps.tanzu.vmware.com/workload-type: web
-    7 + |  name: spring-pet-clinic
+    7 + |  name: tanzu-java-web-app
     8 + |  namespace: default
     9 + |spec:
    10 + |  resources:
@@ -926,7 +944,8 @@ Create workload:
    14 + |    git:
    15 + |      ref:
    16 + |        branch: main
-   17 + |      url: https://github.com/sample-accelerators/spring-petclinic
+   17 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+   18 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload? (y/N)
 ```
@@ -939,7 +958,7 @@ Refers to the minimum memory the workload pods are requesting to use.
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-branch main --type web --request-memory 300Mi
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-branch main --type web --request-memory 300Mi
 Create workload:
      1 + |---
      2 + |apiVersion: carto.run/v1alpha1
@@ -947,7 +966,7 @@ Create workload:
      4 + |metadata:
      5 + |  labels:
      6 + |    apps.tanzu.vmware.com/workload-type: web
-     7 + |  name: spring-pet-clinic
+     7 + |  name: tanzu-java-web-app
      8 + |  namespace: default
      9 + |spec:
     10 + |  resources:
@@ -957,7 +976,8 @@ Create workload:
     14 + |    git:
     15 + |      ref:
     16 + |        branch: main
-    17 + |      url: https://github.com/sample-accelerators/spring-petclinic
+    17 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+    18 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload? (y/N)
 ```
@@ -970,7 +990,7 @@ Refers to the service account to be associated with the workload. A service acco
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-branch main --type web --service-account petc-serviceaccount
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-branch main --type web --service-account petc-serviceaccount
 Create workload:
       1 + |---
       2 + |apiVersion: carto.run/v1alpha1
@@ -978,7 +998,7 @@ Create workload:
       4 + |metadata:
       5 + |  labels:
       6 + |    apps.tanzu.vmware.com/workload-type: web
-      7 + |  name: spring-pet-clinic
+      7 + |  name: tanzu-java-web-app
       8 + |  namespace: default
       9 + |spec:
      10 + |  serviceAccountName: petc-serviceaccount
@@ -986,7 +1006,8 @@ Create workload:
      12 + |    git:
      13 + |      ref:
      14 + |        branch: main
-     15 + |      url: https://github.com/sample-accelerators/spring-petclinic
+     15 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+     16 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload? (y/N)
 ```
@@ -997,11 +1018,11 @@ To unset a service account, pass empty string.
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-branch main --type web --service-account ""
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-branch main --type web --service-account ""
 Update workload:
 ...
   6,  6   |    apps.tanzu.vmware.com/workload-type: web
-  7,  7   |  name: spring-pet-clinic
+  7,  7   |  name: tanzu-java-web-app
   8,  8   |  namespace: default
   9,  9   |spec:
  10     - |  serviceAccountName: petc-serviceaccount
@@ -1011,7 +1032,7 @@ Update workload:
  14, 13   |        branch: main
 ...
 
-? Really update the workload "spring-pet-clinic"? (y/N)
+? Really update the workload "tanzu-java-web-app"? (y/N)
 ```
 </details>
 
@@ -1138,7 +1159,7 @@ Prints the logs of the workload creation in every step.
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-branch main --type web --tail
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-branch main --type web --tail
 Create workload:
       1 + |---
       2 + |apiVersion: carto.run/v1alpha1
@@ -1146,33 +1167,34 @@ Create workload:
       4 + |metadata:
       5 + |  labels:
       6 + |    apps.tanzu.vmware.com/workload-type: web
-      7 + |  name: spring-pet-clinic
+      7 + |  name: tanzu-java-web-app
       8 + |  namespace: default
       9 + |spec:
      10 + |  source:
      11 + |    git:
      12 + |      ref:
      13 + |        branch: main
-     14 + |      url: https://github.com/sample-accelerators/spring-petclinic
+     14 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+     15 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload? Yes
-Created workload "spring-pet-clinic"
+Created workload "tanzu-java-web-app"
 
-To see logs:   "tanzu apps workload tail spring-pet-clinic"
-To get status: "tanzu apps workload get spring-pet-clinic"
+To see logs:   "tanzu apps workload tail tanzu-java-web-app"
+To get status: "tanzu apps workload get tanzu-java-web-app"
 
-Waiting for workload "spring-pet-clinic" to become ready...
-+ spring-pet-clinic-build-1-build-pod › prepare
-spring-pet-clinic-build-1-build-pod[prepare] Build reason(s): CONFIG
-spring-pet-clinic-build-1-build-pod[prepare] CONFIG:
-spring-pet-clinic-build-1-build-pod[prepare]   + env:
-spring-pet-clinic-build-1-build-pod[prepare]   + - name: BP_OCI_SOURCE
-spring-pet-clinic-build-1-build-pod[prepare]   +   value: main/d381fb658cb435a04e2271ca85bd3e8627a5e7e4
-spring-pet-clinic-build-1-build-pod[prepare]   resources: {}
-spring-pet-clinic-build-1-build-pod[prepare]   - source: {}
-spring-pet-clinic-build-1-build-pod[prepare]   + source:
-spring-pet-clinic-build-1-build-pod[prepare]   +   blob:
-spring-pet-clinic-build-1-build-pod[prepare]   +     url: http://source-controller.flux-system.svc.cluster.local./gitrepository/default/spring-pet-clinic/d381fb658cb435a04e2271ca85bd3e8627a5e7e4.tar.gz
+Waiting for workload "tanzu-java-web-app" to become ready...
++ tanzu-java-web-app-build-1-build-pod › prepare
+tanzu-java-web-app-build-1-build-pod[prepare] Build reason(s): CONFIG
+tanzu-java-web-app-build-1-build-pod[prepare] CONFIG:
+tanzu-java-web-app-build-1-build-pod[prepare]   + env:
+tanzu-java-web-app-build-1-build-pod[prepare]   + - name: BP_OCI_SOURCE
+tanzu-java-web-app-build-1-build-pod[prepare]   +   value: main/d381fb658cb435a04e2271ca85bd3e8627a5e7e4
+tanzu-java-web-app-build-1-build-pod[prepare]   resources: {}
+tanzu-java-web-app-build-1-build-pod[prepare]   - source: {}
+tanzu-java-web-app-build-1-build-pod[prepare]   + source:
+tanzu-java-web-app-build-1-build-pod[prepare]   +   blob:
+tanzu-java-web-app-build-1-build-pod[prepare]   +     url: http://source-controller.flux-system.svc.cluster.local./gitrepository/default/tanzu-java-web-app/1c4cf82e499f7e46da182922d4097908d4817320.tar.gz
 ...
 ...
 ...
@@ -1186,7 +1208,7 @@ Prints the logs of the workload creation in every step adding the time in which 
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-branch main --type web --tail-timestamp
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-branch main --type web --tail-timestamp
 Create workload:
       1 + |---
       2 + |apiVersion: carto.run/v1alpha1
@@ -1194,33 +1216,34 @@ Create workload:
       4 + |metadata:
       5 + |  labels:
       6 + |    apps.tanzu.vmware.com/workload-type: web
-      7 + |  name: spring-pet-clinic
+      7 + |  name: tanzu-java-web-app
       8 + |  namespace: default
       9 + |spec:
      10 + |  source:
      11 + |    git:
      12 + |      ref:
      13 + |        branch: main
-     14 + |      url: https://github.com/sample-accelerators/spring-petclinic
+     14 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+     15 + |    subPath: tanzu-java-web-app
 
 ? Do you want to create this workload? Yes
-Created workload "spring-pet-clinic"
+Created workload "tanzu-java-web-app"
 
-To see logs:   "tanzu apps workload tail spring-pet-clinic"
-To get status: "tanzu apps workload get spring-pet-clinic"
+To see logs:   "tanzu apps workload tail tanzu-java-web-app"
+To get status: "tanzu apps workload get tanzu-java-web-app"
 
-Waiting for workload "spring-pet-clinic" to become ready...
-+ spring-pet-clinic-build-1-build-pod › prepare
-spring-pet-clinic-build-1-build-pod[prepare] 2022-06-15T11:28:01.348418803-05:00 Build reason(s): CONFIG
-spring-pet-clinic-build-1-build-pod[prepare] 2022-06-15T11:28:01.364719405-05:00 CONFIG:
-spring-pet-clinic-build-1-build-pod[prepare] 2022-06-15T11:28:01.364761781-05:00   + env:
-spring-pet-clinic-build-1-build-pod[prepare] 2022-06-15T11:28:01.364771861-05:00   + - name: BP_OCI_SOURCE
-spring-pet-clinic-build-1-build-pod[prepare] 2022-06-15T11:28:01.364781718-05:00   +   value: main/d381fb658cb435a04e2271ca85bd3e8627a5e7e4
-spring-pet-clinic-build-1-build-pod[prepare] 2022-06-15T11:28:01.364788374-05:00   resources: {}
-spring-pet-clinic-build-1-build-pod[prepare] 2022-06-15T11:28:01.364795451-05:00   - source: {}
-spring-pet-clinic-build-1-build-pod[prepare] 2022-06-15T11:28:01.365344965-05:00   + source:
-spring-pet-clinic-build-1-build-pod[prepare] 2022-06-15T11:28:01.365364101-05:00   +   blob:
-spring-pet-clinic-build-1-build-pod[prepare] 2022-06-15T11:28:01.365372427-05:00   +     url: http://source-controller.flux-system.svc.cluster.local./gitrepository/default/spring-pet-clinic/d381fb658cb435a04e2271ca85bd3e8627a5e7e4.tar.gz
+Waiting for workload "tanzu-java-web-app" to become ready...
++ tanzu-java-web-app-build-1-build-pod › prepare
+tanzu-java-web-app-build-1-build-pod[prepare] 2022-06-15T11:28:01.348418803-05:00 Build reason(s): CONFIG
+tanzu-java-web-app-build-1-build-pod[prepare] 2022-06-15T11:28:01.364719405-05:00 CONFIG:
+tanzu-java-web-app-build-1-build-pod[prepare] 2022-06-15T11:28:01.364761781-05:00   + env:
+tanzu-java-web-app-build-1-build-pod[prepare] 2022-06-15T11:28:01.364771861-05:00   + - name: BP_OCI_SOURCE
+tanzu-java-web-app-build-1-build-pod[prepare] 2022-06-15T11:28:01.364781718-05:00   +   value: main/d381fb658cb435a04e2271ca85bd3e8627a5e7e4
+tanzu-java-web-app-build-1-build-pod[prepare] 2022-06-15T11:28:01.364788374-05:00   resources: {}
+tanzu-java-web-app-build-1-build-pod[prepare] 2022-06-15T11:28:01.364795451-05:00   - source: {}
+tanzu-java-web-app-build-1-build-pod[prepare] 2022-06-15T11:28:01.365344965-05:00   + source:
+tanzu-java-web-app-build-1-build-pod[prepare] 2022-06-15T11:28:01.365364101-05:00   +   blob:
+tanzu-java-web-app-build-1-build-pod[prepare] 2022-06-15T11:28:01.365372427-05:00   +     url: http://source-controller.flux-system.svc.cluster.local./gitrepository/default/tanzu-java-web-app/1c4cf82e499f7e46da182922d4097908d4817320.tar.gz
 ...
 ...
 ...
@@ -1234,7 +1257,7 @@ Sets the type of the workload by adding the label `apps.tanzu.vmware.com/workloa
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-branch main --type web
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-branch main --type web
 Create workload:
       1 + |---
       2 + |apiVersion: carto.run/v1alpha1
@@ -1242,14 +1265,15 @@ Create workload:
       4 + |metadata:
       5 + |  labels:
       6 + |    apps.tanzu.vmware.com/workload-type: web
-      7 + |  name: spring-pet-clinic
+      7 + |  name: tanzu-java-web-app
       8 + |  namespace: default
       9 + |spec:
      10 + |  source:
      11 + |    git:
      12 + |      ref:
      13 + |        branch: main
-     14 + |      url: https://github.com/sample-accelerators/spring-petclinic
+     14 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+     15 + |    subPath: tanzu-java-web-app
 ```
 </details>
 
@@ -1260,24 +1284,25 @@ Holds until workload is ready.
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-tag tap-1.1 --type web --wait
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-tag tap-1.3 --type web --wait
 Update workload:
 ...
 10, 10   |  source:
 11, 11   |    git:
 12, 12   |      ref:
 13, 13   |        branch: main
-    14 + |        tag: tap-1.1
-14, 15   |      url: https://github.com/sample-accelerators/spring-petclinic
+    14 + |        tag: tap-1.3
+14, 15   |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+15, 16   |    subPath: tanzu-java-web-app
 
-? Really update the workload "spring-pet-clinic"? Yes
-Updated workload "spring-pet-clinic"
+? Really update the workload "tanzu-java-web-app"? Yes
+Updated workload "tanzu-java-web-app"
 
-To see logs:   "tanzu apps workload tail spring-pet-clinic"
-To get status: "tanzu apps workload get spring-pet-clinic"
+To see logs:   "tanzu apps workload tail tanzu-java-web-app"
+To get status: "tanzu apps workload get tanzu-java-web-app"
 
-Waiting for workload "spring-pet-clinic" to become ready...
-Workload "spring-pet-clinic" is ready
+Waiting for workload "tanzu-java-web-app" to become ready...
+Workload "tanzu-java-web-app" is ready
 ```
 </details>
 
@@ -1288,25 +1313,26 @@ Sets a timeout to wait for workload to become ready.
 <details><summary>Example</summary>
 
 ```bash
-tanzu apps workload apply spring-pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-tag tap-1.1 --type web --wait --wait-timeout 1m
+tanzu apps workload apply tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-tag tap-1.3-take1 --type web --wait --wait-timeout 1m
 Update workload:
 ...
 10, 10   |  source:
 11, 11   |    git:
 12, 12   |      ref:
 13, 13   |        branch: main
-14     - |        tag: tap-1.2
-    14 + |        tag: tap-1.1
-15, 15   |      url: https://github.com/sample-accelerators/spring-petclinic
+14     - |        tag: tap-1.3
+    14 + |        tag: tap-1.3-take1
+15, 15   |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+16, 16   |    subPath: tanzu-java-web-app
 
-? Really update the workload "spring-pet-clinic"? Yes
-Updated workload "spring-pet-clinic"
+? Really update the workload "tanzu-java-web-app"? Yes
+Updated workload "tanzu-java-web-app"
 
-To see logs:   "tanzu apps workload tail spring-pet-clinic"
-To get status: "tanzu apps workload get spring-pet-clinic"
+To see logs:   "tanzu apps workload tail tanzu-java-web-app"
+To get status: "tanzu apps workload get tanzu-java-web-app"
 
-Waiting for workload "spring-pet-clinic" to become ready...
-Workload "spring-pet-clinic" is ready
+Waiting for workload "tanzu-java-web-app" to become ready...
+Workload "tanzu-java-web-app" is ready
 ```
 </details>
 

--- a/cli-plugins/apps/command-reference/commands-details/workload_get.hbs.md
+++ b/cli-plugins/apps/command-reference/commands-details/workload_get.hbs.md
@@ -83,7 +83,7 @@ To see logs: "tanzu apps workload tail rmq-sample-app"
 Exports the submitted workload in `yaml` format. This flag can also be used with `--output` flag. With export, the output is shortened because some fields are removed.
 
 ```bash
-tanzu apps workload get pet-clinic --export
+tanzu apps workload get tanzu-java-web-app --export
 
 ---
 apiVersion: carto.run/v1alpha1
@@ -92,14 +92,15 @@ metadata:
 labels:
     apps.tanzu.vmware.com/workload-type: web
     autoscaling.knative.dev/min-scale: "1"
-name: pet-clinic
+name: tanzu-java-web-app
 namespace: default
 spec:
 source:
     git:
     ref:
-        tag: tap-1.2
-    url: https://github.com/sample-accelerators/spring-petclinic
+        tag: tap-1.3
+      url: https://github.com/vmware-tanzu/application-accelerator-samples
+    subPath: tanzu-java-web-app
 ```
 
 ### <a id="get-output"></a> `--output`/`-o`
@@ -108,7 +109,7 @@ Configures how the workload is being shown. This supports the values `yaml`, `ym
 
 + `yaml/yml`
     ```yaml
-    tanzu apps workload get pet-clinic -o yaml]
+    tanzu apps workload get tanzu-java-web-app -o yaml]
     ---
     apiVersion: carto.run/v1alpha1
     kind: Workload
@@ -122,9 +123,10 @@ Configures how the workload is being shown. This supports the values `yaml`, `ym
     spec:
     source:
         git:
-        ref:
-            tag: tap-1.1
-        url: https://github.com/sample-accelerators/spring-petclinic
+            ref:
+                tag: tap-1.1
+            url: https://github.com/vmware-tanzu/application-accelerator-samples
+        subPath: tanzu-java-web-app
     status:
         conditions:
         - lastTransitionTime: "2022-06-03T18:10:59Z"
@@ -153,12 +155,12 @@ Configures how the workload is being shown. This supports the values `yaml`, `ym
 
 + `json`
     ```json
-    tanzu apps workload get pet-clinic -o json
+    tanzu apps workload get tanzu-java-web-app -o json
     {
         "kind": "Workload",
         "apiVersion": "carto.run/v1alpha1",
         "metadata": {
-            "name": "pet-clinic",
+            "name": "tanzu-java-web-app",
             "namespace": "default",
             "uid": "937679ca-9c72-4e23-bfef-6334e6c003a7",
             "resourceVersion": "111637840",
@@ -173,11 +175,12 @@ Configures how the workload is being shown. This supports the values `yaml`, `ym
     "spec": {
             "source": {
                 "git": {
-                    "url": "https://github.com/sample-accelerators/spring-petclinic",
+                    "url": "https://github.com/vmware-tanzu/application-accelerator-samples",
                     "ref": {
-                        "tag": "tap-1.1"
+                        "tag": "tap-1.3"
                     }
-                }
+                },
+                "subPath": "tanzu-java-web-app"
             }
         },
         "status": {
@@ -215,7 +218,7 @@ Configures how the workload is being shown. This supports the values `yaml`, `ym
                     "stampedRef": {
                         "kind": "GitRepository",
                         "namespace": "default",
-                        "name": "pet-clinic",
+                        "name": "tanzu-java-web-app",
                         ...
                     }
                 }
@@ -231,51 +234,52 @@ Configures how the workload is being shown. This supports the values `yaml`, `ym
 Specifies the namespace where the workload is deployed.
 
 ```bash
-tanzu apps workload get spring-pet-clinic -n development
+tanzu apps workload get tanzu-java-web-app -n development
 
 📡 Overview
-   name:   spring-pet-clinic
+   name:   tanzu-java-web-app
    type:   web
 
 💾 Source
    type:     git
-   url:      https://github.com/sample-accelerators/spring-petclinic
-   branch:   accelerator
+   url:      https://github.com/vmware-tanzu/application-accelerator-samples
+   sub-path: tanzu-java-web-app
+   tag:      tap-1.3
 
 📦 Supply Chain
    name:   source-to-url
 
    RESOURCE          READY   HEALTHY   TIME   OUTPUT
-   source-provider   True    True      27h    GitRepository/spring-pet-clinic
-   image-builder     True    True      22h    Image/spring-pet-clinic
-   config-provider   True    True      60d    PodIntent/spring-pet-clinic
-   app-config        True    True      60d    ConfigMap/spring-pet-clinic
-   config-writer     True    True      22h    Runnable/spring-pet-clinic-config-writer
+   source-provider   True    True      27h    GitRepository/tanzu-java-web-app
+   image-builder     True    True      22h    Image/tanzu-java-web-app
+   config-provider   True    True      60d    PodIntent/tanzu-java-web-app
+   app-config        True    True      60d    ConfigMap/tanzu-java-web-app
+   config-writer     True    True      22h    Runnable/tanzu-java-web-app-config-writer
 
 🚚 Delivery
    name:   delivery-basic
 
    RESOURCE          READY   HEALTHY   TIME   OUTPUT
-   source-provider   True    True      60d    ImageRepository/spring-pet-clinic-delivery
-   deployer          True    True      22h    App/spring-pet-clinic
+   source-provider   True    True      60d    ImageRepository/tanzu-java-web-app-delivery
+   deployer          True    True      22h    App/tanzu-java-web-app
 
 💬 Messages
    No messages found.
 
 🛶 Pods
    NAME                                        READY   STATUS      RESTARTS   AGE
-   spring-pet-clinic-build-11-build-pod        0/1     Completed   0          6d12h
-   spring-pet-clinic-build-12-build-pod        0/1     Completed   0          22h
-   spring-pet-clinic-build-3-build-pod         0/1     Completed   0          60d
-   spring-pet-clinic-config-writer-655rb-pod   0/1     Completed   0          21d
-   spring-pet-clinic-config-writer-7h8bn-pod   0/1     Completed   0          6d12h
-   spring-pet-clinic-config-writer-7xr6m-pod   0/1     Completed   0          60d
-   spring-pet-clinic-config-writer-g9gp8-pod   0/1     Completed   0          45d
+   tanzu-java-web-app-build-11-build-pod       0/1     Completed   0          6d12h
+   tanzu-java-web-app-build-12-build-pod       0/1     Completed   0          22h
+   tanzu-java-web-app-build-3-build-pod        0/1     Completed   0          60d
+   tanzu-java-web-app-config-writer-655rb-pod  0/1     Completed   0          21d
+   tanzu-java-web-app-config-writer-7h8bn-pod  0/1     Completed   0          6d12h
+   tanzu-java-web-app-config-writer-7xr6m-pod  0/1     Completed   0          60d
+   tanzu-java-web-app-config-writer-g9gp8-pod  0/1     Completed   0          45d
 
 🚢 Knative Services
    NAME                READY   URL
-   spring-pet-clinic   Ready   http://spring-pet-clinic.default.127.0.0.1.nip.io
+   tanzu-java-web-app  Ready   http://tanzu-java-web-app.default.127.0.0.1.nip.io
 
-To see logs: "tanzu apps workload tail spring-pet-clinic"
+To see logs: "tanzu apps workload tail tanzu-java-web-app"
 
 ```

--- a/cli-plugins/apps/command-reference/commands-details/workload_list.hbs.md
+++ b/cli-plugins/apps/command-reference/commands-details/workload_list.hbs.md
@@ -18,6 +18,8 @@ rmq-sample-app4     web       <empty>            WorkloadLabelsMissing   29d
 spring-pet-clinic   web       <empty>            Unknown                 166m
 spring-petclinic2   web       spring-petclinic   Unknown                 29d
 spring-petclinic3   <empty>   spring-petclinic   Ready                   29d
+tanzu-java-web-app  web       tanzu-java-web-app Ready                   40m
+tanzu-java-web-app2 web       tanzu-java-web-app Ready                   20m
 ```
 
 ## >Workload List flags
@@ -37,6 +39,8 @@ default     web    rmq-sample-app4     <empty>            WorkloadLabelsMissing 
 default     web    spring-pet-clinic   <empty>            Unknown                       3h1m
 default     web    spring-petclinic2   spring-petclinic   Unknown                       29d
 default     web    spring-petclinic3   spring-petclinic   Ready                         29d
+default     web    tanzu-java-web-app  tanzu-java-web-app Ready                         40m
+default     web    tanzu-java-web-app2 tanzu-java-web-app Ready                         20m
 nginx-ns    web    nginx2              <empty>            TemplateRejectedByAPIServer   8d
 nginx-ns    web    nginx4              <empty>            TemplateRejectedByAPIServer   8d
 ```
@@ -79,7 +83,7 @@ Allows to list all workloads in the specified namespace in yaml, yml or json for
         creationTimestamp: "2022-05-17T22:06:49Z"
         generation: 1
         labels:
-        app.kubernetes.io/part-of: spring-petclinic
+        app.kubernetes.io/part-of: tanzu-java-web-app
         apps.tanzu.vmware.com/workload-type: web
         managedFields:
         ...
@@ -87,16 +91,17 @@ Allows to list all workloads in the specified namespace in yaml, yml or json for
         manager: cartographer
         operation: Update
         time: "2022-05-17T22:06:52Z"
-    name: spring-petclinic3
+    name: tanzu-java-web-app2
     namespace: default
-    resourceVersion: "106252670"
-    uid: fcca2d4b-c713-43a5-9a53-9f1ebb214726
+    resourceVersion: "6071972"
+    uid: 7fbcd40d-4eb3-41dc-a1db-657b64148708
     spec:
         source:
             git:
                 ref:
-                    tag: tap-1.1
-                url: https://github.com/sample-accelerators/spring-petclinic
+                  tag: tap-1.3
+                url: https://github.com/vmware-tanzu/application-accelerator-samples
+            subPath: tanzu-java-web-app
     ...
     ...
     ---
@@ -106,7 +111,7 @@ Allows to list all workloads in the specified namespace in yaml, yml or json for
         creationTimestamp: "2022-05-17T22:06:49Z"
         generation: 1
         labels:
-        app.kubernetes.io/part-of: spring-petclinic
+        app.kubernetes.io/part-of: tanzu-java-web-app
         apps.tanzu.vmware.com/workload-type: web
         managedFields:
         ...
@@ -114,16 +119,17 @@ Allows to list all workloads in the specified namespace in yaml, yml or json for
         manager: cartographer
         operation: Update
         time: "2022-05-17T22:06:52Z"
-    name: spring-petclinic2
+    name: tanzu-java-web-app
     namespace: default
-    resourceVersion: "106252670"
-    uid: fcca2d4b-c713-43a5-9a53-9f1ebb214726
+    resourceVersion: "6071972"
+    uid: 7fbcd40d-4eb3-41dc-a1db-657b64148708
     spec:
         source:
             git:
                 ref:
-                    tag: tap-1.1
-                url: https://github.com/sample-accelerators/spring-petclinic
+                  tag: tap-1.3
+                url: https://github.com/vmware-tanzu/application-accelerator-samples
+            subPath: tanzu-java-web-app
     ...
     ...
     ```
@@ -135,14 +141,14 @@ Allows to list all workloads in the specified namespace in yaml, yml or json for
             "kind": "Workload",
             "apiVersion": "carto.run/v1alpha1",
             "metadata": {
-                "name": "spring-petclinic3",
+                "name": "tanzu-java-web-app2",
                 "namespace": "default",
-                "uid": "fcca2d4b-c713-43a5-9a53-9f1ebb214726",
-                "resourceVersion": "106252670",
+                "uid": "7fbcd40d-4eb3-41dc-a1db-657b64148708",
+                "resourceVersion": "6071972",
                 "generation": 1,
                 "creationTimestamp": "2022-05-17T22:06:49Z",
                 "labels": {
-                    "app.kubernetes.io/part-of": "spring-petclinic",
+                    "app.kubernetes.io/part-of": "tanzu-java-web-app",
                     "apps.tanzu.vmware.com/workload-type": "web"
                 },
             ...
@@ -153,14 +159,14 @@ Allows to list all workloads in the specified namespace in yaml, yml or json for
             "kind": "Workload",
             "apiVersion": "carto.run/v1alpha1",
             "metadata": {
-                "name": "spring-petclinic2",
+                "name": "tanzu-java-web-app",
                 "namespace": "default",
-                "uid": "fcca2d4b-c713-43a5-9a53-9f1ebb214726",
-                "resourceVersion": "106252670",
+                "uid": "7fbcd40d-4eb3-41dc-a1db-657b64148708",
+                "resourceVersion": "6071972",
                 "generation": 1,
                 "creationTimestamp": "2022-05-17T22:06:49Z",
                 "labels": {
-                    "app.kubernetes.io/part-of": "spring-petclinic",
+                    "app.kubernetes.io/part-of": "tanzu-java-web-app",
                     "apps.tanzu.vmware.com/workload-type": "web"
                 },
             ...

--- a/cli-plugins/apps/create-workload.hbs.md
+++ b/cli-plugins/apps/create-workload.hbs.md
@@ -22,15 +22,17 @@ Tanzu Application Platform supports creating a workload from an existing git rep
 To create a named workload and specify a git source code location, run:
 
  ```bash
-tanzu apps workload create pet-clinic --git-repo https://github.com/sample-accelerators/spring-petclinic --git-tag tap-1.1 --type web
+tanzu apps workload create tanzu-java-web-app --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --sub-path tanzu-java-web-app --git-tag tap-1.3 --type web
 ```
 
 Respond `Y` to prompts to complete process.
 
 Where:
 
-- `pet-clinic` is the name of the workload.
+- `tanzu-java-web-app` is the name of the workload.
 - `--git-repo` is the location of the code to build the workload from.
+- `--sub-path` is the relative path inside the repository to treat as application root.
+- `--git-tag` (optional) specifies which tag in the repository to pull the code from.
 - `--git-branch` (optional) specifies which branch in the repository to pull the code from.
 - `--type` is used to distinguish the workload type.
 

--- a/cli-plugins/apps/usage.hbs.md
+++ b/cli-plugins/apps/usage.hbs.md
@@ -43,16 +43,17 @@ For example, a valid file looks similar to the following example:
 apiVersion: carto.run/v1alpha1
 kind: Workload
 metadata:
-  name: spring-petclinic
+  name: tanzu-java-web-app
   labels:
-    app.kubernetes.io/part-of: spring-petclinic
+    app.kubernetes.io/part-of: tanzu-java-web-app
     apps.tanzu.vmware.com/workload-type: web
 spec:
   source:
     git:
-      url: https://github.com/sample-accelerators/spring-petclinic
+      url: https://github.com/vmware-tanzu/application-accelerator-samples
       ref:
-        tag: tap-1.1
+        tag: tap-1.3
+    subPath: tanzu-java-web-app
 ```
 
 To create a workload from a file like the one just shown, run:

--- a/fluxcd-source-controller/install-fluxcd-source-controller.hbs.md
+++ b/fluxcd-source-controller/install-fluxcd-source-controller.hbs.md
@@ -141,7 +141,7 @@ To install FluxCD source-controller from the Tanzu Application Platform package 
           name: gitrepository-sample
         spec:
           interval: 1m
-          url: https://github.com/sample-accelerators/tanzu-java-web-app
+          url: https://github.com/vmware-tanzu/application-accelerator-samples
           ref:
             branch: main
         ```
@@ -157,8 +157,8 @@ To install FluxCD source-controller from the Tanzu Application Platform package 
 
         ```
         kubectl get GitRepository
-        NAME                   URL                                                         READY   STATUS                                                              AGE
-        gitrepository-sample   https://github.com/sample-accelerators/tanzu-java-web-app   True    Fetched revision: main/132f4e719209eb10b9485302f8593fc0e680f4fc   4s
+        NAME                   URL                                                               READY   STATUS                                                              AGE
+        gitrepository-sample   https://github.com/vmware-tanzu/application-accelerator-samples   True    Fetched revision: main/132f4e719209eb10b9485302f8593fc0e680f4fc   4s
         ```
 
     For more examples, see the samples directory on [fluxcd/source-controller/samples](https://github.com/fluxcd/source-controller/tree/main/config/samples) in GitHub.

--- a/getting-started/add-test-and-security.hbs.md
+++ b/getting-started/add-test-and-security.hbs.md
@@ -114,7 +114,8 @@ the workload must be updated to point at your Tekton pipeline.
 
     ```console
     tanzu apps workload create tanzu-java-web-app \
-      --git-repo https://github.com/sample-accelerators/tanzu-java-web-app \
+      --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
+      --sub-path tanzu-java-web-app \
       --git-branch main \
       --type web \
       --label apps.tanzu.vmware.com/has-tests=true \
@@ -138,7 +139,8 @@ the workload must be updated to point at your Tekton pipeline.
        12 + |    git:
        13 + |      ref:
        14 + |        branch: main
-       15 + |      url: https://github.com/sample-accelerators/tanzu-java-web-app
+       15 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+       16 + |    subPath: tanzu-java-web-app
 
     ? Do you want to create this workload? Yes
     Created workload "tanzu-java-web-app"
@@ -156,8 +158,8 @@ the workload must be updated to point at your Tekton pipeline.
     NAME                                    AGE
     workload.carto.run/tanzu-java-web-app   109s
 
-    NAME                                                        URL                                                         READY   STATUS                                                            AGE
-    gitrepository.source.toolkit.fluxcd.io/tanzu-java-web-app   https://github.com/sample-accelerators/tanzu-java-web-app   True    Fetched revision: main/872ff44c8866b7805fb2425130edb69a9853bfdf   109s
+    NAME                                                        URL                                                               READY   STATUS                                                            AGE
+    gitrepository.source.toolkit.fluxcd.io/tanzu-java-web-app   https://github.com/vmware-tanzu/application-accelerator-samples   True    Fetched revision: main/872ff44c8866b7805fb2425130edb69a9853bfdf   109s
 
     NAME                                              SUCCEEDED   REASON      STARTTIME   COMPLETIONTIME
     pipelinerun.tekton.dev/tanzu-java-web-app-4ftlb   True        Succeeded   104s        77s
@@ -291,7 +293,8 @@ pipeline:
 
     ```console
     tanzu apps workload create tanzu-java-web-app \
-      --git-repo https://github.com/sample-accelerators/tanzu-java-web-app \
+      --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
+      --sub-path tanzu-java-web-app \
       --git-branch main \
       --type web \
       --label apps.tanzu.vmware.com/has-tests=true \
@@ -317,7 +320,8 @@ pipeline:
         12 + |    git:
         13 + |      ref:
         14 + |        branch: main
-        15 + |      url: https://github.com/sample-accelerators/tanzu-java-web-app
+        15 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+        16 + |    subPath: tanzu-java-web-app
 
     ? Do you want to create this workload? Yes
     Created workload "tanzu-java-web-app"
@@ -335,11 +339,11 @@ pipeline:
     NAME                                    AGE
     workload.carto.run/tanzu-java-web-app   109s
 
-    NAME                                                        URL                                                         READY   STATUS                                                            AGE
-    gitrepository.source.toolkit.fluxcd.io/tanzu-java-web-app   https://github.com/sample-accelerators/tanzu-java-web-app   True    Fetched revision: main/872ff44c8866b7805fb2425130edb69a9853bfdf   109s
+    NAME                                                        URL                                                               READY   STATUS                                                            AGE
+    gitrepository.source.toolkit.fluxcd.io/tanzu-java-web-app   https://github.com/vmware-tanzu/application-accelerator-samples   True    Fetched revision: main/872ff44c8866b7805fb2425130edb69a9853bfdf   109s
 
-    NAME                                                           PHASE       SCANNEDREVISION                            SCANNEDREPOSITORY                                           AGE    CRITICAL   HIGH   MEDIUM   LOW   UNKNOWN   CVETOTAL
-    sourcescan.scanning.apps.tanzu.vmware.com/tanzu-java-web-app   Completed   187850b39b754e425621340787932759a0838795   https://github.com/sample-accelerators/tanzu-java-web-app   90s
+    NAME                                                           PHASE       SCANNEDREVISION                            SCANNEDREPOSITORY                                                 AGE    CRITICAL   HIGH   MEDIUM   LOW   UNKNOWN   CVETOTAL
+    sourcescan.scanning.apps.tanzu.vmware.com/tanzu-java-web-app   Completed   187850b39b754e425621340787932759a0838795   https://github.com/vmware-tanzu/application-accelerator-samples   90s
 
     NAME                                              SUCCEEDED   REASON      STARTTIME   COMPLETIONTIME
     pipelinerun.tekton.dev/tanzu-java-web-app-4ftlb   True        Succeeded   104s        77s

--- a/getting-started/deploy-first-app.hbs.md
+++ b/getting-started/deploy-first-app.hbs.md
@@ -77,7 +77,8 @@ In this example, we use the `Tanzu-Java-Web-App` accelerator. We also use the Ta
 
     ```console
     tanzu apps workload create tanzu-java-web-app \
-    --git-repo https://github.com/vmware-tanzu/application-accelerator-samples/tree/main/tanzu-java-web-app \
+    --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
+    --sub-path tanzu-java-web-app \
     --git-branch main \
     --type web \
     --label app.kubernetes.io/part-of=tanzu-java-web-app \

--- a/intellij-extension/getting-started.hbs.md
+++ b/intellij-extension/getting-started.hbs.md
@@ -162,8 +162,8 @@ It has a syntax similar to the `.gitignore` file.
 
 ### <a id="example-tanzuignore"></a> Example `.tanzuignore`
 
-See the [Tanzu Java Web App Sample](https://github.com/sample-accelerators/tanzu-java-web-app) for a
-[typical `.tanzuignore`](https://github.com/sample-accelerators/tanzu-java-web-app/blob/main/.tanzuignore) file that you can use as is, or as a starting point for your own.
+See the [Tanzu Java Web App Sample](https://github.com/vmware-tanzu/application-accelerator-samples/tree/main/tanzu-java-web-app) for a
+[typical `.tanzuignore`](https://github.com/vmware-tanzu/application-accelerator-samples/blob/main/tanzu-java-web-app/.tanzuignore) file that you can use as is, or as a starting point for your own.
 
 ## <a id="example-project"></a> View an example project
 
@@ -192,8 +192,10 @@ where your company placed it. Contact the appropriate team to determine its loca
 
 To clone the example from GitHub:
 
-1. Use `git clone` to clone the [tanzu-java-web-app](https://github.com/sample-accelerators/tanzu-java-web-app)
+1. Use `git clone` to clone the [application-accelerator-samples](https://github.com/vmware-tanzu/application-accelerator-samples)
 repository from GitHub.
+
+1. Change into the `tanzu-java-web-app` directory.
 
 1. Open the `Tiltfile` and replace `your-registry.io/project` with your registry.
 

--- a/multicluster/getting-started.hbs.md
+++ b/multicluster/getting-started.hbs.md
@@ -10,7 +10,7 @@ Before implementing a multicluster topology, complete the following:
 
 1. Complete all [installation steps for the four profiles](installing-multicluster.md): Build, Run, View and Iterate.
 
-1. For the sample workload, VMware uses the same Application Accelerator - Tanzu Java Web App in the non-multicluster [Getting Started](../getting-started.md) guide. You can download this accelerator to your own Git infrastructure of choice. You might need to configure additional permissions. Alternatively, you can also use the [sample-accelerators GitHub repository](https://github.com/sample-accelerators/tanzu-java-web-app).
+1. For the sample workload, VMware uses the same Application Accelerator - Tanzu Java Web App in the non-multicluster [Getting Started](../getting-started.md) guide. You can download this accelerator to your own Git infrastructure of choice. You might need to configure additional permissions. Alternatively, you can also use the [application-accelerator-samples GitHub repository](https://github.com/vmware-tanzu/application-accelerator-samples).
 
 1. The two supply chains are `ootb-supply-chain-basic` on the Build/Iterate profile and `ootb-delivery-basic` on the Run profile. For the Build/Iterate and Run profiled clusters, perform the steps described in [Setup Developer Namespace](../set-up-namespaces.md). This guide assumes that you use the `default` namespace.
 
@@ -33,7 +33,8 @@ The Build cluster starts by building the necessary bundle for the workload that 
 
     ```bash
     tanzu apps workload create tanzu-java-web-app \
-    --git-repo https://github.com/sample-accelerators/tanzu-java-web-app \
+    --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
+    --sub-path tanzu-java-web-app \
     --git-branch main \
     --type web \
     --label app.kubernetes.io/part-of=tanzu-java-web-app \
@@ -140,4 +141,4 @@ The Build cluster starts by building the necessary bundle for the workload that 
 
     Select the URL that corresponds to the domain you specified in your Run cluster's profile and enter it into a browser. Expect to see the message "Greetings from Spring Boot + Tanzu!".
 
-1. View the component in Tanzu Application Platform GUI, by following [these steps](../tap-gui/catalog/catalog-operations.md#register-comp) and using the [catalog file](https://github.com/sample-accelerators/tanzu-java-web-app/blob/main/catalog/catalog-info.yaml) from the sample accelerator in GitHub.
+1. View the component in Tanzu Application Platform GUI, by following [these steps](../tap-gui/catalog/catalog-operations.md#register-comp) and using the [catalog file](https://github.com/vmware-tanzu/application-accelerator-samples/blob/main/tanzu-java-web-app/catalog/catalog-info.yaml) from the sample accelerator in GitHub.

--- a/scc/building-from-source.hbs.md
+++ b/scc/building-from-source.hbs.md
@@ -35,13 +35,15 @@ you must fill `workload.spec.source.git`. With the `tanzu` CLI, you can do so by
 
 For example, after installing `ootb-supply-chain-basic`, to create a
 `Workload` the source code for which comes from the `main` branch of the
-`github.com/sample-accelerators/tanzu-java-web-app` Git repository, run:
+`github.com/vmware-tanzu/application-accelerator-samples` Git repository, 
+and the subdirectory `tanzu-java-web-app` run:
 
   ```bash
   tanzu apps workload create tanzu-java-web-app \
     --app tanzu-java-web-app \
     --type web \
-    --git-repo https://github.com/sample-accelerators/tanzu-java-web-app \
+    --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
+    --sub-path tanzu-java-web-app \
     --git-branch main
   ```
 
@@ -63,7 +65,8 @@ Expect to see the following output:
       12 + |    git:
       13 + |      ref:
       14 + |        branch: main
-      15 + |      url: https://github.com/sample-accelerators/tanzu-java-web-app
+      15 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+      16 + |    subPath: tanzu-java-web-app
   ```
 
 >**Note:** The Git repository URL must include the scheme: `http://`,
@@ -115,7 +118,8 @@ is installed. You can use the `--param` flag in Tanzu CLI. For example:
   tanzu apps workload create tanzu-java-web-app \
     --app tanzu-java-web-app \
     --type web \
-    --git-repo https://github.com/sample-accelerators/tanzu-java-web-app \
+    --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
+    --sub-path tanzu-java-web-app \
     --git-branch main \
     --param gitops_ssh_secret=SECRET-NAME
   ```
@@ -141,7 +145,8 @@ Expect to see the following output:
       15 + |    git:
       16 + |      ref:
       17 + |        branch: main
-      18 + |      url: https://github.com/sample-accelerators/tanzu-java-web-app
+      18 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+      19 + |    subPath: tanzu-java-web-app
   ```
 
 >**Note:** A secret reference is only provided to `GitRepository` if
@@ -268,7 +273,7 @@ The digest of the latest commit:
     interval: 1m0s
     ref: {branch: main}
     timeout: 20s
-    url: https://github.com/sample-accelerators/tanzu-java-web-app
+    url: https://github.com/vmware-tanzu/application-accelerator-samples
   status:
     artifact:
       checksum: 375c2daee5fc8657c5c5b49711a8e94d400994d7

--- a/scc/gitops-vs-regops.hbs.md
+++ b/scc/gitops-vs-regops.hbs.md
@@ -198,7 +198,8 @@ to the workload:
   tanzu apps workload create tanzu-java-web-app \
     --app tanzu-java-web-app \
     --type web \
-    --git-repo https://github.com/sample-accelerators/tanzu-java-web-app \
+    --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
+    --sub-path tanzu-java-web-app \
     --git-branch main \
     --param gitops_ssh_secret=GIT-SECRET-NAME \
     --param gitops_repository=https://github.com/my-org/config-repo
@@ -475,7 +476,8 @@ create a workload as follows:
   ```console
   tanzu apps workload create tanzu-java-web-app \
     --git-branch main \
-    --git-repo https://github.com/sample-accelerators/tanzu-java-web-app
+    --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
+    --sub-path tanzu-java-web-app \
     --label app.kubernetes.io/part-of=tanzu-java-web-app \
     --type web
   ```
@@ -498,7 +500,8 @@ Expect to see the following output:
       12 + |    git:
       13 + |      ref:
       14 + |        branch: main
-      15 + |      url: https://github.com/sample-accelerators/tanzu-java-web-app
+      15 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+      16 + |    subPath: tanzu-java-web-app
   ```
 
 As a result, the Kubernetes configuration is pushed to

--- a/scc/ootb-supply-chain-testing-scanning.hbs.md
+++ b/scc/ootb-supply-chain-testing-scanning.hbs.md
@@ -327,7 +327,8 @@ For example:
 ```console
 tanzu apps workload create tanzu-java-web-app \
   --git-branch main \
-  --git-repo https://github.com/sample-accelerators/tanzu-java-web-app \
+  --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
+  --sub-path tanzu-java-web-app \
   --label apps.tanzu.vmware.com/has-tests=true \
   --label app.kubernetes.io/part-of=tanzu-java-web-app \
   --type web
@@ -350,7 +351,8 @@ Create workload:
      13 + |    git:
      14 + |      ref:
      15 + |        branch: main
-     16 + |      url: https://github.com/sample-accelerators/tanzu-java-web-app
+     16 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+     17 + |    subPath: tanzu-java-web-app
 ```
 ## <a id="cve-triage-workflow"></a> CVE triage workflow
 

--- a/scc/ootb-supply-chain-testing.hbs.md
+++ b/scc/ootb-supply-chain-testing.hbs.md
@@ -252,7 +252,8 @@ For example:
 ```console
 tanzu apps workload create tanzu-java-web-app \
   --git-branch main \
-  --git-repo https://github.com/sample-accelerators/tanzu-java-web-app \
+  --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
+  --sub-path tanzu-java-web-app \
   --label apps.tanzu.vmware.com/has-tests=true \
   --label app.kubernetes.io/part-of=tanzu-java-web-app \
   --type web
@@ -275,5 +276,6 @@ Create workload:
      13 + |    git:
      14 + |      ref:
      15 + |        branch: main
-     16 + |      url: https://github.com/sample-accelerators/tanzu-java-web-app
+     16 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
+     17 + |    subPath: tanzu-java-web-app
 ```

--- a/scc/pre-built-image.hbs.md
+++ b/scc/pre-built-image.hbs.md
@@ -204,7 +204,7 @@ You can use Spring Boot's `build-image` target to build a container image that r
 The `build-image` target must use a Dockerfile.
 
 For example, using the same sample repository as mentioned before
-(https://github.com/sample-accelerators/tanzu-java-web-app):
+(https://github.com/vmware-tanzu/application-accelerator-samples/tree/main/tanzu-java-web-app):
 
 1. Build the image by running the following command from the root of the repository:
 

--- a/vscode-extension/getting-started.hbs.md
+++ b/vscode-extension/getting-started.hbs.md
@@ -277,7 +277,7 @@ you can remove the entire `allow_k8s_contexts` line. For more information, see t
 
 ### <a id="create-tanzuignore-file"></a> Create a `.tanzuignore` file
 
-The `.tanzuignore` file specifies the filepaths to exclude from the source code image. When working with local source code, you can exclude files from the source code to be uploaded within the image. Directories must not end with the system path separator (`/` or `\`). See [example](https://github.com/sample-accelerators/tanzu-java-web-app/blob/main/.tanzuignore).
+The `.tanzuignore` file specifies the filepaths to exclude from the source code image. When working with local source code, you can exclude files from the source code to be uploaded within the image. Directories must not end with the system path separator (`/` or `\`). See [example](https://github.com/vmware-tanzu/application-accelerator-samples/blob/main/tanzu-java-web-app/.tanzuignore).
 
 ### <a id="example-project"></a> Example project
 
@@ -300,7 +300,8 @@ you can obtain the sample application there if it was not removed.
 **Option 2: Clone from GitHub**
 
 1. Run `git clone` to clone the
-[tanzu-java-web-app](https://github.com/sample-accelerators/tanzu-java-web-app) repository from GitHub.
+[tanzu-java-web-app](https://github.com/vmware-tanzu/application-accelerator-samples) repository from GitHub.
+1. Change into the `tanzu-java-web-app` directory.
 1. Open the Tiltfile and replace `your-registry.io/project` with your container registry.
 
 ## <a id="next-steps"></a> Next steps

--- a/vscode-extension/live-hover.hbs.md
+++ b/vscode-extension/live-hover.hbs.md
@@ -8,7 +8,7 @@ For more information about this feature, see the **Live application information 
 To integrate Live Hover by using Spring Boot Tools you need:
 
 - A Tanzu Spring Boot application, such as
-[tanzu-java-web-app](https://github.com/sample-accelerators/tanzu-java-web-app)
+[tanzu-java-web-app](https://github.com/vmware-tanzu/application-accelerator-samples/tree/main/tanzu-java-web-app)
 - Spring Boot Extension Pack (includes Spring Boot Dashboard)
 [extension](https://marketplace.visualstudio.com/items?itemName=Pivotal.vscode-boot-dev-pack) 
 
@@ -21,7 +21,7 @@ Activate the Live Hover feature by enabling it in
 
 Follow these steps to deploy the workload for an app to a cluster, making live hovers appear.
 The examples in some steps reference the sample
-[tanzu-java-web-app](https://github.com/sample-accelerators/tanzu-java-web-app).
+[tanzu-java-web-app](https://github.com/vmware-tanzu/application-accelerator-samples/tree/main/tanzu-java-web-app).
 
 1. Clone the repository by running:
 
@@ -30,7 +30,7 @@ The examples in some steps reference the sample
     ```
 
     Where `REPOSITORY-ADDRESS` is your repository address.
-    For example, `https://github.com/sample-accelerators/tanzu-java-web-app`.
+    For example, `https://github.com/vmware-tanzu/application-accelerator-samples`.
 
 1. Open the project in VS Code, with the Live Hover feature enabled, by running:
 
@@ -39,7 +39,7 @@ The examples in some steps reference the sample
     ```
 
     Where `PROJECT-DIRECTORY` is your project directory.
-    For example, `./tanzu-java-web-app`.
+    For example, `./application-accelerator-samples/tanzu-java-web-app`.
 
 1. Verify that you are targeting the cluster on which you want to run the workload by running:
 


### PR DESCRIPTION
This commit also changes the examples to use tanzu-java-web-app instead of spring-petclinic, because spring-petclinic is not part of the accelerator repository.

Which other branches should this be merged with (if any)?
This is only for 1.3