### PR TITLE
Prisma scanner updates for alpha 3 package update

### DIFF
--- a/scst-scan/install-prisma-integration.hbs.md
+++ b/scst-scan/install-prisma-integration.hbs.md
@@ -1,5 +1,7 @@
 # Prerequisites for Prisma Scanner (Alpha)
 
+This topic describes prerequisites for installing SCST - Scan (Prisma) from the VMware package repository.
+
 >**Note** This integration is in Alpha, which means that it is still in active
 >development by the Tanzu Practices Global Tech Team and might be subject to
 >change at any point. Users might encounter unexpected behavior.
@@ -52,7 +54,7 @@ To relocate images from the VMware Tanzu Network registry to your registry:
     - `MY-REGISTRY-USER` is the user with write access to MY-REGISTRY.
     - `MY-REGISTRY-PASSWORD` is the password for `MY-REGISTRY-USER`.
     - `MY-REGISTRY` is your own registry.
-    - `VERSION` is your Prisma Scanner version. For example, `0.1.4-alpha.1`.
+    - `VERSION` is your Prisma Scanner version. For example, `0.1.4-alpha.3`.
     - `TARGET-REPOSITORY` is your target repository, a directory or repository on `MY-REGISTRY` that serves as the location for the installation files for Prisma Scanner.
 
 5. [Install the Carvel tool imgpkg CLI](https://docs.vmware.com/en/Cluster-Essentials-for-VMware-Tanzu/1.4/cluster-essentials/deploy.html#optionally-install-clis-onto-your-path-6).
@@ -60,7 +62,7 @@ To relocate images from the VMware Tanzu Network registry to your registry:
 6. Relocate the images with the imgpkg CLI by running:
 
     ```console
-    imgpkg copy -b projects.registry.vmware.com/tap-scanners-package/prisma-repo-scanning-bundle:${VERSION} --to-repo ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/prisma-repo-scanning-bundle
+    imgpkg copy -b projects.registry.vmware.com/tanzu_practice/tap-scanners-package/prisma-repo-scanning-bundle:${VERSION} --to-repo ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/prisma-repo-scanning-bundle
     ```
 
 ## Add the Prisma Scanner package repository
@@ -96,7 +98,7 @@ VMware recommends installing the Prisma Scanner objects in the existing `tap-ins
     NAME:          prisma-scanner-repository
     VERSION:       71091125
     REPOSITORY:    index.docker.io/tapsme/prisma-repo-scanning-bundle
-    TAG:           0.1.4-alpha.1
+    TAG:           0.1.4-alpha.3
     STATUS:        Reconcile succeeded
     REASON:
     ```
@@ -116,17 +118,13 @@ VMware recommends installing the Prisma Scanner objects in the existing `tap-ins
       prisma.scanning.apps.tanzu.vmware.com                Prisma for Supply Chain Security Tools - Scan                             Default scan templates using Prisma
     ```
 
-## Prerequisites for Prisma Scanner (Alpha)
-
-This topic describes prerequisites for installing SCST - Scan (Prisma) from the VMware package repository.
-
-### Prepare the Prisma Scanner configuration
+## Prepare the Prisma Scanner configuration
 
 To prepare the Prisma configuration before you install any scanners:
 
-1. Obtain a Prisma Token from Prisma.
-
-1. Create a Prisma secret YAML file and insert the base64 encoded Prisma API token into the `prisma_token`:
+1. Obtain your Prisma Compute Console url and Access Keys/Token by following the documentation [here](https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-admin-compute/authentication/access_keys)  
+   * Note - generated tokens expire after an hour
+2. Create a Prisma secret YAML file and insert the base64 encoded Prisma API token into the `prisma_token`:
 
     ```yaml
     apiVersion: v1
@@ -144,7 +142,7 @@ To prepare the Prisma configuration before you install any scanners:
     - `APP-NAME` is the namespace you want to use.
     - `BASE64-PRISMA-API-TOKEN` is the name of your base64 encoded Prisma API token.
 
-2. Apply the Prisma secret YAML file by running:
+3. Apply the Prisma secret YAML file by running:
 
     ```console
     kubectl apply -f YAML-FILE
@@ -152,7 +150,7 @@ To prepare the Prisma configuration before you install any scanners:
 
     Where `YAML-FILE` is the name of the Prisma secret YAML file you created.
 
-3. Define the `--values-file` flag to customize the default configuration. You
+4. Define the `--values-file` flag to customize the default configuration. You
    must define the following fields in the `values.yaml` file for the Prisma
    Scanner configuration. You can add fields as needed to activate or deactivate
    behaviors. You can append the values to this file as shown later in this
@@ -183,7 +181,7 @@ To prepare the Prisma configuration before you install any scanners:
 The Prisma integration can work with or without the SCST - Store integration.
 The values.yaml file is slightly different for each configuration.
 
-### Supply Chain Security Tools - Store integration
+## Supply Chain Security Tools - Store integration
 
 When using SCST - Store integration, to persist the results
 found by the Prisma Scanner, you can enable the SCST -
@@ -264,7 +262,7 @@ metadataStore:
   url: "" # Configuration is moved, so set this string to empty
 ```
 
-### Sample ScanPolicy for CycloneDX Format
+## Sample ScanPolicy for CycloneDX Format
 
 ```yaml
 apiVersion: scanning.apps.tanzu.vmware.com/v1beta1
@@ -321,371 +319,10 @@ Where:
 - `DEV-NAMESPACE` is the name of the developer namespace you want to use.
 - `SCAN-POLICY-YAML` is the name of your SCST - Scan YAML.
 
-## Install Another Scanner for Supply Security Tools - Scan (Prisma)
+## Install Prisma Scanner
 
-This topic describes how to install scanners to work with SCST - Scan from the VMware package repository.
+After all prerequisites are completed, follow the steps in [Install another scanner for Supply Chain Security Tools - Scan](install-scanners.hbs.md) to install the Prisma Scanner.
 
-Follow these instructions to install a scanner other than the out of the box Grype Scanner.
-
-### Prerequisites
-
-Before installing a new scanner, install SCST - Scan. It must be present on the same cluster. The prerequisites for Scan are also required.
-
-### Install
-
-To install a new scanner:
-
-1. List the available packages to discover what scanners you can use by running:
-
-    ```console
-    tanzu package available list --namespace tap-install
-    ```
-
-    For example:
-
-    ```console
-    $ tanzu package available list --namespace tap-install
-    / Retrieving available packages...
-      NAME                                                 DISPLAY-NAME                                                              SHORT-DESCRIPTION
-      grype.scanning.apps.tanzu.vmware.com                 Grype Scanner for Supply Chain Security Tools - Scan                      Default scan templates using Anchore Grype
-      snyk.scanning.apps.tanzu.vmware.com                  Snyk for Supply Chain Security Tools - Scan                               Default scan templates using Snyk
-      carbonblack.scanning.apps.tanzu.vmware.com           Carbon Black Scanner for Supply Chain Security Tools - Scan               Default scan templates using Carbon Black
-      prisma.scanning.apps.tanzu.vmware.com                Prisma for Supply Chain Security Tools - Scan                             Default scan templates using Prisma
-    ```
-
-2. List version information for the scanner package by running:
-
-    ```console
-    tanzu package available list SCANNER-NAME --namespace tap-install
-    ```
-
-    For example:
-
-    ```console
-    $ tanzu package available list prisma.scanning.apps.tanzu.vmware.com --namespace tap-install
-    / Retrieving package versions for prisma.scanning.apps.tanzu.vmware.com...
-      NAME                                  VERSION           RELEASED-AT
-      prisma.scanning.apps.tanzu.vmware.com   0.1.4-alpha.1
-    ```
-
-3. (Optional) Confirm that the `prisma-token-secret` secret is created.
-
-4. Create a `values.yaml` to apply custom configurations to the scanner:
-
-    To list the values you can configure for any scanner, run:
-
-    ```console
-    tanzu package available get SCANNER-NAME/VERSION --values-schema -n tap-install
-    ```
-
-    Where:
-
-    - `SCANNER-NAME` is the name of the scanner package you retrieved earlier.
-    - `VERSION` is your package version number. For example, `prisma.scanning.apps.tanzu.vmware.com/0.1.4-alpha.1`.
-
-    For example:
-
-    ```console
-    $ tanzu package available get prisma.scanning.apps.tanzu.vmware.com/0.1.4-alpha.1 --values-schema -n tap-install
-
-      KEY                                           DEFAULT                                                           TYPE    DESCRIPTION
-      prisma.tokenSecret.name                       prisma-token                                                      string  Reference to the secret named prisma-token containing a Prisma API Token set as
-                                                                                                                              prisma_token
-      prisma.url                                                                                                      string  Twistlock server url (https://twistlock.example.com:8083)
-      prisma.caCertConfigMap.name                                                                                     string  Reference to the configmap containing the registry ca cert set as ca_cert_data
-      prisma.projectName                                                                                              string  Twistlock target project
-      resources.limits.cpu                          1000m                                                             string  Limits describes the maximum amount of cpu resources allowed.
-      resources.requests.cpu                        250m                                                              string  Requests describes the minimum amount of cpu resources required.
-      resources.requests.memory                     128Mi                                                             string  Requests describes the minimum amount of memory resources
-      scanner.docker.password                                                                                         string  <nil>
-      scanner.docker.server                                                                                           string  <nil>
-      scanner.docker.username                                                                                         string  <nil>
-      scanner.pullSecret                                                                                              string  <nil>
-      scanner.serviceAccount                        prisma-scanner                                                    string  Name of scan pod's service ServiceAccount
-      scanner.serviceAccountAnnotations                                                                               string  Annotations added to ServiceAccount
-      targetImagePullSecret                                                                                           string  Reference to the secret used for pulling images from private
-      metadataStore.authSecret.importFromNamespace                                                                    string  Namespace from which to import the Insight Metadata Store auth_token
-      metadataStore.authSecret.name                                                                                   string  Name of deployed Secret with key auth_token
-      metadataStore.caSecret.importFromNamespace    metadata-store                                                    string  Namespace from which to import the Insight Metadata Store CA Cert
-      metadataStore.caSecret.name                   app-tls-cert                                                      string  Name of deployed Secret with key ca.crt holding the CA Cert of the Insight
-                                                                                                                              Metadata Store
-      metadataStore.clusterRole                     metadata-store-read-write                                         string  Name of the deployed ClusterRole for read/write access to the Insight Metadata
-                                                                                                                              Store deployed in the same cluster
-      metadataStore.url                             https://metadata-store-app.metadata-store.svc.cluster.local:8443  string  Url of the Insight Metadata Store
-      namespace                                     default                                                           string  Deployment namespace for the Scan Templates
-    ```
-
-5. Define the `--values-file` flag to customize the default configuration:
-
-    The `values.yaml` file you created earlier is referenced with the `--values-file` flag when running your Tanzu install command:
-
-    ```console
-    tanzu package install REFERENCE-NAME \
-      --package-name SCANNER-NAME \
-      --version VERSION \
-      --namespace tap-install \
-      --values-file PATH-TO-VALUES-YAML
-    ```
-
-    Where:
-
-    - `REFERENCE-NAME` is the name referenced by the installed package. For example, `prisma-scanner`.
-    - `SCANNER-NAME` is the name of the scanner package you retrieved earlier. For example, `prisma.scanning.apps.tanzu.vmware.com`.
-    - `VERSION` is your package version number. For example, `0.1.4-alpha.1`.
-    - `PATH-TO-VALUES-YAML` is the path that points to the `values.yaml` file created earlier.
-
-    For example:
-
-    ```console
-    $ tanzu package install prisma-scanner \
-      --package-name primsa.scanning.apps.tanzu.vmware.com \
-      --version 0.1.4-alpha.1 \
-      --namespace tap-install \
-      --values-file values.yaml
-    / Installing package 'prisma.scanning.apps.tanzu.vmware.com'
-    | Getting namespace 'tap-install'
-    | Getting package metadata for 'prisma.scanning.apps.tanzu.vmware.com'
-    | Creating service account 'prisma-scanner-tap-install-sa'
-    | Creating cluster admin role 'prisma-scanner-tap-install-cluster-role'
-    | Creating cluster role binding 'prisma-scanner-tap-install-cluster-rolebinding'
-    / Creating package resource
-    - Package install status: Reconciling
-
-    Added installed package 'prisma-scanner' in namespace 'tap-install'
-    ```
-
-### Verify Installation
-
-To verify the installation create an `ImageScan` or `SourceScan` referencing one of the newly added `ScanTemplates` for the scanner.
-
-1. (Optional) Create a `ScanPolicy` formatted for the output specific to the scanner you are installing, to reference in the `ImageScan` or `SourceScan`.
-
-    ```console
-    kubectl apply -n $DEV_NAMESPACE -f SCAN-POLICY-YAML
-    ```
-
-    Where:
-
-    - `DEV-NAMESPACE` is the name of the developer namespace you want to use.
-    - `SCAN-POLICY-YAML` is the name of your SCST - Scan YAML.
-
-    > **Note** As vulnerability scanners output different formats, the `ScanPolicies` can vary. For information about policies and samples, see [Enforce compliance policy using Open Policy Agent](./policies.hbs.md).
-
-1. Retrieve available `ScanTemplates` from the namespace where the scanner is installed:
-
-    ```console
-    kubectl get scantemplates -n DEV-NAMESPACE
-    ```
-
-    Where `DEV-NAMESPACE` is the developer namespace where the scanner is installed.
-
-    For example:
-
-    ```console
-    $ kubectl get scantemplates
-    NAME                                AGE
-    prisma-blob-source-scan-template    10d
-    primsa-public-source-scan-template  10d
-    prisma-private-image-scan-template  10d
-    prisma-public-image-scan-template   10d
-    prisma-private-source-scan-template 10d
-    ```
-
-2. Create the following ImageScan YAML:
-
-    ```yaml
-    apiVersion: scanning.apps.tanzu.vmware.com/v1beta1
-    kind: ImageScan
-    metadata:
-      name: sample-prisma-public-image-scan
-    spec:
-      registry:
-        image: "nginx:1.16"
-      scanTemplate: SCAN-TEMPLATE
-      scanPolicy: SCAN-POLICY # Optional
-    ```
-
-    Where:
-
-    - `SCAN-TEMPLATE` is the name of the installed `ScanTemplate` in the `DEV-NAMESPACE` you retrieved earlier.
-    - `SCAN-POLICY` is an optional reference to an existing `ScanPolicy` in the same `DEV-NAMESPACE`.
-
-    For example:
-
-    ```yaml
-    apiVersion: scanning.apps.tanzu.vmware.com/v1beta1
-    kind: ImageScan
-    metadata:
-      name: sample-prisma-public-image-scan
-    spec:
-      registry:
-        image: "nginx:1.16"
-      scanTemplate: prisma-public-image-scan-template
-      scanPolicy: prisma-scan-policy
-    ```
-
-3. Create the following SourceScan YAML:
-
-    ```yaml
-    apiVersion: scanning.apps.tanzu.vmware.com/v1beta1
-    kind: SourceScan
-    metadata:
-      name: sample-prisma-public-source-scan
-    spec:
-      registry:
-        image: "nginx:1.16"
-      scanTemplate: SCAN-TEMPLATE
-      scanPolicy: SCAN-POLICY # Optional
-    ```
-
-    Where:
-
-    - `SCAN-TEMPLATE` is the name of the installed ScanTemplate in the `DEV-NAMESPACE` you retrieved earlier.
-    - `SCAN-POLICY` is an optional reference to an existing ScanPolicy in the same `DEV-NAMESPACE`.
-
-    For example:
-
-    ```yaml
-    apiVersion: scanning.apps.tanzu.vmware.com/v1beta1
-    kind: SourceScan
-    metadata:
-      name: sample-prisma-public-source-scan
-    spec:
-      git:
-        url: "https://github.com/houndci/hound.git"
-        revision: "5805c650"
-      scanTemplate: prisma-public-source-scan-template
-      scanPolicy: prisma-scan-policy
-    ```
-
-4. Apply the ImageScan and Source YAMLs:
-
-    To run the scans, apply them to the cluster by running these commands:
-
-    `ImageScan`:
-
-    ```console
-    kubectl apply -f PATH-TO-IMAGE-SCAN-YAML -n DEV-NAMESPACE
-    ```
-
-    Where `PATH-TO-IMAGE-SCAN-YAML` is the path to the YAML file created earlier.
-
-    `SourceScan`:
-
-    ```console
-    kubectl apply -f PATH-TO-SOURCE-SCAN-YAML -n DEV-NAMESPACE
-    ```
-
-    Where `PATH-TO-SOURCE-SCAN-YAML` is the path to the YAML file created earlier.
-
-    For example:
-
-    ```console
-    $ kubectl apply -f imagescan.yaml -n my-apps
-    imagescan.scanning.apps.tanzu.vmware.com/sample-prisma-public-image-scan created
-
-    $ kubectl apply -f sourcescan.yaml -n my-apps
-    sourcescan.scanning.apps.tanzu.vmware.com/sample-prisma-public-source-scan created
-    ```
-
-5. To verify the integration, get the scan to see if it completed by running:
-
-    For `ImageScan`:
-
-    ```console
-    kubectl get imagescan IMAGE-SCAN-NAME -n DEV-NAMESPACE
-    ```
-
-    Where `IMAGE-SCAN-NAME` is the name of the `ImageScan` as defined in the YAML file created earlier.
-
-    For `SourceScan`:
-
-    ```console
-    kubectl get sourcescan SOURCE-SCAN-NAME -n DEV-NAMESPACE
-    ```
-
-    Where `SOURCE-SCAN-NAME` is the name of the SourceScan as defined in the YAML file created earlier.
-
-    For example:
-
-    ```console
-    $ kubectl get imagescan sample-prisma-public-image-scan -n my-apps
-    NAME                            PHASE       SCANNEDIMAGE   AGE   CRITICAL   HIGH   MEDIUM   LOW   UNKNOWN   CVETOTAL
-    sample-primsa-public-image-scan   Completed   nginx:1.16     26h   0          114    58       314   0         486
-
-    $ kubectl get sourcescan sample-prisma-public-source-scan -n my-apps
-    NAME                                                                      PHASE       SCANNEDREVISION   SCANNEDREPOSITORY                      AGE     CRITICAL   HIGH   MEDIUM   LOW   UNKNOWN   CVETOTAL
-    sourcescan.scanning.apps.tanzu.vmware.com/prisma-sourcescan-sample-public   Completed   5805c650          https://github.com/houndci/hound.git   8m34s   21         121    112      9
-    ```
-
-    > **Note** If you define a `ScanPolicy` for the scans and the evaluation finds a violation, the `Phase` is `Failed` instead of `Completed`. In both cases the scan was successful.
-
-6. Clean up:
-
-    ```console
-    kubectl delete -f PATH-TO-SCAN-YAML -n DEV-NAMESPACE
-    ```
-
-    Where `PATH-TO-SCAN-YAML` is the path to the YAML file created earlier.
-
-### Configure Tanzu Application Platform Supply Chain to use new scanner
-
-In order to scan your images with the new scanner installed in the [Out of the
-Box Supply Chain with Testing and
-Scanning](../scc/ootb-supply-chain-testing-scanning.hbs.md), you must update
-your Tanzu Application Platform installation.
-
-Add the `ootb_supply_chain_testing_scanning.scanning` section to your
-`tap-values.yaml` and perform a [Tanzu Application Platform
-update](../upgrading.hbs.md#perform-the-upgrade-of-tanzu-application-platform).
-
-In this file you can define which `ScanTemplates` is used for both `SourceScan`
-and `ImageScan`. The default values are the Grype Scanner `ScanTemplates`, but
-it is overwritten by any other `ScanTemplate` present in your
-`DEV-NAMESPACE`. The same applies to the `ScanPolicies` applied to each kind of
-scan.
-
-```yaml
-ootb_supply_chain_testing_scanning:
-  scanning:
-    image:
-      template: IMAGE-SCAN-TEMPLATE
-      policy: IMAGE-SCAN-POLICY
-    source:
-      template: SOURCE-SCAN-TEMPLATE
-      policy: SOURCE-SCAN-POLICY
-```
-
-> **Note:**
-> For the Supply Chain to work properly, the `SOURCE-SCAN-TEMPLATE` must support blob files and the `IMAGE-SCAN-TEMPLATE` must support private images.
-
-For example:
-
-```yaml
-ootb_supply_chain_testing_scanning:
-  scanning:
-    image:
-      template: prisma-private-image-scan-template
-      policy: prisma-scan-policy
-    source:
-      template: prisma-blob-source-scan-template
-      policy: prisma-scan-policy
-```
-
-### Uninstall Scanner
-
-To replace the scanner in the Supply Chain, follow the steps mentioned in [Configure Tanzu Application Platform Supply Chain to Use New Scanner](#configure-tanzu-application-platform-supply-chain-to-use-new-scanner). After the scanner is no longer required by the Supply Chain, you can remove the package by running:
-
-```console
-tanzu package installed delete REFERENCE-NAME \
-    --namespace tap-install
-```
-
-Where `REFERENCE-NAME` is the name you identified the package with, when installing in the [Install](#install-another-scanner-for-supply-security-tools---scan-prisma) section. For example, `prisma-scanner`.
-
-For example:
-
-```console
-$ tanzu package installed delete prisma-scanner \
-    --namespace tap-install
-```
+## Known Limitations
+* AWS ECR is not supported
+* OpenShift is not supported


### PR DESCRIPTION

Made the following changes
* adjust prisma imgpkg copy command to the correct url
* adjust prisma scanner version to latest alpha, 0.1.4-alpha.3
* remove install instructions and replace with a pointer to the general install another scanner doc

Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

1-4-0, 1-4-1

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
