### PR TITLE
VSEE-829 | Announce deprecation of plain text (docker) cred fields

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -47,6 +47,14 @@ This release has the following breaking changes, listed by area and component.
 
 - `Tanzu Debug` no longer port forwards the application port (8080).
 
+#### <a id="1-4-0-scst-scan-bc"></a> Supply Chain Security Tools - Scan
+- Removed deprecated ScanTemplates:
+  - Deprecated Grype ScanTemplates shipped with versions prior to TAP 1.2.0 have been removed and are no longer supported. Please ensure you are using Grype ScanTemplates v1.2+ moving forward.
+- Deprecation notice:
+  - `docker` field and related sub-fields by Supply Chain Security Tools - Scan are deprecated and marked for removal in TAP 1.7.0.
+  - The deprecation will impact the following components: Scan Controller, Grype Scanner and Snyk Scanner.
+  - See [troubleshooting](/scst-scan/observing.hbs.md#unable-to-pull-scanner-controller-images) documentation for the migration path.
+
 #### <a id="1-4-0-ipw-bc"></a> Supply Chain Security Tools - Image Policy Webhook
 
 The Image Policy Webhook component is removed in TAP 1.4 after being deprecated

--- a/scst-scan/observing.hbs.md
+++ b/scst-scan/observing.hbs.md
@@ -323,3 +323,13 @@ then this indicates that the self-signed cert may be incorrectly configured.
 To resolve this issue, follow this [example](../multicluster/reference/tap-values-build-sample.hbs.md) of how to set up the shared self-signed cert.
 
 The shared.ca_cert_data installation value can contain a PEM-encoded CA bundle. The scanning component will then trust the CAs contained in the bundle. The self-signed cert is configured through the [shared top level key](../partials/_view-package-config.hbs.md).
+
+#### <a id="unable-to-pull-scanner-controller-images"></a> Unable to pull scan controller and scanner images from a specified registry
+
+The `docker` field and related sub-fields by Supply Chain Security Tools - Scan Controller, Grype Scanner, or Snyk Scanner were deprecated in TAP 1.4.0. Previously these fields could be used to populate the `registry-credentials` secret. If you encounter the following error during installation:
+```
+UNAUTHORIZED: unauthorized to access repository
+```
+The recommended migration path for users who are setting up their namespaces manually is to add registry credentials to both the developer namespace and the `scan-link-system` namespace, using these [instructions](../partials/_set-up-namespaces.hbs.md).
+
+Note: This manual step does not apply to users who used `--export-to-all-namespaces` when setting up the TAP package repo.


### PR DESCRIPTION
Which other branches do you want a technical writer to cherry-pick this PR to (if any)? NA

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches

Signed-off-by: Robin Li <lrobin@vmware.com>