### PR TITLE
Improves instructions on applying a Redis CA certificate for AuthServer storage

### DIFF
--- a/app-sso/service-operators/storage.hbs.md
+++ b/app-sso/service-operators/storage.hbs.md
@@ -39,20 +39,12 @@ The following steps introduce the path to configuring Redis with AppSSO:
 
 ### Configuring Redis Server CA certificate
 
-If your Redis comes with a custom or non-public Server CA certificate, you are required to add the certificate to AppSSO
-package in order for an authorization server to establish an encrypted TLS connection successfully.
+If your Redis comes with a custom or non-public Server CA certificate, you will need to instruct AppSSO to
+trust the CA certificate. This is required in order for the authorization server to communicate with your
+Redis over TLS successfully.
 
-Redis Server CA certificate can be added
-to [AppSSO configuration](../platform-operators/configuration.md#ca_cert_data) via `values.yaml`:
-
-```yaml
-...
-ca_cert_data: |
-  -----BEGIN CERTIFICATE-----
-  <certificate-data>
-  -----END CERTIFICATE-----
-...
-```
+There are multiple ways of configuring a CA certificate with AppSSO, please refer to
+[CA certificates page](./ca-certs.md) for instructions.
 
 ### Configuring a Redis Secret
 


### PR DESCRIPTION
TAP 1.4.x only.
