### PR TITLE
Add note of how tap-values is stored as a kubernetes secret

### DIFF
--- a/install-air-gap.hbs.md
+++ b/install-air-gap.hbs.md
@@ -197,6 +197,7 @@ The sample values file contains the necessary defaults for:
     exclude the policy controller `policy.apps.tanzu.vmware.com`, or deploy a
     Sigstore Stack to use as a TUF Mirror. For more information, see [Policy
     controller known issues](scst-policy/known-issues.hbs.md).
+    
     >**Note** `tap-values.yaml` is set as a Kubernetes secret, which provides a secure means for tap components to read these credentials.
 
 ### <a id='full-profile'></a> Full Profile

--- a/install-air-gap.hbs.md
+++ b/install-air-gap.hbs.md
@@ -197,6 +197,7 @@ The sample values file contains the necessary defaults for:
     exclude the policy controller `policy.apps.tanzu.vmware.com`, or deploy a
     Sigstore Stack to use as a TUF Mirror. For more information, see [Policy
     controller known issues](scst-policy/known-issues.hbs.md).
+    >**Note** `tap-values.yaml` is set as a Kubernetes secret, which provides a secure means for tap components to read these credentials.
 
 ### <a id='full-profile'></a> Full Profile
 

--- a/install-aws.hbs.md
+++ b/install-aws.hbs.md
@@ -161,6 +161,7 @@ The sample values file contains the necessary defaults for:
     - Subordinate packages, or individual child packages.
 
     >**Important** Keep the values file for future configuration use.
+    
     >**Note** `tap-values.yaml` is set as a Kubernetes secret, which provides a secure means for tap components to read these credentials.
 
 1. [View possible configuration settings for your package](view-package-config-aws.hbs.md)

--- a/install-aws.hbs.md
+++ b/install-aws.hbs.md
@@ -161,6 +161,7 @@ The sample values file contains the necessary defaults for:
     - Subordinate packages, or individual child packages.
 
     >**Important** Keep the values file for future configuration use.
+    >**Note** `tap-values.yaml` is set as a Kubernetes secret, which provides a secure means for tap components to read these credentials.
 
 1. [View possible configuration settings for your package](view-package-config-aws.hbs.md)
 

--- a/install-openshift.hbs.md
+++ b/install-openshift.hbs.md
@@ -202,6 +202,7 @@ The sample values file contains the necessary defaults for:
     - Subordinate packages, or individual child packages.
 
     >**Important** Keep the values file for future configuration use.
+    >**Note** `tap-values.yaml` is set as a Kubernetes secret, which provides a secure means for tap components to read these credentials.
 
 
 1. [View possible configuration settings for your package](view-package-config-openshift.hbs.md)

--- a/install-openshift.hbs.md
+++ b/install-openshift.hbs.md
@@ -202,6 +202,7 @@ The sample values file contains the necessary defaults for:
     - Subordinate packages, or individual child packages.
 
     >**Important** Keep the values file for future configuration use.
+    
     >**Note** `tap-values.yaml` is set as a Kubernetes secret, which provides a secure means for tap components to read these credentials.
 
 

--- a/install.hbs.md
+++ b/install.hbs.md
@@ -216,6 +216,7 @@ The sample values file contains the necessary defaults for:
     - Subordinate packages, or individual child packages.
 
     >**Important** Keep the values file for future configuration use.
+    >**Note** `tap-values.yaml` is set as a Kubernetes secret, which provides a secure means for tap components to read these credentials.
 
 
 1. [View possible configuration settings for your package](view-package-config.hbs.md)

--- a/install.hbs.md
+++ b/install.hbs.md
@@ -216,6 +216,7 @@ The sample values file contains the necessary defaults for:
     - Subordinate packages, or individual child packages.
 
     >**Important** Keep the values file for future configuration use.
+    
     >**Note** `tap-values.yaml` is set as a Kubernetes secret, which provides a secure means for tap components to read these credentials.
 
 


### PR DESCRIPTION
Which other branches do you want a technical writer to cherry-pick this PR to (if any)? n/a

Make the docs more clear that the tap-values.yaml is stored as a kubernetes secret.

cc: @miketeve 
