### PR TITLE
Change CVEs resolution docs to VMware required format.

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -12,14 +12,8 @@ This release has the following security fixes, listed by area and component.
 
 #### <a id='1-3-1-stk-sec-fix'></a> Services Toolkit
 
-The following CVEs were removed:
-
-- [CVE-2022-3786](https://nvd.nist.gov/vuln/detail/CVE-2022-3786) (High)
-- [CVE-2022-3358](https://nvd.nist.gov/vuln/detail/CVE-2022-3358) (Low)
-- [CVE-2022-3602](https://nvd.nist.gov/vuln/detail/CVE-2022-3602) (High)
-- [CVE-2022-3358](https://nvd.nist.gov/vuln/detail/CVE-2022-3358) (Low)
-- [CVE-2022-3602](https://nvd.nist.gov/vuln/detail/CVE-2022-3602) (High)
-- [CVE-2022-3786](https://nvd.nist.gov/vuln/detail/CVE-2022-3786) (High)
+- `libssl3` has been updated to `3.0.2-0ubuntu1.7` to resolve [CVE-2022-3786](https://nvd.nist.gov/vuln/detail/CVE-2022-3786).
+- `libssl3` has been updated to `3.0.2-0ubuntu1.7` to resolve [CVE-2022-3602](https://nvd.nist.gov/vuln/detail/CVE-2022-3602).
 
 #### <a id='1-3-1-scst-grype-fixes'></a> Supply Chain Security Tools - Grype
 


### PR DESCRIPTION
Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
1.3.1 only is fine

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
