### PR TITLE
Update K8S Version and EBS CSI Driver

### DIFF
--- a/aws-resources.hbs.md
+++ b/aws-resources.hbs.md
@@ -103,7 +103,7 @@ To simplify this walkthrough, use a script to create these policy documents and 
 Run:
 
 ```console
-oidcProvider=$(aws eks describe-cluster --name $EKS_CLUSTER_NAME --region $AWS_REGION | jq '.cluster.identity.oidc.issuer' | tr -d '"' | sed 's/https:\/\///')
+export OIDCPROVIDER=$(aws eks describe-cluster --name $EKS_CLUSTER_NAME --region $AWS_REGION | jq '.cluster.identity.oidc.issuer' | tr -d '"' | sed 's/https:\/\///')
 cat << EOF > build-service-trust-policy.json
 {
     "Version": "2012-10-17",
@@ -111,15 +111,15 @@ cat << EOF > build-service-trust-policy.json
         {
             "Effect": "Allow",
             "Principal": {
-                "Federated": "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/${oidcProvider}"
+                "Federated": "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/${OIDCPROVIDER}"
             },
             "Action": "sts:AssumeRoleWithWebIdentity",
             "Condition": {
                 "StringEquals": {
-                    "${oidcProvider}:aud": "sts.amazonaws.com"
+                    "${OIDCPROVIDER}:aud": "sts.amazonaws.com"
                 },
                 "StringLike": {
-                    "${oidcProvider}:sub": [
+                    "${OIDCPROVIDER}:sub": [
                         "system:serviceaccount:kpack:controller",
                         "system:serviceaccount:build-service:dependency-updater-controller-serviceaccount"
                     ]
@@ -274,13 +274,13 @@ cat << EOF > workload-trust-policy.json
         {
             "Effect": "Allow",
             "Principal": {
-                "Federated": "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/${oidcProvider}"
+                "Federated": "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/${OIDCPROVIDER}"
             },
             "Action": "sts:AssumeRoleWithWebIdentity",
             "Condition": {
                 "StringEquals": {
-                    "${oidcProvider}:sub": "system:serviceaccount:default:default",
-                    "${oidcProvider}:aud": "sts.amazonaws.com"
+                    "${OIDCPROVIDER}:sub": "system:serviceaccount:default:default",
+                    "${OIDCPROVIDER}:aud": "sts.amazonaws.com"
                 }
             }
         }

--- a/aws-resources.hbs.md
+++ b/aws-resources.hbs.md
@@ -51,12 +51,16 @@ Where:
 To create an EKS cluster in the specified region, run:
 
 ```
-eksctl create cluster --name $EKS_CLUSTER_NAME --managed --region $AWS_REGION --instance-types t3.large --version 1.22 --with-oidc -N 5
+eksctl create cluster --name $EKS_CLUSTER_NAME --managed --region $AWS_REGION --instance-types t3.large --version 1.23 --with-oidc -N 5
 ```
 
 Creating the control plane and node group can take anywhere from 30-60 minutes.
 
->**Note** This step is optional if you already have an existing EKS Cluster of at least v1.22 with OpenID Connect (OIDC) authentication enabled. To enable the OIDC provider, see this [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html).
+>**Note** This step is optional if you already have an existing EKS Cluster of at least v1.23 with OpenID Connect (OIDC) authentication enabled. To enable the OIDC provider, see this [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html).
+
+## <a id='Install EBS CSI Driver'></a>Install EBS CSI Driver
+
+Starting with EKS 1.23, the EBS CSI driver is no longer installed by default, which is required for the Tanzu Application Platform.  Ensure it is installed using the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html).
 
 ## <a id='create-container-repos'></a>Create the container repositories
 


### PR DESCRIPTION
Need to upgrade to version 1.23 of EKS, which also brings in the requirement to add the EBS CSI Driver.