### PR TITLE
Mention upgrade to cert-manager 1.11.0 in the release notes

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -10,6 +10,10 @@ This topic contains release notes for Tanzu Application Platform v1.5.
 
 ### <a id='1-5-0-new-component-features'></a> New features by component and area
 
+### <a id='1-5-0-cert-manager-ncf'></a> cert-manager
+
+- `cert-manager.tanzu.vmware.com` has upgraded to [cert-manager `v1.11.0`](https://github.com/cert-manager/cert-manager/releases/tag/v1.11.0)
+
 ### <a id='1-5-0-breaking-changes'></a> Breaking changes
 
 This release has the following breaking changes, listed by area and component.


### PR DESCRIPTION
Targeted for TAP `1.5.x`

---
Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
 * None

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
 * Ack
