### PR TITLE
extensions: add timeout error to troubleshooting

### DIFF
--- a/intellij-extension/troubleshooting.hbs.md
+++ b/intellij-extension/troubleshooting.hbs.md
@@ -19,7 +19,7 @@ the same time.
 These controls are reactivated when the launch configuration is started.
 As such, starting multiple Tanzu debug and live update sessions is a synchronous activity.
 
-## <a id='dbg-fail-crrpt-lnch-conf'>Starting a Tanzu Debug session fails with `Unable to open debugger port`
+## <a id='dbg-fail-crrpt-lnch-conf'></a> Starting a Tanzu Debug session fails with `Unable to open debugger port`
 
 ### Symptom
 
@@ -57,3 +57,18 @@ the plug-in when the plug-in is hot-swapped into an active session instead of lo
 
 Closing and restarting IntelliJ typically fixes this problem.
 If that doesn't work for you, delete the old corrupted launch configuration and recreate it.
+
+## <a id="live-update-timeout"></a> Timeout error when Live Updating
+
+### Sympton
+When a user attempts to Live Update their workload, they may get the following error in the logs: 
+
+`ERROR: Build Failed: apply command timed out after 30s - see }}{{https://docs.tilt.dev/api.html#api.update_settings{{ for how to increase}}`
+
+### Cause
+
+Kubernetes times out on upserts over 30 seconds.
+
+### Solution
+
+Add `update_settings (k8s_upsert_timeout_secs = 300)` to the Tiltfile. See Tiltfile [docs](https://docs.tilt.dev/api.html#api.update_settings).

--- a/vscode-extension/troubleshooting.hbs.md
+++ b/vscode-extension/troubleshooting.hbs.md
@@ -56,3 +56,18 @@ Force the VS Code Java tooling to re-read and synchronize information from the P
 
 This causes the internal compiler level to be set correctly based on the information from `pom.xml`.
 For example, Java 11 in `tanzu-java-web-app`.
+
+## <a id="live-update-timeout"></a> Timeout error when Live Updating
+
+### Sympton
+When a user attempts to Live Update their workload, they may get the following error in the logs: 
+
+`ERROR: Build Failed: apply command timed out after 30s - see }}{{https://docs.tilt.dev/api.html#api.update_settings{{ for how to increase}}`
+
+### Cause
+
+Kubernetes times out on upserts over 30 seconds.
+
+### Solution
+
+Add `update_settings (k8s_upsert_timeout_secs = 300)` to the Tiltfile. See Tiltfile [docs](https://docs.tilt.dev/api.html#api.update_settings).


### PR DESCRIPTION
Which other branches do you want a technical writer to cherry-pick this PR to (if any)?


It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches

Please cherry pick to all previous branches.
