### PR TITLE
updated procedure to use new repo name

### DIFF
--- a/upgrading.hbs.md
+++ b/upgrading.hbs.md
@@ -10,7 +10,7 @@ Before you upgrade Tanzu Application Platform:
 
 - Verify that you meet all the [prerequisites](prerequisites.md) of the target Tanzu Application Platform version. If the target Tanzu Application Platform version does not support your existing Kubernetes version, VMware recommends upgrading to a supported version before proceeding with the upgrade.
 - For information about installing your Tanzu Application Platform, see [Install your Tanzu Application Platform profile](install.md#install-profile).
-- For information about installing or updating the Tanzu CLI and plug-ins, see [Install or update the Tanzu CLI and plug-ins](install-tanzu-cli.md#cli-and-plugin).
+- Ensure that Tanzu CLI is updated to version recommended for TAP version being upgraded to. For information about installing or updating the Tanzu CLI and plug-ins, see [Install or update the Tanzu CLI and plug-ins](install-tanzu-cli.md#cli-and-plugin).
 - For information on Tanzu Application Platform GUI considerations, see [Tanzu Application Platform GUI Considerations](tap-gui/upgrades.md#considerations).
 - Verify all packages are reconciled by running `tanzu package installed list -A`.
 - It is strongly recommended to [upgrade](https://docs.vmware.com/en/Cluster-Essentials-for-VMware-Tanzu/1.3/cluster-essentials/GUID-deploy.html#upgrade-7) the Cluster Essentials to version 1.2 to avoid the temporary warning state as described in the following section.

--- a/upgrading.hbs.md
+++ b/upgrading.hbs.md
@@ -28,11 +28,13 @@ Follow these steps to update the new package repository:
     - If you are using Cluster Essentials 1.2 or above, run:
 
         ```console
-        tanzu package repository add tanzu-tap-repository \
+        tanzu package repository add TANZU-TAP-REPOSITORY-NEW \
         --url ${INSTALL_REGISTRY_HOSTNAME}/TARGET-REPOSITORY/tap-packages:${TAP_VERSION} \
         --namespace tap-install
         ```
-
+    >**Note:** Make sure to update the `TANZU-TAP-REPOSITORY-NEW` to the a new repository name. Do NOT use the existing Tanzu package repostitory name with the previous version of TAP Packages.
+    
+    
     - If you are using Cluster Essentials 1.1 or 1.0, run:
 
         ```console


### PR DESCRIPTION
updated procedure to use new repo name in case of Cluster essentials >=1.2

Which other branches should this be merged with (if any)?
TAP 1.3.x