### PR TITLE
scc: fix misindented section in `ootb-supply-chain-scanning` sample `tap-values`

### DIFF
--- a/scc/ootb-supply-chain-testing-scanning.hbs.md
+++ b/scc/ootb-supply-chain-testing-scanning.hbs.md
@@ -122,13 +122,13 @@ The names of the objects **must** match the ones in the example with default ins
 
     ```yaml
     ootb_supply_chain_testing_scanning:
-    scanning:
-      source:
-        policy: SCAN-POLICY
-        template: SCAN-TEMPLATE
-      image:
-        policy: SCAN-POLICY
-        template: SCAN-TEMPLATE
+      scanning:
+        source:
+          policy: SCAN-POLICY
+          template: SCAN-TEMPLATE
+        image:
+          policy: SCAN-POLICY
+          template: SCAN-TEMPLATE
     ```
 
     Where `SCAN-POLICY` and `SCAN-TEMPLATE` are the names of the `ScanPolicy` and `ScanTemplate`.


### PR DESCRIPTION
In the sample `tap-values.yaml` provided, the `scanning` section should be set as a field of `ootb_supply_chain_testing_scanning` rather than a sibling as it's a field that's configured in the
`ootb-supply-chain-testing-scanning` package.

e.g., inspecting the `ootb-supply-chain-testing` package's schema:

```console
k get pkg -n tap-install ootb-supply-chain-testing-scanning.tanzu.vmware.com.0.10.0 -o yaml | vim -
```

we can see:

```
        scanning:
          properties:
            image:
              properties:
                policy:
                  default: scan-policy
                  description: |
                    Name of the default ScanPolicy object to use to evaluate the results of scanning a container image.
                  type: string
                template:
                  default: private-image-scan-template
                  description: |
                    Name of the default ScanTemplate object to use to scan a container image.
                  type: string
              type: object
```

