### PR TITLE
Update docs to specify VS Code in turning off optional git repo creation

### DIFF
--- a/tap-gui/plugins/application-accelerator-git-repo.hbs.md
+++ b/tap-gui/plugins/application-accelerator-git-repo.hbs.md
@@ -1,17 +1,19 @@
-# Creating an Application Accelerator Git repository in Tanzu Application Platform GUI
+# Creating an Application Accelerator Git repository during project creation
 
 This topic describes how to enable and use the GitHub repository creation in the Application
 Accelerator plug-in.
 
 ## <a id="overview"></a> Overview
 
-The Application Accelerator plug-in uses the backstage GitHub provider integration and the
+The Application Accelerator plug-in uses the Backstage GitHub provider integration and the
 authentication mechanism to retrieve an access token. Then it can interact with the provider API to
 create GitHub repositories.
 
 ## <a id="supported-providers"></a> Supported Providers
 
-In Tanzu Application Platform v1.4 the supported Git providers are GitHub and GitLab.
+In the currently suppoteded Git providers are
+* GitHub
+* GitLab
 
 ## <a id="configuration"></a> Configure
 
@@ -31,8 +33,8 @@ The following steps describe an example configuration that uses GitHub:
      providers:
        github:
          development:
-           clientId: GITHUB_CLIENT_ID
-           clientSecret: GITHUB_CLIENT_SECRET
+           clientId: GITHUB-CLIENT-ID
+           clientSecret: GITHUB-CLIENT-SECRET
    ```
 
 2. Add a GitHub integration in your `app-config.yaml` configuration. For example:
@@ -47,10 +49,10 @@ The following steps describe an example configuration that uses GitHub:
    For more information, see the
    [Backstage documentation](https://backstage.io/docs/integrations/github/locations).
 
-### <a id="disable-git-repo-creation"></a> Disable optional git repo creation
+### <a id="disable-git-repo-creation"></a> Disable optional git repo creation in the Application Accelerator extension for VS Code
 
 From version 1.4 of the Tanzu Application Platform, the Application Accelerator extension for VS Code leverages the Tanzu Application GUI URL to interact with the accelerator system.
-There is a new plugin called `gitProviders` that can be optionally configured to disable the git repository creation system-wide. 
+There is a new plugin called `gitProviders` that can be optionally configured to disable the git repository creation in the VS Code extension. 
 
 To disable optional git repo creation, set `app_config.gitProviders.active` to `false` in the `tap-values.yaml` as shown in the example below:
 


### PR DESCRIPTION
Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

1.4+

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
