### PR TITLE
[VSEE-793] Add python security fix for grype scanner

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -59,6 +59,9 @@ Policy Controller no longer initializes TUF by default which is needed to suppor
 
 This release has the following security fixes, listed by area and component.
 
+#### <a id='1-4-0-scst-grype-fixes'></a> Supply Chain Security Tools - Grype
+- `python` has been updated to `3.7.5-22.ph3`
+
 ### <a id='1-4-0-resolved-issues'></a> Resolved issues
 
 The following issues, listed by area and component, are resolved in this release.


### PR DESCRIPTION
Summary:
* Add security fix for python for grype scanner.

Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
N/A
It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
