### PR TITLE
remove "overview" from H1/Title

### DIFF
--- a/namespace-provisioner/about.hbs.md
+++ b/namespace-provisioner/about.hbs.md
@@ -1,4 +1,4 @@
-# Namespace Provisioner overview
+# Namespace Provisioner
 
 Namespace Provisioner provides a secure, automated way for platform operators to provision
 namespaces with the resources and proper namespace-level privileges required for their workloads


### PR DESCRIPTION
The reference guide, instead of this page, was coming up in rank order 1 of search results for "Namespace Provisioner" because this page included "overview" in the title. This should fix that.

Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

TAP 1.4+
