### PR TITLE
Updating the missing param

### DIFF
--- a/workloads/using-functions.hbs.md
+++ b/workloads/using-functions.hbs.md
@@ -156,6 +156,7 @@ To deploy and verify your function:
     --type web \
     --yes
     --namespace YOUR-DEVELOPER-NAMESPACE
+    --build-env 'BP_FUNCTION=func.hello'
     ```
 
     Where:


### PR DESCRIPTION
Updating the missing param for deploying the function type of workload successfully

Which other branches do you want a technical writer to cherry-pick this PR to (if any)? Should be cherry picked to both 1.3.0 and 1.3.1 docs.
It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
