### PR TITLE
prisma scanner updates

### DIFF
--- a/toc.md
+++ b/toc.md
@@ -418,7 +418,7 @@ docs.vmware.com is built.
         - [Install another Scanner](scst-scan/install-scanners.hbs.md)
             - [Prerequisites for Snyk Scanner (Beta)](scst-scan/install-snyk-integration.hbs.md)
             - [Prerequisites for Carbon Black Scanner (Beta)](scst-scan/install-carbonblack-integration.hbs.md)
-            - [Install Prisma Scanner](scst-scan/install-prisma-integration.hbs.md)
+            - [Prerequisites for Prisma Scanner (Alpha)](scst-scan/install-prisma-integration.hbs.md)
         - [Spec reference](scst-scan/explanation.hbs.md)
         - [Scan samples](scst-scan/samples/overview.hbs.md)
             - [Overview](scst-scan/samples/overview.hbs.md)


### PR DESCRIPTION
* added instructions for finding the latest version
* added scan policy example utilizing scan passed fields from output
* updated limitations to remove ECR is no longer supported (supported in latest alpha)
* corrected docker login sample with correct registry
* added example prisma values using access keys
* updated TOC with name to align with other scanners and page title

Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
1-4-0, 1-4-1

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
