### PR TITLE
make note of resolved issue

### DIFF
--- a/cloud-native-runtimes/install-cnrt.hbs.md
+++ b/cloud-native-runtimes/install-cnrt.hbs.md
@@ -30,7 +30,7 @@ To install Cloud Native Runtimes:
     $ tanzu package available list cnrs.tanzu.vmware.com --namespace tap-install
     - Retrieving package versions for cnrs.tanzu.vmware.com...
       NAME                   VERSION  RELEASED-AT
-      cnrs.tanzu.vmware.com  2.0.1    2022-10-11T00:00:00Z
+      cnrs.tanzu.vmware.com  2.0.2    2022-11-15T00:00:00Z
     ```
 
 1. (Optional) Make changes to the default installation settings:
@@ -38,14 +38,14 @@ To install Cloud Native Runtimes:
     1. Gather values schema.
 
         ```console
-        tanzu package available get cnrs.tanzu.vmware.com/2.0.1 --values-schema -n tap-install
+        tanzu package available get cnrs.tanzu.vmware.com/2.0.2 --values-schema -n tap-install
         ```
 
         For example:
 
         ```console
-        $ tanzu package available get cnrs.tanzu.vmware.com/2.0.1 --values-schema -n tap-install
-        | Retrieving package details for cnrs.tanzu.vmware.com/2.0.1...
+        $ tanzu package available get cnrs.tanzu.vmware.com/2.0.2 --values-schema -n tap-install
+        | Retrieving package details for cnrs.tanzu.vmware.com/2.0.2...
           KEY                         DEFAULT                               TYPE     DESCRIPTION
           provider                    <nil>                                 string   Optional: Kubernetes cluster provider. To be specified if deploying CNR on a local Kubernetes cluster provider.
           default_tls_secret          <nil>                                 string   Optional: Overrides the config-contour configmap in namespace knative-serving.
@@ -85,13 +85,13 @@ To install Cloud Native Runtimes:
 1. Install the package by running:
 
     ```console
-    tanzu package install cloud-native-runtimes -p cnrs.tanzu.vmware.com -v 2.0.1 -n tap-install -f cnr-values.yaml --poll-timeout 30m
+    tanzu package install cloud-native-runtimes -p cnrs.tanzu.vmware.com -v 2.0.2 -n tap-install -f cnr-values.yaml --poll-timeout 30m
     ```
 
     For example:
 
     ```console
-    $ tanzu package install cloud-native-runtimes -p cnrs.tanzu.vmware.com -v 2.0.1 -n tap-install -f cnr-values.yaml --poll-timeout 30m
+    $ tanzu package install cloud-native-runtimes -p cnrs.tanzu.vmware.com -v 2.0.2 -n tap-install -f cnr-values.yaml --poll-timeout 30m
     - Installing package 'cnrs.tanzu.vmware.com'
     | Getting package metadata for 'cnrs.tanzu.vmware.com'
     | Creating service account 'cloud-native-runtimes-tap-install-sa'
@@ -118,7 +118,7 @@ To install Cloud Native Runtimes:
     | Retrieving installation details for cc...
     NAME:                    cloud-native-runtimes
     PACKAGE-NAME:            cnrs.tanzu.vmware.com
-    PACKAGE-VERSION:         2.0.1
+    PACKAGE-VERSION:         2.0.2
     STATUS:                  Reconcile succeeded
     CONDITIONS:              [{ReconcileSucceeded True  }]
     USEFUL-ERROR-MESSAGE:

--- a/eventing/install-eventing.hbs.md
+++ b/eventing/install-eventing.hbs.md
@@ -28,7 +28,7 @@ To install Eventing:
     $ tanzu package available list eventing.tanzu.vmware.com --namespace tap-install
     - Retrieving package versions for eventing.tanzu.vmware.com...
       NAME                   VERSION  RELEASED-AT
-      eventing.tanzu.vmware.com  2.0.1    2022-10-11T00:00:00Z
+      eventing.tanzu.vmware.com  2.0.2    2022-10-11T00:00:00Z
     ```
 
 1. (Optional) Make changes to the default installation settings:
@@ -36,14 +36,14 @@ To install Eventing:
     1. Gather values schema.
 
         ```console
-        tanzu package available get eventing.tanzu.vmware.com/2.0.1 --values-schema -n tap-install
+        tanzu package available get eventing.tanzu.vmware.com/2.0.2 --values-schema -n tap-install
         ```
 
         For example:
 
         ```console
-        $ tanzu package available get eventing.tanzu.vmware.com/2.0.1 --values-schema -n tap-install
-        | Retrieving package details for eventing.tanzu.vmware.com/2.0.1...
+        $ tanzu package available get eventing.tanzu.vmware.com/2.0.2 --values-schema -n tap-install
+        | Retrieving package details for eventing.tanzu.vmware.com/2.0.2...
           KEY           DEFAULT  TYPE     DESCRIPTION
           lite.enable   false    boolean  Optional: Not recommended for production. Set to "true" to reduce CPU and Memory resource requests for all Eventing Deployments, Daemonsets, and Statefulsets by half. On by default when "provider" is set to "local".
           pdb.enable    true     boolean  Optional: Set to true to enable Pod Disruption Budget. If provider local is set to "local", the PDB will be disabled automatically.
@@ -69,13 +69,13 @@ To install Eventing:
 1. Install the package by running:
 
     ```console
-    tanzu package install eventing -p eventing.tanzu.vmware.com -v 2.0.1 -n tap-install -f eventing-values.yaml --poll-timeout 30m
+    tanzu package install eventing -p eventing.tanzu.vmware.com -v 2.0.2 -n tap-install -f eventing-values.yaml --poll-timeout 30m
     ```
 
     For example:
 
     ```console
-    $ tanzu package install eventing -p eventing.tanzu.vmware.com -v 2.0.1 -n tap-install -f eventing-values.yaml --poll-timeout 30m
+    $ tanzu package install eventing -p eventing.tanzu.vmware.com -v 2.0.2 -n tap-install -f eventing-values.yaml --poll-timeout 30m
     - Installing package 'eventing.tanzu.vmware.com'
     | Getting package metadata for 'eventing.tanzu.vmware.com'
     | Creating service account 'eventing-tap-install-sa'
@@ -105,7 +105,7 @@ To install Eventing:
     | Retrieving installation details for eventing...
     NAME:                    eventing
     PACKAGE-NAME:            eventing.tanzu.vmware.com
-    PACKAGE-VERSION:         2.0.1
+    PACKAGE-VERSION:         2.0.2
     STATUS:                  Reconcile succeeded
     CONDITIONS:              [{ReconcileSucceeded True  }]
     USEFUL-ERROR-MESSAGE:

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -52,6 +52,10 @@ The following issues, listed by area and component, are resolved in this release
 - The extension can now generate a snippet on a `Tiltfile` when the user has a Tilt extension installed
 - The extension can now Live Update when the workload type is `server` or `worker`
 
+#### <a id="1-3-1-cnr-resolved"></a> Cloud Native Runtimes
+
+- Deploying workloads on a `run` cluster in multicluster setup on Openshift no longer fails with Forbidden errors.
+
 ### <a id='1-3-1-known-issues'></a> Known issues
 
 This release has the following known issues, listed by area and component.


### PR DESCRIPTION
TAP 1.3.1 includes CNR 2.0.2, which resolves an issue with Openshift.

Corresponding CNR docs changes here: https://gitlab.eng.vmware.com/daisy/cloud-native-runtimes-for-vmware-tanzu/-/merge_requests/143

Which other branches should this be merged with (if any)? none, just 1-3-1
