### PR TITLE
Explain why https creds required for pr flow

### DIFF
--- a/scc/gitops-vs-regops.hbs.md
+++ b/scc/gitops-vs-regops.hbs.md
@@ -297,6 +297,11 @@ You can use this strategy with the following Git providers:
 #### <a id="auth"></a> Authentication
 
 The pull request approach requires HTTP(S) authentication with a token.
+This is because a pull request is not a part of the git specification,
+it is functionality layered on top by nearly all git server providers.
+As such, you need to authenticate with those providers,
+which we do with a token.
+
 In the [Kubernetes secret](#http-auth)
 that holds the Git credentials, the password text box must be filled with a token.
 When generating a token, ensure that it is given proper scope:


### PR DESCRIPTION
Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

**This should backport to 1.2 and 1.3**

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
