### PR TITLE
SSO: Clarify instructions for securing workload

### DIFF
--- a/app-sso/app-operators/tutorials/securing-first-workload.hbs.md
+++ b/app-sso/app-operators/tutorials/securing-first-workload.hbs.md
@@ -131,7 +131,7 @@ as described.
 
 Apply the `client.yaml` definition file (described [above](#the-sample-applications-clientregistration))
 
-> **Caution** Make sure to set `auth_server_name` field to the name of the AuthServer custom resource.
+> **Caution** Make sure to set `auth_server_name` field to the value of the label "name" on the AuthServer custom resource (this may differ from the name of the AuthServer custom resource).
 
 ```shell
 ytt \
@@ -151,7 +151,7 @@ A bit more detail on the above YTT data values:
 - **domain** - the domain name under which the workload will be deployed. The workload instance will use a subdomain to
   distinguish itself from other workloads. If working locally, `127.0.0.1.nip.io` is the easiest approach to get a
   working DNS route on a local cluster.
-- **auth_server_name** - the name of the AuthServer resource that you have installed and want to use with your Workload.
+- **auth_server_name** - the value of the label "name" on the AuthServer resource that you have installed and want to use with your Workload (this may differ from the name of the AuthServer custom resource).
 - **claim_name** - the service resource claim name being assigned for this workload, this is the binding between the
   workload and AppSSO. You may choose any reasonably descriptive name for this, it will be used in the next step.
 


### PR DESCRIPTION
The `client.yaml` file in the sample application has the following format:
```
#@ load("@ytt:data", "data")

---
apiVersion: sso.apps.tanzu.vmware.com/v1alpha1
kind: ClientRegistration
metadata:
  name: #@ data.values.workload_name
  namespace: #@ data.values.namespace
spec:
  authServerSelector:
    matchLabels:
      name: #@ data.values.auth_server_name
# ...
```

This means that the client registration will try to match the authorization server based on the label called "name" and not the name of the resource.

This is especially confusing because in the documentation for [Provision an AuthServer
](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.3/tap/GUID-app-sso-getting-started-provision-auth-server.html) the resource name (i.e my-authserver-example) and the label "name" (i.e my-first-auth-server) are different.


Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
1.3.x, 1.4.x

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
