### PR TITLE
add eventing known issue to the release notes

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -438,6 +438,12 @@ This can be due to ServiceAccounts or users bound to overly restrictive Security
 
 For information about resolving this issue, see the Cloud Native Runtimes [troubleshooting documentation](https://docs.vmware.com/en/Cloud-Native-Runtimes-for-VMware-Tanzu/2.0/tanzu-cloud-native-runtimes/GUID-troubleshooting.html).
 
+#### <a id="eventing-issues"></a> Eventing
+
+**Eventing package fails during a TAP Profile-based installation**
+
+For information about resolving this issue, see the "Known Issues" section of the Cloud Native Runtimes [upgrade documentation](https://docs.vmware.com/en/Cloud-Native-Runtimes-for-VMware-Tanzu/2.0/tanzu-cloud-native-runtimes/GUID-upgrade.html).
+
 #### <a id="grype-scan-known-issues"></a>Grype scanner
 
 **Scanning Java source code that uses Gradle package manager might not reveal vulnerabilities:**


### PR DESCRIPTION
Adds workaround info for a known issue with eventing package during a TAP profile upgrade. Relates to [TANZUSC-2057](https://jira.eng.vmware.com/browse/TANZUSC-2057)

Which other branches should this be merged with (if any)?
1-3-0
1-3-1