### PR TITLE
Update aws blogpost link

### DIFF
--- a/tanzu-build-service/troubleshooting.hbs.md
+++ b/tanzu-build-service/troubleshooting.hbs.md
@@ -59,7 +59,7 @@ For instructions, refer to the following documentation for your Kubernetes clust
 
 For AWS, see:
 
-- The [Amazon blog](https://aws.amazon.com/blogs/containers/amazon-eks-1-21-released/)
+- The [Amazon blog](https://docs.aws.amazon.com/eks/latest/userguide/dockershim-deprecation.html)
 - The [eksctl CLI documentation](https://eksctl.io/usage/container-runtime/)
 
 For AKS, see:


### PR DESCRIPTION
- The previous link containerd false information
- The new link shows that dockershim will be removed in eks 1.24

Which other branches should this be merged with (if any)?

- This could be added to the 1.3.x branch as well