### PR TITLE
Warn of breaking changes for GUI->Store configuration

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -218,9 +218,9 @@ As such, if you have explicitly set the fields `tap_gui.app_config.app.baseUrl`,
 
 ##### Communication with Supply Chain Security Tools - Store
 
-In previous versions of installation guide, users were asked to configure the TAP GUI to use the read-only access token to communicate with Supply Chain Security Tools - Store.
-In v1.4, users need to use the read-write access token.
-The change is necessary to enable the use of new APIs to support the Security Analysis GUI plugin.
+In previous version of TAP, users were asked to configure the TAP GUI to use the read-only access token to communicate with Supply Chain Security Tools - Store.
+In v1.4, users need to use the read-write access token in order to use new features in the Security Analysis GUI plugin.
+Users upgrading from v1.3 should update their TAP GUI configuration.
 See the updated instructions in [Enable CVE scan results](tap-gui/plugins/scc-tap-gui.hbs.md#scan).
 
 #### <a id="1-4-0-scst-scan-bc"></a> Supply Chain Security Tools - Scan

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -194,6 +194,8 @@ For more information, see [Multicluster Tanzu Application Platform overview](mul
 
 #### <a id="1-4-0-tap-gui-bc"></a> Tanzu Application Platform GUI
 
+##### Ingress URL
+
 As mentioned in the [new features section](#1-4-0-tap-new-features), Tanzu Application Platform GUI
 participates in the shared ingress issuer feature.
 As such, if you have explicitly set the fields `tap_gui.app_config.app.baseUrl`,
@@ -213,6 +215,13 @@ As such, if you have explicitly set the fields `tap_gui.app_config.app.baseUrl`,
   ```
 
   Where `INGRESS-DOMAIN` is the ingress domain you have configured for Tanzu Application Platform.
+
+##### Communication with Supply Chain Security Tools - Store
+
+In previous versions of installation guide, users were asked to configure the TAP GUI to use the read-only access token to communicate with Supply Chain Security Tools - Store.
+In v1.4, users need to use the read-write access token.
+The change is necessary to enable the use of new APIs to support the Security Analysis GUI plugin.
+See the updated instructions in [Enable CVE scan results](tap-gui/plugins/scc-tap-gui.hbs.md#scan).
 
 #### <a id="1-4-0-scst-scan-bc"></a> Supply Chain Security Tools - Scan
 


### PR DESCRIPTION
Because of new APIs in the metadata store to support new 1.4 features for Security Analysis GUI, we need to use the read-write access token instead of the read-only access token when configuration the GUI to talk to metadata store.

This doc warns about those breaking changes and the highlights the new configuration.