### PR TITLE
[VSEE-837] Add troubleshooting docs for incorrect configured self-signed cert

### DIFF
--- a/partials/_view-package-config.hbs.md
+++ b/partials/_view-package-config.hbs.md
@@ -56,4 +56,4 @@ Shared Keys define values that configure multiple packages. These keys are defin
 
 |Shared Key|Used By|Description|
 |----|----|----|
-|`ca_cert_data`|`convention_controller`, `source_controller`|Optional: PEM Encoded certificate data to trust TLS connections with a private CA.|
+|`ca_cert_data`|`convention_controller`, `scanning`, `source_controller`|Optional: PEM Encoded certificate data to trust TLS connections with a private CA.|

--- a/scst-scan/observing.hbs.md
+++ b/scst-scan/observing.hbs.md
@@ -306,3 +306,20 @@ Summary logs could not be retrieved: . error opening stream pod logs reader: con
 ```
 
 One possible reason is due to using Grype Scanner ScanTemplates shipped with versions before Supply Chain Security Tools - Scan v1.2.0 which are now deprecated and are no longer supported in v1.4.0+.
+
+The two options to resolve this issue are:
+1. Upgrade Grype Scanner to v1.2+ (preferably latest). This will automatically replace the old ScanTemplates with the upgraded ScanTemplates.
+2. Create a ScanTemplate using this [steps](create-scan-template.hbs.md).
+
+
+#### <a id="incorrectly-configured-self-signed-cert"></a> Incorrectly configured self-signed cert
+
+If the pod logs show the following error:
+```
+x509: certificate signed by unknown authority
+```
+then this indicates that the self-signed cert may be incorrectly configured.
+
+To resolve this issue, follow this [example](../multicluster/reference/tap-values-build-sample.hbs.md) of how to set up the shared self-signed cert.
+
+The shared.ca_cert_data installation value can contain a PEM-encoded CA bundle. The scanning component will then trust the CAs contained in the bundle. The self-signed cert is configured through the [shared top level key](../partials/_view-package-config.hbs.md).


### PR DESCRIPTION
Summary:
* Add troubleshooting docs for incorrect configured self-signed cert.

Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
N/A

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
