### PR TITLE
AppSSO: add docs for configuring AuthServer storage.

### DIFF
--- a/app-sso/about.hbs.md
+++ b/app-sso/about.hbs.md
@@ -18,7 +18,7 @@ solutions in your software.
 
 It's easy to get started with AppSSO, deploy an authorization server with static test users, and eventually progress to
 multiple authorization servers of production-grade scale with token key rotation, multiple upstream identity providers,
-and client restrictions.
+configured secure storage, and client restrictions.
 
 AppSSO's authorization server is based off of Spring Authorization Server project. 
 For more information, see [Spring documentation](https://spring.io/projects/spring-authorization-server).

--- a/app-sso/crds/authserver.md
+++ b/app-sso/crds/authserver.md
@@ -1,7 +1,7 @@
 # AuthServer
 
 `AuthServer` represents the request for an OIDC authorization server. It results in the deployment of an authorization
-server backed by Redis over mTLS.
+server backed by Redis over mutual TLS (if no storage is defined).
 
 An `AuthServer` should have labels which allow to uniquely match it amongst others. `ClientRegistration` selects an
 `AuthServer` by label selector and needs a unique match to be successful.
@@ -28,12 +28,12 @@ An `AuthServer` reconciles into the following resources in its namespace:
 
 ```text
 AuthServer/my-authserver
-├─Certificate/my-authserver-redis-client
-├─Certificate/my-authserver-redis-server
+├─Certificate/my-authserver-redis-client                   # if no storage is defined
+├─Certificate/my-authserver-redis-server                   # if no storage is defined
 ├─Certificate/my-authserver-root
 ├─ConfigMap/my-authserver-ca-cert
 ├─Deployment/my-authserver-auth-server
-├─Deployment/my-authserver-redis
+├─Deployment/my-authserver-redis                           # if no storage is defined
 ├─Issuer/my-authserver-bootstrap
 ├─Issuer/my-authserver-root
 ├─Role/my-authserver-auth-server
@@ -41,9 +41,10 @@ AuthServer/my-authserver
 ├─Secret/my-authserver-auth-server-clients
 ├─Secret/my-authserver-auth-server-keys
 ├─Secret/my-authserver-auth-server-properties
-├─Secret/my-authserver-redis-client-cert-keystore-password
+├─Secret/my-authserver-redis-service-binding               # if no storage is defined
+├─Secret/my-authserver-redis-client-cert-keystore-password # if no storage is defined
 ├─Secret/my-authserver-registry-credentials
-├─Service/my-authserver-redis
+├─Service/my-authserver-redis                              # if no storage is defined
 └─ServiceAccount/my-authserver-auth-server
 ```
 
@@ -78,6 +79,10 @@ spec:
       name: ""
     extraVerifyKeyRefs:
       - name: ""
+  storage: # optional
+    redis: # required if 'storage' is defined
+      secretRef: # Reference to Secret resource within same namespace as this AuthServer
+        name: ""
   identityProviders: # optional
     # each must be one and only one of internalUnsafe, ldap, openID or saml
     - name: "" # must be unique
@@ -150,8 +155,12 @@ status:
       configHash: ""
       image: ""
       replicas: 0
+    redis: # empty if storage is configured by the service operator
+      image: "" 
+  storage:
     redis:
-      image: ""
+      host: "" # the hostname of the configured Redis
+      port: "" # the port of the configured Redis
   conditions:
     - lastTransitionTime:
       message: ""
@@ -180,7 +189,10 @@ to troubleshoot issues.
 `.status.deployments.authServer` describes the current authorization server deployment by listing the running image,
 its replicas, the hash of the current configuration and the generation which has last resulted in a restart.
 
-`.status.deployments.redis` describes the current Redis deployment by listing its running image.
+`.status.deployments.redis` describes the current provided Redis deployment by listing its running image. This field is
+nil if storage is defined explicitly via `.spec.storage`.
+
+`.status.storage.redis` describes the configured Redis storage such as hostname and port number.
 
 `.status.conditions` documents each step in the reconciliation:
 
@@ -209,8 +221,12 @@ deployments:
     configHash: "11216479096262796218"
     image: "..."
     replicas: 1
-  redis:
+  redis: # empty if external storage is defined
     image: "..."
+storage:
+  redis:
+   host: "" # the hostname of the configured Redis
+   port: "" # the port of the configured Redis
 conditions:
   - lastTransitionTime: "2022-08-24T09:58:10Z"
     message: ""

--- a/app-sso/getting-started/provision-auth-server.md
+++ b/app-sso/getting-started/provision-auth-server.md
@@ -230,3 +230,11 @@ consider using OpenID Connect IDPs instead.
 
 The `email` and `roles` fields are optional for internal users. However, they will be useful when we want to use SSO
 with a client application later in this guide.
+
+### Configuring storage
+
+An `AuthServer` issues a Redis instance by default, and may be used for testing, prototyping, and other non-production
+purposes -- no additional configuration is needed.
+
+To configure your own storage that is ready for production, follow the steps outlined
+in [configuring Storage documentation](../service-operators/storage.hbs.md).

--- a/app-sso/platform-operators/configuration.md
+++ b/app-sso/platform-operators/configuration.md
@@ -50,7 +50,7 @@ You can configure trust for custom CAs by providing their certificates as a PEM 
 `AuthServer` will trust your custom CAs.
 
 This is useful if you have [identity providers](../service-operators/identity-providers.md) which serve certificates
-from a custom CA.
+from a custom CA, as well as [configuring `AuthServer` storage](../service-operators/storage.md).
 
 > ℹ️ AppSSO-specific `ca_cert_data` is concatenated with `shared.ca_cert_data`. The resulting PEM bundle contains both.
 

--- a/app-sso/service-operators/index.md
+++ b/app-sso/service-operators/index.md
@@ -1,7 +1,7 @@
 # Application Single Sign-On for Service Operators
 
 `AuthServer` represents the request for an OIDC authorization server. It results in the deployment of an authorization
-server backed by Redis over mTLS.
+server backed by Redis over mutual TLS (if no external storage is explicitly configured).
 
 You can configure the labels with which clients can select an `AuthServer`, the namespaces it allows clients from,
 its issuer URI, its token signature keys, identity providers and further details for its deployment.
@@ -14,5 +14,6 @@ The following sections outline the essential steps to configure a fully operatio
 - [Issuer URI and TLS](./issuer-uri-and-tls.md)
 - [Token signature](./token-signature.md)
 - [Identity providers](./identity-providers.md)
+- [Storage](./storage.hbs.md)
 - [AuthServer readiness](./readiness.md)
 - [Scale AuthServer](./scale.md)

--- a/app-sso/service-operators/storage.hbs.md
+++ b/app-sso/service-operators/storage.hbs.md
@@ -1,0 +1,138 @@
+# Storage
+
+AppSSOs `AuthServer` handles data pertaining to user's session, identity and access tokens, and approved or rejected
+consents. For production environments, it is critical to provide your own storage source to enable enterprise
+functions such as data backup and recovery, auditing, and long-term persistence, as per your organization's data and
+security policies.
+
+AppSSO currently only supports Redis `v6.0` or above as a storage solution. Version 6.0 introduced TLS support to ensure
+encrypted client-server communication -- AppSSO enforces TLS by default.
+
+<p class="note">
+<strong>Note:</strong>
+[Storage provided by default](#storage-provided-by-default) refers to an `AuthServer` resource in which the field
+`.spec.storage` is not set.
+</p>
+
+## Configuring Redis
+
+To configure Redis as authorization server storage, you must have the following details about your Redis server:
+
+* **Server CA certificate** (optional) - the Certificate Authority (CA) certificate used to verify Redis TLS
+  connections. If Redis Server certificate is signed by a public CA, providing this certificate is not required.
+* **host** (required) - the domain name, IP address, or host name of your Redis server.
+* **port** (optional) - the port number of your Redis server (default: `6379`).
+* **username** (optional) - the username used to authenticate against your Redis server.
+* **password** (optional) - the password used to authenticate against your Redis server.
+
+<p class="note caution">
+<strong>Caution:</strong>
+AppSSO takes _secure-by-default_ approach and will not establish non-encrypted communication channels.
+The `AuthServer` resource will enter an error state should a non-encrypted connection be attempted.
+</p>
+
+The following steps introduce the path to configuring Redis with AppSSO:
+
+1. [Configuring Redis Server CA certificate](#configuring-redis-server-ca-certificate)
+1. [Configuring a Redis Secret](#configuring-a-redis-secret)
+1. [Attaching storage to an `AuthServer`](#attaching-storage-to-an-authserver)
+
+### Configuring Redis Server CA certificate
+
+If your Redis comes with a custom or non-public Server CA certificate, you are required to add the certificate to AppSSO
+package in order for an authorization server to establish an encrypted TLS connection successfully.
+
+Redis Server CA certificate can be added
+to [AppSSO configuration](../platform-operators/configuration.md#ca_cert_data) via `values.yaml`:
+
+```yaml
+...
+ca_cert_data: |
+  -----BEGIN CERTIFICATE-----
+  <certificate-data>
+  -----END CERTIFICATE-----
+...
+```
+
+### Configuring a Redis Secret
+
+To provide _coordinates_ (the location details) of your Redis server, you have to create a `Secret` resource that
+follows well-known Secret entries conventions specified
+in [Service Bindings 1.0.0 specification](https://github.com/servicebinding/spec#well-known-secret-entries).
+
+Here is an example of a properly formatted `Secret` resource:
+
+<p class="note">
+<strong>Note:</strong>
+The Secret **must** be created in the same namespace as your `AuthServer`
+</p>
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-credentials
+  namespace: my-authserver
+type: servicebinding.io/redis        # required
+stringData:
+  type: "redis"                      # required, must equal 'redis'
+  ssl: "true"                        # required, must equal 'true'
+  host: "redis01.prod.example.com"   # required
+  port: 6379                         # optional, must be an integer, defaults to 6379 if not specified
+  password: "!!veryStrongPassword!!" # optional
+  username: "redis01-user"           # optional
+```
+
+### Attaching storage to an AuthServer
+
+Once a Redis Secret resource is applied, you may reference the Secret in `.spec.storage`. Here is an example of an
+AuthServer with a reference to a Redis Secret:
+
+```yaml
+apiVersion: sso.apps.tanzu.vmware.com/v1alpha1
+kind: AuthServer
+metadata:
+  name: my-authserver-example
+  namespace: my-authserver
+spec:
+  # ...
+  storage:
+    redis:
+      secretRef:
+        name: redis-credentials
+```
+
+Once `AuthServer` is applied, ensure that its `Status` is equivalent to `Ready`, and you may query the status of the
+configured storage as follows:
+
+```bash
+kubectl get authserver <authserver-name> \
+  --namespace <authserver-namespace> \
+  --output jsonpath="{.status.storage.redis}" | jq
+```
+
+## Storage provided by default
+
+If no storage is defined, an `AuthServer` provides its own short-lived ephemeral storage solution,
+Redis. The provided Redis is configured to never flush any data to any volume that may be attached to the Pods operating
+the authorization server.
+
+<p class="note caution">
+<strong>Caution:</strong>
+The default storage configuration is most useful in prototyping or testing environments, and **should not be relied on
+in production environments.**
+</p>
+
+To view details for Redis of an `AuthServer`:
+
+```shell
+# Get the Redis image
+kubectl get authserver <authserver-name> \
+  --namespace <authserver-namespace> \
+  --output jsonpath="{.status.deployments.redis}" | jq
+
+# Get the Redis host and port
+kubectl get authserver <authserver-name> \
+  --namespace <authserver-namespace> \
+  --output jsonpath="{.status.storage.redis}" | jq
+```

--- a/toc.md
+++ b/toc.md
@@ -258,6 +258,7 @@ docs.vmware.com is built.
             - [Issuer URI and TLS](app-sso/service-operators/issuer-uri-and-tls.md)
             - [Identity providers](app-sso/service-operators/identity-providers.md)
             - [Token signatures](app-sso/service-operators/token-signature.md)
+            - [Storage](app-sso/service-operators/storage.hbs.md)
             - [AuthServer readiness](app-sso/service-operators/readiness.md)
             - [Scale AuthServer](app-sso/service-operators/scale.md)
             - [AuthServer audit logs](app-sso/service-operators/audit-logs.md)


### PR DESCRIPTION
Which other branches should this be merged with (if any)? TAP 1.4 only.

Feature targeted for TAP 1.4 release.
