### PR TITLE
Revise relevant `tanzu apps workload create` examples to not use the tanzu-java-web-app repository

### DIFF
--- a/getting-started/add-test-and-security.hbs.md
+++ b/getting-started/add-test-and-security.hbs.md
@@ -114,16 +114,18 @@ the workload must be updated to point at your Tekton pipeline.
 
 1. Update the workload by running the following with the Tanzu CLI:
 
-    ```console
+    ```bash
     tanzu apps workload create tanzu-java-web-app \
-      --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
-      --sub-path tanzu-java-web-app \
-      --git-branch main \
+      --git-repo ${GIT_PROJECT_URL} \
+      --git-branch ${GIT_BRANCH} \
       --type web \
       --label apps.tanzu.vmware.com/has-tests=true \
       --label app.kubernetes.io/part-of=tanzu-java-web-app \
-      --yes
+      --yes \
+      --namespace ${DEVELOPER_NAMESPACE}
     ```
+
+    Example output:
 
     ```console
     Create workload:
@@ -141,8 +143,7 @@ the workload must be updated to point at your Tekton pipeline.
        12 + |    git:
        13 + |      ref:
        14 + |        branch: main
-       15 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
-       16 + |    subPath: tanzu-java-web-app
+       15 + |      url: https://github.com/my/tanzu-project.git
 
     ? Do you want to create this workload? Yes
     Created workload "tanzu-java-web-app"
@@ -296,37 +297,36 @@ pipeline:
 
 1. Update the workload by running the following using the Tanzu CLI:
 
-    ```console
+    ```bash
     tanzu apps workload create tanzu-java-web-app \
-      --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
-      --sub-path tanzu-java-web-app \
-      --git-branch main \
+      --git-repo ${GIT_PROJECT_URL} \
+      --git-branch ${GIT_BRANCH} \
       --type web \
       --label apps.tanzu.vmware.com/has-tests=true \
       --label app.kubernetes.io/part-of=tanzu-java-web-app \
-      --yes
+      --yes \
+      --namespace ${DEVELOPER_NAMESPACE}
     ```
 
     Example output:
 
-    ```console
+    ```console 
     Create workload:
-          1 + |---
-          2 + |apiVersion: carto.run/v1alpha1
-          3 + |kind: Workload
-          4 + |metadata:
-          5 + |  labels:
-          6 + |    apps.tanzu.vmware.com/has-tests: "true"
-          7 + |    apps.tanzu.vmware.com/workload-type: web
-          8 + |  name: tanzu-java-web-app
-          9 + |  namespace: default
-        10 + |spec:
-        11 + |  source:
-        12 + |    git:
-        13 + |      ref:
-        14 + |        branch: main
-        15 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
-        16 + |    subPath: tanzu-java-web-app
+      1 + |---
+      2 + |apiVersion: carto.run/v1alpha1
+      3 + |kind: Workload
+      4 + |metadata:
+      5 + |  labels:
+      6 + |    apps.tanzu.vmware.com/has-tests: "true"
+      7 + |    apps.tanzu.vmware.com/workload-type: web
+      8 + |  name: tanzu-java-web-app
+      9 + |  namespace: default
+      10 + |spec:
+      11 + |  source:
+      12 + |    git:
+      13 + |      ref:
+      14 + |        branch: main
+      15 + |      url: https://github.com/my/tanzu-project.git
 
     ? Do you want to create this workload? Yes
     Created workload "tanzu-java-web-app"

--- a/getting-started/deploy-first-app.hbs.md
+++ b/getting-started/deploy-first-app.hbs.md
@@ -50,46 +50,34 @@ In this example, you use the `Tanzu-Java-Web-App` accelerator. You also use Tanz
 
 7. After downloading the ZIP file, expand it in a workspace directory. If you did not create a Git repository in the preceding steps, follow your preferred procedure for uploading the generated project files to a Git repository for your new project.
 
-## <a id="deploy-your-app"></a>Deploy your application through Tanzu Application Platform GUI
+## <a id="deploy-your-app"></a>Deploy your application through Tanzu Application Platform GUI 
 
 1. Set up environment variables by running:
 
-    ```console
-    export GIT_URL_TO_REPO=GIT-URL-TO-PROJECT-REPO
-    export YOUR_NAMESPACE=YOUR-DEVELOPER-NAMESPACE
+    ```bash
+    export GIT_PROJECT_URL=GIT-URL-TO-PROJECT-REPO
+    export GIT_BRANCH=GIT-PROJECT-BRANCH
+    export DEVELOPER_NAMESPACE=YOUR-DEVELOPER-NAMESPACE
     ```
 
     Where:
 
-    - `GIT-URL-TO-PROJECT-REPO` is the path you uploaded to earlier.
+    - `GIT-URL-TO-PROJECT-REPO` is the git URL of the repository you uploaded your source code to earlier. e.g. `https://github.com/my-org/repository.git`
+    - `GIT-PROJECT-BRANCH` is the git branch of the project. e.g. `main`
     - `YOUR-DEVELOPER-NAMESPACE` is the namespace configured earlier.
 
 2. Deploy the Tanzu Java Web App accelerator by running the `tanzu apps workload create` command:
 
-    ```console
+    ```bash
     tanzu apps workload create tanzu-java-web-app \
-    --git-repo ${GIT_URL_TO_REPO} \
-    --git-branch main \
-    --type web \
-    --label app.kubernetes.io/part-of=tanzu-java-web-app \
-    --yes \
-    --namespace ${YOUR_NAMESPACE}
+        --git-repo ${GIT_PROJECT_URL} \
+        --git-branch ${GIT_BRANCH} \
+        --type web \
+        --label apps.tanzu.vmware.com/has-tests=true \
+        --label app.kubernetes.io/part-of=tanzu-java-web-app \
+        --yes \
+        --namespace ${DEVELOPER_NAMESPACE}
     ```
-
-    If you bypassed step 5 or were unable to upload your accelerator to a Git repository, use the following public version to test:
-
-    ```console
-    tanzu apps workload create tanzu-java-web-app \
-    --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
-    --sub-path tanzu-java-web-app \
-    --git-branch main \
-    --type web \
-    --label app.kubernetes.io/part-of=tanzu-java-web-app \
-    --yes \
-    --namespace YOUR-DEVELOPER-NAMESPACE
-    ```
-
-    Where `YOUR-DEVELOPER-NAMESPACE` is the namespace configured earlier.
 
     For more information, see [Tanzu Apps Workload Apply](../cli-plugins/apps/command-reference/workload_create_update_apply.hbs.md).
 
@@ -98,7 +86,7 @@ In this example, you use the `Tanzu-Java-Web-App` accelerator. You also use Tanz
 
 3. View the build and runtime logs for your app by running the `tail` command:
 
-    ```console
+    ```bash
     tanzu apps workload tail tanzu-java-web-app --since 10m --timestamp --namespace YOUR-DEVELOPER-NAMESPACE
     ```
 
@@ -106,7 +94,7 @@ In this example, you use the `Tanzu-Java-Web-App` accelerator. You also use Tanz
 
 4. After the workload is built and running, you can view the web app in your browser. View the URL of the web app by running the following command and then press **ctrl-click** on the Workload Knative Services URL at the bottom of the command output.
 
-    ```console
+    ```bash
     tanzu apps workload get tanzu-java-web-app --namespace YOUR-DEVELOPER-NAMESPACE
     ```
 

--- a/multicluster/getting-started.hbs.md
+++ b/multicluster/getting-started.hbs.md
@@ -17,11 +17,15 @@ Before implementing a multicluster topology, complete the following:
 1. To set the value of `DEVELOPER_NAMESPACE` to the namespace you setup in the previous step, run:
 
     ```bash
+    export GIT_PROJECT_URL=GIT-URL-TO-PROJECT-REPO
+    export GIT_BRANCH=GIT-PROJECT-BRANCH
     export DEVELOPER_NAMESPACE=YOUR-DEVELOPER-NAMESPACE
     ```
 
     Where:
 
+    - `GIT-URL-TO-PROJECT-REPO` is the git URL of the repository you uploaded your source code to. e.g. `https://github.com/my-org/repository.git`
+    - `GIT-PROJECT-BRANCH` is the git branch of the project. e.g. `main`
     - `YOUR-DEVELOPER-NAMESPACE` is the namespace you set up in [Set up developer namespaces to use installed packages](../set-up-namespaces.md). `default` is used in this example.
 
 
@@ -33,7 +37,8 @@ The Build cluster starts by building the necessary bundle for the workload that 
 
     ```bash
     tanzu apps workload create tanzu-java-web-app \
-    --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
+    --git-repo ${GIT_PROJECT_URL} \
+    --git-branch ${GIT_BRANCH} \
     --sub-path tanzu-java-web-app \
     --git-branch main \
     --type web \

--- a/scc/building-from-source.hbs.md
+++ b/scc/building-from-source.hbs.md
@@ -42,12 +42,12 @@ and the subdirectory `tanzu-java-web-app` run:
   tanzu apps workload create tanzu-java-web-app \
     --app tanzu-java-web-app \
     --type web \
-    --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
+    --git-repo ${GIT_PROJECT_URL} \
     --sub-path tanzu-java-web-app \
-    --git-branch main
+    --git-branch ${GIT_BRANCH}
   ```
 
-Expect to see the following output:
+Expect to see similar output:
 
   ```console
   Create workload:
@@ -65,8 +65,7 @@ Expect to see the following output:
       12 + |    git:
       13 + |      ref:
       14 + |        branch: main
-      15 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
-      16 + |    subPath: tanzu-java-web-app
+      15 + |      url: https://github.com/my/tanzu-project.git
   ```
 
 >**Note** The Git repository URL must include the scheme: `http://`,
@@ -118,13 +117,12 @@ is installed. You can use the `--param` flag in Tanzu CLI. For example:
   tanzu apps workload create tanzu-java-web-app \
     --app tanzu-java-web-app \
     --type web \
-    --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
-    --sub-path tanzu-java-web-app \
-    --git-branch main \
+    --git-repo ${GIT_PROJECT_URL} \
+    --git-branch ${GIT_BRANCH} \
     --param gitops_ssh_secret=SECRET-NAME
   ```
 
-Expect to see the following output:
+Expect to see similar output:
 
   ```console
   Create workload:
@@ -145,8 +143,7 @@ Expect to see the following output:
       15 + |    git:
       16 + |      ref:
       17 + |        branch: main
-      18 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
-      19 + |    subPath: tanzu-java-web-app
+      18 + |      url: https://github.com/my/tanzu-project.git
   ```
 
 >**Note** A secret reference is only provided to `GitRepository` if

--- a/scc/gitops-vs-regops.hbs.md
+++ b/scc/gitops-vs-regops.hbs.md
@@ -197,9 +197,8 @@ to the workload:
   tanzu apps workload create tanzu-java-web-app \
     --app tanzu-java-web-app \
     --type web \
-    --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
-    --sub-path tanzu-java-web-app \
-    --git-branch main \
+    --git-repo ${GIT_PROJECT_URL} \
+    --git-branch ${GIT_BRANCH} \
     --param gitops_ssh_secret=GIT-SECRET-NAME \
     --param gitops_repository=https://github.com/my-org/config-repo
   ```
@@ -482,9 +481,8 @@ create a workload as follows:
 
   ```console
   tanzu apps workload create tanzu-java-web-app \
-    --git-branch main \
-    --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
-    --sub-path tanzu-java-web-app \
+    --git-repo ${GIT_PROJECT_URL} \
+    --git-branch ${GIT_BRANCH} \
     --label app.kubernetes.io/part-of=tanzu-java-web-app \
     --type web
   ```
@@ -507,8 +505,7 @@ Expect to see the following output:
       12 + |    git:
       13 + |      ref:
       14 + |        branch: main
-      15 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
-      16 + |    subPath: tanzu-java-web-app
+      15 + |      url: https://github.com/my/tanzu-project.git
   ```
 
 As a result, the Kubernetes configuration is pushed to

--- a/scc/ootb-supply-chain-testing-scanning.hbs.md
+++ b/scc/ootb-supply-chain-testing-scanning.hbs.md
@@ -329,15 +329,16 @@ Basic, except that you mark the workload as having tests enabled.
 
 For example:
 
-```console
+```bash
 tanzu apps workload create tanzu-java-web-app \
-  --git-branch main \
-  --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
-  --sub-path tanzu-java-web-app \
+  --git-repo ${GIT_PROJECT_URL} \
+  --git-branch ${GIT_BRANCH} \
   --label apps.tanzu.vmware.com/has-tests=true \
   --label app.kubernetes.io/part-of=tanzu-java-web-app \
   --type web
 ```
+
+Expect to see output similar to the following:
 
 ```console
 Create workload:
@@ -356,8 +357,7 @@ Create workload:
      13 + |    git:
      14 + |      ref:
      15 + |        branch: main
-     16 + |      url: https://github.com/vmware-tanzu/application-accelerator-samples
-     17 + |    subPath: tanzu-java-web-app
+     16 + |      url: https://github.com/my/tanzu-project.git
 ```
 
 ## <a id="cve-triage-workflow"></a> CVE triage workflow

--- a/scc/ootb-supply-chain-testing.hbs.md
+++ b/scc/ootb-supply-chain-testing.hbs.md
@@ -259,9 +259,8 @@ For example:
 
 ```console
 tanzu apps workload create tanzu-java-web-app \
-  --git-branch main \
-  --git-repo https://github.com/vmware-tanzu/application-accelerator-samples \
-  --sub-path tanzu-java-web-app \
+  --git-repo ${GIT_PROJECT_URL} \
+  --git-branch ${GIT_BRANCH} \
   --label apps.tanzu.vmware.com/has-tests=true \
   --label app.kubernetes.io/part-of=tanzu-java-web-app \
   --type web


### PR DESCRIPTION
Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

1.4.0+

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
