### PR TITLE
Order of operation for multicluster upgrade

### DIFF
--- a/upgrading.hbs.md
+++ b/upgrading.hbs.md
@@ -88,6 +88,18 @@ You can wait for the next build of the workloads that new source code changes tr
 If you do not want to wait for subsequent builds to run automatically, follow the instructions in
 [Builds fail after upgrading to Tanzu Application Platform v1.2](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.2/tap/GUID-tanzu-build-service-troubleshooting.html#builds-fail-after-upgrading-to-tanzu-application-platform).
 
+### Multicluster upgrade order
+
+Upgrading a [multicluster deployment](multicluster/installing-multicluster.hbs.md) requires updating multiple clusters with different profiles.
+If upgrades are not carried out at the exact same time, different cluster will have different versions of profile installed temporarily.
+This could cause a temporary API mismatch which causes some errors.
+Those errors will eventually stop when all clusters are at the same version.
+
+To reduce the likelihood of temporary failures, users should upgrade the View profile cluster first before other profiles:
+
+1. First upgrade the View profile cluster.
+1. Then upgrade all other clusters in any order.
+
 ### <a id="comp-specific-instruct"></a> Upgrade instructions for component-specific installation
 
 For information about upgrading Tanzu Application Platform GUI, see [Upgrade Tanzu Application Platform GUI](tap-gui/upgrades.html).


### PR DESCRIPTION
A short recommendation on the order of operation for a multicluster upgrade.

This is to address an issue testers saw when they upgraded build cluster before view cluster when upgrading from 1.3 to 1.4.

Please merge into `main`.