### PR TITLE
appsso: remove references to removed fields issuerURI and LastParentG…

### DIFF
--- a/app-sso/crds/authserver.md
+++ b/app-sso/crds/authserver.md
@@ -17,8 +17,6 @@ You can view the issuer URI by running
 
 See [Issuer URI & TLS](../service-operators/issuer-uri-and-tls.md) for more information.
 
->**Note:** You must configure the issuer URI through `spec.tls` instead of `spec.issuerURI`, which is deprecated.
-
 Token signature keys are configured through `spec.tokenSignature`. This is a required field. See
 [token signature](../service-operators/token-signature.md) for more context.
 
@@ -75,7 +73,6 @@ spec:
     secretRef:
       name: ""
     disabled: false # If true, requires annotation `sso.apps.tanzu.vmware.com/allow-unsafe-issuer-uri: ""`
-  issuerURI: "" # DEPRECATED and marked for removal. Use .tls instead.
   tokenSignature: # required
     signAndVerifyKeyRef:
       name: ""
@@ -150,7 +147,6 @@ status:
   tokenSignatureKeyCount: 0
   deployments:
     authServer:
-      LastParentGenerationWithRestart: 0 # DEPRECATED and marked for removal.
       configHash: ""
       image: ""
       replicas: 0

--- a/app-sso/service-operators/issuer-uri-and-tls.md
+++ b/app-sso/service-operators/issuer-uri-and-tls.md
@@ -38,9 +38,6 @@ Learn how to configure TLS for your `AuthServer`:
 
 > ℹ️ If your `AuthServer` obtains a certificate from a custom CA, then [help _App
 > Operators_ to trust it](#allow-workloads-to-trust-a-custom-ca-authserver).
->
-> ⚠️ The existing `.spec.issuerURI` is deprecated and is marked for deletion in the next release! The release notes
-> contain a [migration guide](../../release-notes.md#app-sso-features)
 
 ## Configure TLS by using a (Cluster)Issuer
 


### PR DESCRIPTION
…enerationWithRestart

Merge this once `1.3` has been released. It should _not_ go into the 1.3 docs.
