### PR TITLE
Fixes example for backend.reading.allow in air gap install docs

### DIFF
--- a/install-air-gap.hbs.md
+++ b/install-air-gap.hbs.md
@@ -295,7 +295,7 @@ tap_gui:
     backend:
       reading:
         allow:
-          - host: https://GIT-CATALOG-URL/catalog-info.yaml
+          - host: GITLABURL # e.g. gitlab.example.com
 
 metadata_store:
   ns_for_export_app_cert: "MY-DEV-NAMESPACE"


### PR DESCRIPTION
Signed-off-by: Michael Stergianis <mstergianis@vmware.com>

Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
Could be transferred to all branches that have that line

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
