### PR TITLE
If the tag is included in relocation it will fail

### DIFF
--- a/partials/_full-deps.hbs.md
+++ b/partials/_full-deps.hbs.md
@@ -15,7 +15,7 @@ To install `full` dependencies:
       --to-tar=tbs-full-deps.tar
     # move tbs-full-deps.tar to environment with registry access
     imgpkg copy --tar tbs-full-deps.tar \
-      --to-repo=INSTALL-REGISTRY-HOSTNAME/TARGET-REPOSITORY/tbs-full-deps:VERSION
+      --to-repo=INSTALL-REGISTRY-HOSTNAME/TARGET-REPOSITORY/tbs-full-deps
     ```
 
     Where:


### PR DESCRIPTION
Very small change. The installation steps will fail without this change.

Which other branches should this be merged with (if any)?

1.2 could also have this change