### PR TITLE
Adding the new policyEngine setting on Learning Center docs

### DIFF
--- a/learning-center/getting-started/learning-center-operator.hbs.md
+++ b/learning-center/getting-started/learning-center-operator.hbs.md
@@ -42,6 +42,14 @@ deploying workloads to the cluster. The default policy prohibits running of imag
 a privileged pod. Specified workshops can relax these restrictions and apply a policy that enables additional
 privileges required by the workshop.
 
+In order to enforce some sort of security policy around what a user can do, different mechanisms have been provided over time with standard Kubernetes distributions and derivatives such as OpenShift. These are:
+
+    Pod security policies (Kubernetes <= 1.25)
+    Pod security standards (Kubernetes >= 1.22)
+    Security context constraints (OpenShift)
+
+For pod security policies and pod security standards, these both need to be enabled in the Kubernetes cluster at the time the cluster is created, it is not something that can be enabled afterwards. For some Kubernetes distributions, such as Tanzu Community Edition (TCE), it is not possible to enable pod security policies, and pod security standards being new, may also not be supported.
+
 VMware recommends that the pod security policy admission controller be enabled for the cluster to ensure
 that the pod security policies are applied. If the admission controller is not enabled, users can
 deploy workloads that run as the `root` user in a container, or run privileged pods.

--- a/learning-center/install-learning-center.hbs.md
+++ b/learning-center/install-learning-center.hbs.md
@@ -225,6 +225,17 @@ network:
   blockCIDRs:
   - 169.254.169.254/32
   - fd00:ec2::254/128
+
+#! clusterSecurity and policyEngine settings are used to change the security policy engine used by Learning Center. Possible values are:  
+#! "pod-security-policies" - kubernetes <= 1.24
+#! "pod-security-standards" - kubernetes >= 1.22
+#! "security-context-constraints" - Openshift <= 4.10
+#! "security-context-constraints-v2" - Openshift >= 4.11
+#! "none" - Disable security - Not recommended 
+
+clusterSecurity:
+  policyEngine: "pod-security-policies"  #! default value
+
 ```
 
 See [Restricting Network Access](./runtime-environment/system-profile.md#restrict-network-access) for more information on blocking CIDRs.


### PR DESCRIPTION
Which other branches do you want a technical writer to cherry-pick this PR to (if any)? 1-4-0


It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
