### PR TITLE
Update for external_delivery fixes for 1.4.0

### DIFF
--- a/multicluster/getting-started.hbs.md
+++ b/multicluster/getting-started.hbs.md
@@ -53,7 +53,7 @@ The Build cluster starts by building the necessary bundle for the workload that 
 1. Verify that your supply chain has produced the necessary `ConfigMap` containing `Deliverable` content produced by the `Workload`:
 
     ```bash
-    kubectl get configmap tanzu-java-web-app --namespace ${DEVELOPER_NAMESPACE} -o go-template='\{{.data.deliverable}}'
+    kubectl get configmap tanzu-java-web-app-deliverable --namespace ${DEVELOPER_NAMESPACE} -o go-template='\{{.data.deliverable}}'
     ```
 
     The output resembles the following:
@@ -62,7 +62,7 @@ The Build cluster starts by building the necessary bundle for the workload that 
     apiVersion: carto.run/v1alpha1
     kind: Deliverable
     metadata:
-      name: tanzu-java-web-app
+      name: tanzu-java-web-app-deliverable
       labels:
         apis.apps.tanzu.vmware.com/register-api: "true"
         app.kubernetes.io/part-of: tanzu-java-web-app
@@ -83,7 +83,7 @@ The Build cluster starts by building the necessary bundle for the workload that 
 1. Store the `Deliverable` content, which you can take to the Run profile clusters from the `ConfigMap` by running:
 
    ```console
-   kubectl get configmap tanzu-java-web-app -n ${DEVELOPER_NAMESPACE} -o go-template='\{{.data.deliverable}}' > deliverable.yaml
+   kubectl get configmap tanzu-java-web-app-deliverable -n ${DEVELOPER_NAMESPACE} -o go-template='\{{.data.deliverable}}' > deliverable.yaml
    ```
 
 1. Take this `Deliverable` file to the Run profile clusters by running:

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -162,6 +162,12 @@ This release has the following breaking changes, listed by area and component.
 - Removed deprecated field `AuthServer.spec.issuerURI`. For more information, see [IssuerURI and TLS](./app-sso/service-operators/issuer-uri-and-tls.hbs.md).
 </br></br>
 
+#### <a id="1-4-0-supply-chain-templates"></a> OOTB Supply Chain Templates
+
+In a [multi-cluster setup](./multicluster/about.hbs.md), when a Deliverable is created on a Build profile cluster, 
+the ConfigMap it is placed in has been renamed from `<workload-name>` to `<workload-name>-deliverable`.  Any automation
+depending on obtaining the Deliverable content by the former name must be updated to use the new name.
+
 #### <a id="1-4-0-intellij-bc"></a> Tanzu Developer Tools for IntelliJ
 
 - IntelliJ IDEA v2022.2 to v2022.3 is required to install the extension.
@@ -251,6 +257,15 @@ The following issues, listed by area and component, are resolved in this release
   versions 1.23.x and lower.
 - LDAP error log now contains proper error message.
 </br></br>
+
+
+#### <a id="1-4-0-supply-chain-templates-resolved"></a> OOTB Supply Chain Templates
+
+Issues fixed with deliverable content written into ConfigMaps in
+[multi-cluster setup](./multicluster/about.hbs.md):
+- ConfigMap is renamed to avoid conflict with `config-template`;
+- Labels to attribute the Deliverable content with the supply chain and template used are now added just as 
+  the would when written into an ordinary Delivery on a non-Build profile cluster.
 
 #### <a id="1-4-0-apps-cli-plugin-ri"></a> Tanzu CLI Apps Plug-in
 


### PR DESCRIPTION
- Added breaking change note regarding rename of deliverable TSCC-144
- Added resolved issues for TSCC-144 and TANZUSC-2682
- Updated multicluster documentation to reflect changed name of deliverable TSCC-144

Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
None. This currently only applies to 1.4.0+

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
