### PR TITLE
Add namespace notes for VS plugin

### DIFF
--- a/vs-extension/troubleshooting.hbs.md
+++ b/vs-extension/troubleshooting.hbs.md
@@ -50,3 +50,24 @@ to
 This copies the correct portion of the local workspace to the remote app.
 The actual path `bin/Debug/net6.0` might be different depending on your Visual Studio configuration
 and target.
+
+## <a id='delete-workload-fails'></a> Delete workload fails to delete workload
+
+### Symptom
+
+In v0.1.0 and earlier, the `Tanzu: Delete Workload` command appears to complete successfully but does not delete the workload.
+
+### Cause
+
+The workload is running in a namespace other than `default`.
+
+### Solution
+
+Only deploy workloads to the `default` namespace.
+
+Alternatively, set the default Kubernetes namespace to that where your workload is running.
+
+```
+$ kubectl config set-context --current --namespace=NAMESPACE
+
+```


### PR DESCRIPTION
This documents an issue found late today in the Visual Studio plugin.  It describes how to workaround not being to delete workloads in namespaces other than `default`.