### PR TITLE
Streamline workload arn

### DIFF
--- a/set-up-namespaces-aws.hbs.md
+++ b/set-up-namespaces-aws.hbs.md
@@ -12,9 +12,13 @@ that you plan to create the `Workload` in:
 
 Follow these steps to enable your current user to submit jobs to the Supply Chain:
 
-1. Gather the ARN created for workloads in the [Create AWS Resources](aws-resources.html).
+1. If the AWS_ACCOUNT_ID environment variable is not set from the [install](install-aws.html) still, export the AWS Account ID.
 
-1. Update the `YOUR-NAMESPACE` and `ROLE-ARN` and run the following command to add secrets, a service account to execute the supply chain, and RBAC rules to authorize the service account to the developer namespace.
+    ```console
+    export AWS_ACCOUNT_ID=MY-AWS-ACCOUNT-ID
+    ```
+
+1. Update the `YOUR-NAMESPACE` variable to your developer namespace and run the following command to add a service account to execute the supply chain, and RBAC rules to authorize the service account to the developer namespace.
 
     ```console
     cat <<EOF | kubectl -n YOUR-NAMESPACE apply -f -
@@ -23,7 +27,7 @@ Follow these steps to enable your current user to submit jobs to the Supply Chai
     metadata:
       name: default
       annotations:
-        eks.amazonaws.com/role-arn: ROLE-ARN
+        eks.amazonaws.com/role-arn: "arn:aws:iam::${AWS_ACCOUNT_ID}:role/tap-workload"
     ---
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding


### PR DESCRIPTION
Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
This just streamlines the document, and isn't a fix.  If that qualifies for a cherry-pick, then in can be cherry picked to all 1.3.x versions, but it's not a requirement.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
