### PR TITLE
Update STK component docs links

### DIFF
--- a/getting-started/consume-services.hbs.md
+++ b/getting-started/consume-services.hbs.md
@@ -190,7 +190,7 @@ There are more service use cases not covered in this getting started guide. See 
 </table>
 
 For more information about the APIs and concepts underpinning Services on Tanzu Application Platform, see the
-[Services Toolkit Component documentation](https://docs.vmware.com/en/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.7/svc-tlk/GUID-overview.html).
+[Services Toolkit Component documentation](https://docs-staging.vmware.com/en/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.8/svc-tlk/GUID-overview.html).
 
 ## Next steps
 

--- a/services-toolkit/about.hbs.md
+++ b/services-toolkit/about.hbs.md
@@ -10,4 +10,4 @@ DNS records, and so on) on Kubernetes:
 - Service resource claims
 
 To learn more about Services Toolkit, see the
-[Services Toolkit for VMware Tanzu documentation](https://docs.vmware.com/en/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.7/svc-tlk/GUID-overview.html)
+[Services Toolkit for VMware Tanzu documentation](https://docs-staging.vmware.com/en/Services-Toolkit-for-VMware-Tanzu-Application-Platform/0.8/svc-tlk/GUID-overview.html)


### PR DESCRIPTION
Hi there,

This is a small PR to update links to the Services Toolkit Component documentation to refer to the latest release (0.8) for TAP 1.3.

**Note** These are staging links and will need to be updated to production links once our component documentation goes live (at the same time as the TAP 1.3 docs)

Also quick question - would it be possible to get a "latest" URL for our component docs, so that we don't have to update these links each time we cut a new release?

Thanks!
Ed
 
Which other branches should this be merged with (if any)? None
