### PR TITLE
updating the supported K8s versions for TAP 1.4.0

### DIFF
--- a/prerequisites.hbs.md
+++ b/prerequisites.hbs.md
@@ -80,7 +80,7 @@ For Tanzu Application Platform GUI, you must have:
 
 ## <a id='k8s-cluster-reqs'></a>Kubernetes cluster requirements
 
-Installation requires Kubernetes cluster v1.22, v1.23 or v1.24 on one of the following Kubernetes
+Installation requires Kubernetes cluster v1.23, v1.24 or v1.25 on one of the following Kubernetes
 providers:
 
 - Azure Kubernetes Service.
@@ -144,7 +144,7 @@ For more information, see the [Kubernetes documentation](https://kubernetes.io/d
 
 Installation requires:
 
-- The Kubernetes CLI (kubectl) v1.22, v1.23, or v1.24 installed and authenticated with admin rights for your target cluster. See [Install Tools](https://kubernetes.io/docs/tasks/tools/) in the Kubernetes documentation.
+- The Kubernetes CLI (kubectl) v1.23, v1.24, or v1.25 installed and authenticated with admin rights for your target cluster. See [Install Tools](https://kubernetes.io/docs/tasks/tools/) in the Kubernetes documentation.
 
 ## <a id='next-steps'></a>Next steps
 


### PR DESCRIPTION
updating the supported K8s versions for TAP 1.4.0

Which other branches do you want a technical writer to cherry-pick this PR to (if any)? 1.4.0 only.
Refer to https://confluence.eng.vmware.com/pages/viewpage.action?pageId=789919969 for the supported K8s versions for TAP releases.


It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
