### PR TITLE
rm troubleshooting (only applies to <= TAP 1.0)

### DIFF
--- a/cli-plugins/apps/tutorials.hbs.md
+++ b/cli-plugins/apps/tutorials.hbs.md
@@ -24,23 +24,6 @@ Before you install the Apps CLI plug-in:
 
     A version displays in the output.
 
-    If the following error is displayed during installation:
-
-    ```console
-    Error: could not find plug-in "apps" in any known repositories
-
-    ✖  could not find plug-in "apps" in any known repositories
-    ```
-
-    Verify that there is an `apps` entry in the `cli/manifest.yaml` file. For example:
-
-    ```yaml
-    plugins:
-    ...
-        - name: apps
-        description: Applications on Kubernetes
-        versions: []
-    ```
 
 ## <a id='from-release'></a>Install From Release
 


### PR DESCRIPTION
Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
## This should be cherry picked to docs for TAP 1.1+


This troubleshooting step only applies to TAP v1.0 and earlier (there is no `cli/manifest.yaml` at all in the CLI binaries downloadable from TAP 1.1+).
