### PR TITLE
upgrade steps to refer to appropriate repo name

### DIFF
--- a/upgrading.hbs.md
+++ b/upgrading.hbs.md
@@ -50,6 +50,7 @@ Follow these steps to update the new package repository:
     ```console
     tanzu package repository get tanzu-tap-repository --namespace tap-install
     ```
+    Note: Please use the appropriate package repository name based on what was chosen in the previous step(either NEW-TANZU-TAP-REPOSITORY or tanzu-tap-repository).
 
 ## <a id="upgrade-tap"></a> Perform the upgrade of Tanzu Application Platform
 


### PR DESCRIPTION
updating the upgrade steps to refer to appropriate repo name

Which other branches do you want a technical writer to cherry-pick this PR to (if any)? TAP 1.3.1
It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
