### PR TITLE
Update prerequisites

### DIFF
--- a/prerequisites.hbs.md
+++ b/prerequisites.hbs.md
@@ -86,8 +86,8 @@ providers:
 - Azure Kubernetes Service.
 - Amazon Elastic Kubernetes Service.
     - containerd must be used as the Container Runtime Interface (CRI). Some versions of EKS default to Docker as the container runtime and must be changed to containerd.
-    - EKS clusters on Kubernetes version 1.23 require the [Amazon EBS CSI Driver](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) due to the [CSIMigrationAWS](https://aws.amazon.com/blogs/containers/amazon-eks-now-supports-kubernetes-1-23/) is enabled by default in Kubernetes 1.23.
-        - Users currently on EKS Kubernetes version 1.22 must install the Amazon EBS CSI Driver before upgrading to Kubernetes version 1.23. See [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi-migration-faq.html) for more information.
+    - EKS clusters on Kubernetes version 1.23+ require the [Amazon EBS CSI Driver](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) due to the [CSIMigrationAWS](https://aws.amazon.com/blogs/containers/amazon-eks-now-supports-kubernetes-1-23/) is enabled by default in these versions of Kubernetes.
+        - Users currently on EKS Kubernetes version 1.22 must install the Amazon EBS CSI Driver before upgrading to Kubernetes version 1.23+. See [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi-migration-faq.html) for more information.
 - Google Kubernetes Engine.
     - GKE Autopilot clusters do not have the required features enabled.
     - GKE clusters that are set up in zonal mode might detect Kubernetes API errors when the GKE


### PR DESCRIPTION
We have discovered that this is also a problem in K8s version 1.24. Updating the documentation to reflect this. cc: @mgibson1121

Which other branches do you want a technical writer to cherry-pick this PR to (if any)? Would be great to be backported to 1.3 and 1.4.


It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
