### PR TITLE
Learning Center issue in TAP 1.3.0

### DIFF
--- a/learning-center/troubleshoot-learning-center.hbs.md
+++ b/learning-center/troubleshoot-learning-center.hbs.md
@@ -152,3 +152,11 @@ Where learningcenter.yourdomain.com needs a DNS configuration made to point to y
 In this case, the wildcard domain configuration needed is `*.learningcenter.yourdomain.com`.
 
 After this configuration is made, you might need to restart your operator resource by deleting and redeploying to see the URL update.
+
+## <a id="missing-training-portal-url"></a>session.objects, environment.objects and session.patches are not deployed
+
+Due to a security improvement in Learning Center, session.objects, environment.objects and session.patches are not working properly in TAP 1.2.2 and 1.3.0. 
+
+***Solution***
+
+VMware resolved this issue by Learning Center `v0.2.4` in TAP 1.3.2.

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -617,3 +617,9 @@ Tanzu Application Platform GUI does not work in the Safari web browser.
   Deliverables incorrectly show a DeliveryNotFound error on build profile clusters even though the
   workload is working correctly. The message is typically:
   `No delivery found where full selector is satisfied by labels:`.
+
+### <a id="learning-center-known-issues"></a>Learning Center
+
+- **session.objects, environment.objects and session.patches are not deployed:** 
+
+  - Due to a security improvement in Learning Center, session.objects, environment.objects and session.patches are not working properly. VMware resolved this issue by Learning Center `v0.2.4` in TAP 1.3.2. 


### PR DESCRIPTION
Adding a note on the LC known issues and Troubleshooting page

Due to a security improvement in Learning Center, session.objects, environment.objects and session.patches are not working properly. VMware resolved this issue by Learning Center v0.2.4 in TAP 1.3.2.

Which other branches do you want a technical writer to cherry-pick this PR to (if any)? no
