### PR TITLE
showing Namespace provisioner as per profiles

### DIFF
--- a/about-package-profiles.hbs.md
+++ b/about-package-profiles.hbs.md
@@ -470,6 +470,21 @@ The following table lists the packages contained in each profile:
    </td>
   </tr>
   <tr>
+    <tr>
+   <td>Namespace Provisioner
+  </td>
+   <td>&check;
+   </td>
+   <td>&check;
+   </td>
+   <td>&check;
+   </td>
+   <td>&check;
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
    <td>Out of the Box Delivery - Basic
    </td>
    <td>&check;


### PR DESCRIPTION
showing Namespace provisioner as per profiles

Which other branches do you want a technical writer to cherry-pick this PR to (if any)? 1.4.0


It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
