### PR TITLE
Excluded policy controller in TAP 1.3+ installation

### DIFF
--- a/install-air-gap.hbs.md
+++ b/install-air-gap.hbs.md
@@ -193,6 +193,9 @@ The sample values file contains the necessary defaults for:
 
     >**Important:** Keep the values file for future configuration use.
 
+    >**Important:** The policy controller `policy.apps.tanzu.vmware.com` has to be excluded in all
+    TAP 1.3+ installations. See [Policy controller known issues section](scst-policy/known-issues.md)
+
 ### <a id='full-profile'></a> Full Profile
 
 To install Tanzu Application Platform with Supply Chain Basic,
@@ -214,6 +217,8 @@ shared:
       MIIFXzCCA0egAwIBAgIJAJYm37SFocjlMA0GCSqGSIb3DQEBDQUAMEY...
       -----END CERTIFICATE-----
 profile: full
+excluded_packages:
+- policy.apps.tanzu.vmware.com
 ceip_policy_disclosed: true
 buildservice:
   kp_default_repository: "REPOSITORY"

--- a/install-aws.hbs.md
+++ b/install-aws.hbs.md
@@ -171,6 +171,9 @@ The following command generates the YAML file sample for the full-profile on AWS
 >**Note:** The `profile:` field takes `full` as the default value, but you can also set it to `iterate`, `build`, `run`, or `view`.
 Refer to [Install multicluster Tanzu Application Platform profiles](multicluster/installing-multicluster.html) for more information.
 
+>**Important:** The policy controller `policy.apps.tanzu.vmware.com` has to be excluded in all
+    TAP 1.3+ installations. See [Policy controller known issues section](scst-policy/known-issues.md)
+
 ```console
 cat << EOF > tap-values.yaml
 shared:
@@ -183,6 +186,10 @@ ceip_policy_disclosed: true
 #Below are the keys which may have default values set, but can be overridden.
 
 profile: full # Can take iterate, build, run, view.
+
+excluded_packages:
+- policy.apps.tanzu.vmware.com
+
 supply_chain: basic # Can take testing, testing_scanning.
 
 ootb_supply_chain_basic: # Based on supply_chain set above, can be changed to ootb_supply_chain_testing, ootb_supply_chain_testing_scanning.

--- a/install-openshift.hbs.md
+++ b/install-openshift.hbs.md
@@ -209,6 +209,8 @@ The sample values file contains the necessary defaults for:
 ### <a id='full-profile'></a> Full profile
 
 The following is the YAML file sample for the full-profile:
+>**Important:** The policy controller `policy.apps.tanzu.vmware.com` has to be excluded in all
+    TAP 1.3+ installations. See [Policy controller known issues section](scst-policy/known-issues.md)
 
 >**Note:** The `profile:` field takes `full` as the default value, but you can also set it to `iterate`, `build`, `run` or `view`.
 Refer to [Install multicluster Tanzu Application Platform profiles](multicluster/installing-multicluster.html) for more information.
@@ -233,6 +235,10 @@ ceip_policy_disclosed: FALSE-OR-TRUE-VALUE # Installation fails if this is not s
 #Below are the keys which may have default values set, but can be overridden.
 
 profile: full # Can take iterate, build, run, view.
+
+excluded_packages:
+- policy.apps.tanzu.vmware.com
+
 supply_chain: basic # Can take testing, testing_scanning.
 
 ootb_supply_chain_basic: # Based on supply_chain set above, can be changed to ootb_supply_chain_testing, ootb_supply_chain_testing_scanning.

--- a/install.hbs.md
+++ b/install.hbs.md
@@ -227,6 +227,9 @@ The following is the YAML file sample for the full-profile:
 >**Note:** The `profile:` field takes `full` as the default value, but you can also set it to `iterate`, `build`, `run` or `view`.
 Refer to [Install multicluster Tanzu Application Platform profiles](multicluster/installing-multicluster.html) for more information.
 
+>**Important:** The policy controller `policy.apps.tanzu.vmware.com` has to be excluded in all
+    TAP 1.3+ installations. See [Policy controller known issues section](scst-policy/known-issues.md)
+
 ```yaml
 shared:
   ingress_domain: "INGRESS-DOMAIN"
@@ -247,6 +250,10 @@ ceip_policy_disclosed: FALSE-OR-TRUE-VALUE # Installation fails if this is not s
 #Below are the keys which may have default values set, but can be overridden.
 
 profile: full # Can take iterate, build, run, view.
+
+excluded_packages:
+- policy.apps.tanzu.vmware.com
+
 supply_chain: basic # Can take testing, testing_scanning.
 
 ootb_supply_chain_basic: # Based on supply_chain set above, can be changed to ootb_supply_chain_testing, ootb_supply_chain_testing_scanning.

--- a/scst-policy/known-issues.md
+++ b/scst-policy/known-issues.md
@@ -1,0 +1,29 @@
+# Known Issues
+
+## Invalid TUF key 
+
+### Description
+
+TAP 1.3+ installation with Policy controller included fails with the following error:
+
+```bash
+panic: Failed to initialize TUF client from  : updating local metadata and targets: 
+error updating to TUF remote mirror: tuf: invalid key
+```
+
+Policy controller is trying to initialize TUF keys during installation. Due to a breaking change in 
+[go-tuf](https://github.com/theupdateframework/go-tuf/issues/379) the initialization fails
+
+### Solution
+
+The policy controller's dependency on go-tuf should be updated to the newer version.
+
+### Workaround
+
+Exclude policy controller package in all profile installations:
+
+```yaml
+profile: <profile vaule>
+excluded_packages:
+  - policy.apps.tanzu.vmware.com
+```

--- a/scst-policy/known-issues.md
+++ b/scst-policy/known-issues.md
@@ -4,7 +4,7 @@
 
 ### Description
 
-TAP 1.3+ installation with Policy controller included fails with the following error:
+Installation of policy controller fails with the following error message:
 
 ```bash
 panic: Failed to initialize TUF client from  : updating local metadata and targets: 


### PR DESCRIPTION
The change has to be added in the following TAP versions:
1. 1.4
2. 1.3.0
3. 1.3.1

cc: @elfotografo007 @derwei @dherbrich @DennyHoang 