### PR TITLE
Update 1.3.2 cherry pic

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -116,6 +116,9 @@ Known security vulnerability
     `Builder default is not ready`.
   - Clicking on the `Scan Template` link in the **Overview** section for a scanning stage causes a
     blank page to open in the browser.
+  - The image provider stage is not correctly reporting status failures and is instead showing a green status when it should not. This does, however,       stop the supply chain execution
+  - Image Provider logs are not appearing in the Stage Details section if the build fails. The logs are, however, available through the cli.
+
 
 - **K8s logging backend  Plug-in**
 


### PR DESCRIPTION
Under Known issues in 1.3.1 for Supply Chain Choreographer plug-in, please add these two lines to the 1.3.2 section:

  - The image provider stage is not correctly reporting status failures and is instead showing a green status when it should not. This does, however,       stop the supply chain execution
  - Image Provider logs are not appearing in the Stage Details section if the build fails. The logs are, however, available through the cli.

Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
