### PR TITLE
Adds instruction to create ECR repository

### DIFF
--- a/install-aws.hbs.md
+++ b/install-aws.hbs.md
@@ -355,11 +355,17 @@ To install the `full` dependencies package:
     tanzu package available list buildservice.tanzu.vmware.com --namespace tap-install
     ```
 
+1. Create ECR Repository for full TBS dependencies by running:
+
+    ```console
+    aws ecr create-repository --repository-name tbs-full-deps --region ${AWS_REGION}
+    ```
+
 1. Relocate the Tanzu Build Service full dependencies package repository by running:
 
     ```console
     imgpkg copy -b registry.tanzu.vmware.com/tanzu-application-platform/full-tbs-deps-package-repo:VERSION \
-      --to-repo ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/tbs-full-deps
+      --to-repo ${INSTALL_REGISTRY_HOSTNAME}/tbs-full-deps
     ```
 
     Where `VERSION` is the version of the `buildservice` package you retrieved in the previous step.


### PR DESCRIPTION
Repository must exist before relocating images.

Should go in 1.3 and 1.4