### PR TITLE
remove convention controller references

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Use this table to keep a running list of terms used and how they should be defin
 | API Auto Registration | Both __Auto__ and __Registration__ are separated from each other, and capitalized |
 | API portal | The p _is_ supposed to be lowercase. [Pull request #73](https://github.com/pivotal/docs-tap/pull/73#issue-1011334602).|
 | components | The individual products available in the TAP SKU. For example, Cloud Native Runtimes is a component of TAP. Not: add-ons or capabilities.|
+| convention controller | Lowercase; this is one of the minor components that make up Convention Service |
 | convention server | Lowercase; this is one of the minor components that make up Convention Service |
 | Convention Service | Title case; this is a component with its own TanzuNet product page |
 | Default Supply Chain | singular |

--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ Use this table to keep a running list of terms used and how they should be defin
 | API Auto Registration | Both __Auto__ and __Registration__ are separated from each other, and capitalized |
 | API portal | The p _is_ supposed to be lowercase. [Pull request #73](https://github.com/pivotal/docs-tap/pull/73#issue-1011334602).|
 | components | The individual products available in the TAP SKU. For example, Cloud Native Runtimes is a component of TAP. Not: add-ons or capabilities.|
-| convention controller | Lowercase; this is one of the minor components that make up Convention Service |
 | convention server | Lowercase; this is one of the minor components that make up Convention Service |
 | Convention Service | Title case; this is a component with its own TanzuNet product page |
 | Default Supply Chain | singular |

--- a/about-package-profiles.hbs.md
+++ b/about-package-profiles.hbs.md
@@ -420,20 +420,6 @@ The following table lists the packages contained in each profile:
    </td>
   </tr>
   <tr>
-   <td>Convention controller
-    </td>
-   <td>&check;
-   </td>
-   <td>&check;
-   </td>
-   <td>&check;
-   </td>
-   <td>
-   </td>
-   <td>
-   </td>
-  </tr>
-  <tr>
    <td>Default Roles
    </td>
    <td>&check;

--- a/cartographer-conventions/about.hbs.md
+++ b/cartographer-conventions/about.hbs.md
@@ -2,23 +2,22 @@
 
 ## <a id="overview"></a> Overview
 
->**Note** This component is replacing the [convention controller](../convention-service/about.md).
-
 Cartographer Conventions provides a means for operators to express
-their knowledge about how applications should run on Kubernetes as a convention.
-Cartographer Conventions applies these opinions to fleets of developer workloads as they are deployed to the platform,
-saving operator and developer time.
+their knowledge about how applications should run on Kubernetes as a convention. 
+Cartographer Conventions currently supports defining and applying conventions to Pods.
+It applies these opinions to fleets of developer workloads as they are 
+deployed to the platform, saving operator and developer time.
 
-The service is composed of two components:
+The service is composed of two components
 
-* **The convention controller:**
-  The convention controller provides the metadata to the convention server and executes the updates to Pod Template Spec as per the convention server's requests.
+* **convention controller:**
+  The convention service's convention controller provides the metadata to the convention server and executes 
+  the updates to a [PodTemplateSpec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-template-v1/#PodTemplateSpec) as per the convention server's requests.
 
-* **The convention server:**
+* **convention server:**
   The convention server receives and evaluates metadata associated with a workload and
-  requests updates to the Pod Template Spec associated with that workload.
-  You can have one or more convention servers for a single convention controller instance.
-  Cartographer Conventions supports defining and applying conventions for Pods.
+  requests updates to the [PodTemplateSpec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-template-v1/#PodTemplateSpec) associated with that workload.
+  You can have one or more convention servers for a single controller instance.
 
 ## <a id="about-apply-conventions"></a> About applying conventions
 
@@ -37,8 +36,11 @@ Conventions can use this information to only apply changes to the configuration 
 when they match specific criteria. Such as, Spring Boot or .Net apps, or Spring Boot v2.3+.
 Targeted conventions can ensure uniformity across specific workload types deployed on the cluster.
 
-You can use all the metadata details of an image when evaluating workloads. To see the metadata details, use the Docker CLI command `docker image inspect IMAGE`.
-
+You can use all the metadata details of an image when evaluating workloads.
+To see the metadata details, use the Docker CLI command
+```bash 
+ docker image inspect IMAGE`.
+```
 >**Note** Depending on how the image was built, metadata might not be available to reliably identify
 the image type and match the criteria for a convention server.
 Images built with Cloud Native Buildpacks reliably include rich descriptive metadata.
@@ -47,9 +49,12 @@ Images built by some other process can not include the same metadata.
 ### <a id="apply-wo-image-metadata"></a> Applying conventions without using image metadata
 
 Conventions can be defined to apply to workloads without targeting build service metadata.
-Examples of possible uses of this type of convention include appending a logging or metrics sidecar,
-adding environment variables, or adding cached volumes.
-Such conventions are a great way to ensure infrastructure uniformity
+Examples of possible uses of this type of convention include 
+  - appending a logging or metrics sidecar,
+  - adding environment variables, or 
+  - adding cached volumes.
+  
+These kinds of conventions are a great way to ensure infrastructure uniformity
 across workloads deployed on the cluster while reducing developer toil.
 
 >**Important** Adding a sidecar alone does not make the log or metrics collection work.

--- a/cartographer-conventions/creating-conventions.hbs.md
+++ b/cartographer-conventions/creating-conventions.hbs.md
@@ -73,44 +73,42 @@ the conventions are organized, grouped, and deployed is up to you and the needs 
 your organization.
 
 Convention servers deployed to the cluster does not take action unless triggered to
-do so by the second component of Cartographer Conventions, the [Convention controller](#convention-controller).
+do so by the second component of Cartographer Conventions, the [Convention service's controller](#convention-controller).
 
 ### <a id='convention-controller'></a>Convention controller
 
 The convention controller is the orchestrator of one or many convention servers deployed to the cluster. There are resources available on the `conventions.carto.run/v1aplha1` API that allow the controller to carry out its functions. These resources include:
 
   -  [ClusterPodConvention](./reference/cluster-pod-convention.hbs.md)
-      - `ClusterPodConvention` is a  resource type that allows the conventions author to register a webhook server with the controller using it's `spec.webhook` field.
+    `ClusterPodConvention` is a  resource type that allows the conventions author to register a webhook server with the controller using its `spec.webhook` field.
 
-          ```yaml
-          ...
-          spec:
-            selectorTarget: PodTemplateSpec # optional field with options, defaults to PodTemplateSpec
-            selectors: # optional, defaults to match all workloads
-            - <metav1.LabelSelector>
-            webhook:
-              certificate:
-                name: sample-cert
-                namespace: sample-conventions
-              clientConfig:
-                <admissionregistrationv1.WebhookClientConfig>
-          ```
+      ```yaml
+      ...
+      spec:
+        selectorTarget: PodTemplateSpec # optional field with options, defaults to PodTemplateSpec
+        selectors: # optional, defaults to match all workloads
+        - <metav1.LabelSelector>
+        webhook:
+          certificate:
+            name: sample-cert
+            namespace: sample-conventions
+          clientConfig:
+            <admissionregistrationv1.WebhookClientConfig>
+      ```
 
   - [PodIntent](./reference/pod-intent.hbs.md)
 
-    - The `PodIntent` is a `conventions.carto.run/v1alpha1` resource type that
+    `PodIntent` is a `conventions.carto.run/v1alpha1` resource type that
       is continuously reconciled and applies decorations to a workload
       `PodTemplateSpec` exposing the enriched `PodTemplateSpec` on its status.
       Whenever the status of the `PodIntent` is updated, no side effects are
       caused on the cluster.
 
-  As key types defined on the `conventions.carto.run` API, the
-  `ClusterPodConvention` and `PodIntent` resources are both present on the
+  As key types defined on the `conventions.carto.run` API, the ClusterPodConvention` and `PodIntent` resources are both present on the
   Kubernetes API Server and are queried using
-  `clusterpodconventions.conventions.carto.run` for the former and
-  `podintents.conventions.carto.run` for the later.
+  `clusterpodconventions.conventions.carto.run` for the former and `podintents.conventions.carto.run` for the later.
 
-#### <a id='role-of-the-controller'></a>How the convention controller works
+#### <a id='role-of-the-controller'></a>How the convention services's controller works
 
 When the Supply Chain Choreographer creates or updates a PodIntent for a workload, the convention
 controller retrieves the OCI image metadata from the repository
@@ -352,7 +350,8 @@ spec:
       <admissionregistrationv1.WebhookClientConfig>
 ```
 
-If you do not provide a value for this optional field while using the `conventions.carto.run/v1alpha1` API, the default value is set to `PodTemplateSpec` without the conventions author explicitly doing so. The `selectorTarget` field is not available in the `conventions.apps.tanzu.vmware.com/v1alpha1` API and labels specified in the `PodTemplateSpec` are considered if a matcher is defined in a `ClusterPodConvention` while referencing this deprecated API.
+If you do not provide a value for this optional field while using the `conventions.carto.run/v1alpha1` API,
+the default value is set to `PodTemplateSpec` without the conventions author explicitly doing so. 
 
 ### <a id='match-criteria-env-var'></a> Matching criteria by environment variables
 

--- a/cartographer-conventions/reference/cluster-pod-convention.hbs.md
+++ b/cartographer-conventions/reference/cluster-pod-convention.hbs.md
@@ -1,6 +1,6 @@
 # ClusterPodConvention
 
-`ClusterPodConvention` defines a way to connect to convention servers. It provides a way to apply a set of conventions to a `PodTemplateSpec` and the artifact metadata. A convention will typically focus on a particular application framework, but may be cross cutting. Applied conventions must be pure functions.
+A`ClusterPodConvention` defines how to connect to convention servers. It provides a way to apply a set of conventions to a [PodTemplateSpec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-template-v1/#PodTemplateSpec) and artifact metadata. A convention will typically focus on a particular application framework, but may be cross cutting. Applied conventions must be pure functions.
 
 Webhook servers are currently the only way to define conventions.
 

--- a/cartographer-conventions/reference/convention-resources.hbs.md
+++ b/cartographer-conventions/reference/convention-resources.hbs.md
@@ -4,8 +4,8 @@ There are several resources involved in the application of conventions to worklo
 typically consumed by platform developers and operators rather than by application developers. 
 The resources include the following 
 
-+ [ClusterPodConvention](cluster-pod-convention.md) - 
-  This is a `clusterpodconventions.conventions.carto.run` type resource. See example below.
++ [ClusterPodConvention](cluster-pod-convention.md) 
+  This is a `clusterpodconventions.conventions.carto.run` type resource. See an example below.
   
   ```yaml
     ---
@@ -25,15 +25,14 @@ The resources include the following
         <admissionregistrationv1.WebhookClientConfig>
   ```
  
-  A platform developer can have a single ClusterPodConvention target a single or multiple workloads 
+  A single `ClusterPodConvention` can target a single or multiple workloads 
   or even have multiple conventions being applied to a different types of workloads. 
-  The choice around how to apply conventions is solely at the discretion of the Conventions Author. 
-
+  The choice around how to apply conventions is solely at the discretion of the `Conventions Author`. 
 
 
 + [PodIntent](pod-intent.md) 
 
-  This is a `podintents.conventions.carto.run` type resource. See example below.
+  This is a `podintents.conventions.carto.run` type resource. See an example below.
   ```yaml
   apiVersion: conventions.carto.run/v1alpha1
   kind: PodIntent
@@ -63,35 +62,45 @@ The resources include the following
   to indicate whether it is applied successfully.
   A list of all applied conventions is stored under the annotation `conventions.carto.run/applied-conventions`.
 
+There are also a few other reources within the inner workings of the convention services's `controller`
+and these include the following 
++ [ImageConfig](image-config.md)
++ [PodConventionContextSpec](pod-convention-context-spec.md)
++ [PodConventionContextStatus](pod-convention-context-status.md)
++ [PodConventionContext](pod-convention-context.md)
++ [BOM](bom.md)
+
 ## <a id="collect-logs-from-ctrlr"></a>Collecting Logs from the Controller
 
-  The convention controller is a Kubernetes operator and can be deployed in a cluster with other 
-  components. If you have trouble, you can retrieve and examine the logs from the controller to help identify issues.
+  A successful deployment of the convention service will create it's resources on the `cartographer-system`namespace as shown below 
+  ```bash 
+  ❯ kubectl get all -n cartographer-system
+    NAME                                                               READY   STATUS    RESTARTS   AGE
+    ...
+    pod/cartographer-conventions-controller-manager-76fd86789f-lzh86   1/1     Running   0          20h
 
-  To retrieve Pod logs from the `cartographer-conventions-controller-manage` running in the `cartographer-system` namespace:
+    NAME                                                                  TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
+    ...
+    service/cartographer-conventions-controller-manager-metrics-service   ClusterIP   10.0.250.231   <none>        8443/TCP   20h
+    service/cartographer-conventions-webhook-service                      ClusterIP   10.0.6.254     <none>        443/TCP    20h
+    ...
+
+    NAME                                                          READY   UP-TO-DATE   AVAILABLE   AGE
+    ...
+    deployment.apps/cartographer-conventions-controller-manager   1/1     1            1           20h
+
+    NAME                                                                     DESIRED   CURRENT   READY   AGE
+    ...
+    replicaset.apps/cartographer-conventions-controller-manager-76fd86789f   1         1         1       20h
+  ```
+  In order to examine logs from the cartographer conventions controller to help identify issues, try 
+  inspecting the cartographer conventions controller manager pod as follows  
 
   ```bash
    kubectl -n cartographer-system logs -l control-plane=controller-manager
-  ```
-
-For example:
-
-  ```bash
   ...
   {"level":"info","ts":"2023-02-06T20:49:19.855086032Z","logger":"MetricsReconciler","msg":"reconciling builders configmap","controller":"configmap","controllerGroup":"","controllerKind":"ConfigMap","ConfigMap":{"name":"controller-manager-metrics-data","namespace":"cartographer-system"},"namespace":"cartographer-system","name":"controller-manager-metrics-data","reconcileID":"6f5e38c7-0ce0-4c74-aff3-f938fb742dab","diff":"  map[string]string{\n- \t\"clusterpodconventions_names\": \"appliveview-sample\",\n+ \t\"clusterpodconventions_names\": \"appliveview-sample\\nspring-boot-convention\",\n  \t\"podintents_count\":            \"0\",\n  }\n"}
   {"level":"info","ts":"2023-02-06T20:49:20.101742252Z","logger":"MetricsReconciler","msg":"reconciling builders configmap","controller":"configmap","controllerGroup":"","controllerKind":"ConfigMap","ConfigMap":{"name":"controller-manager-metrics-data","namespace":"cartographer-system"},"namespace":"cartographer-system","name":"controller-manager-metrics-data","reconcileID":"3a1950bc-4c55-47bb-8380-2de574bd5d5e","diff":"  map[string]string{\n  \t\"clusterpodconventions_names\": strings.Join({\n  \t\t\"appliveview-sample\\n\",\n+ \t\t\"developer-conventions\\n\",\n  \t\t\"spring-boot-convention\",\n  \t}, \"\"),\n  \t\"podintents_count\": \"0\",\n  }\n"}
   ...
   ```
 
-
-****
-
-## <a id="references"></a> References
-
-+ [ImageConfig](image-config.md)
-+ [PodConventionContextSpec](pod-convention-context-spec.md)
-+ [PodConventionContextStatus](pod-convention-context-status.md)
-+ [PodConventionContext](pod-convention-context.md)
-+ [ClusterPodConvention](cluster-pod-convention.md)
-+ [PodIntent](pod-intent.md)
-+ [BOM](bom.md)

--- a/cartographer-conventions/reference/convention-resources.hbs.md
+++ b/cartographer-conventions/reference/convention-resources.hbs.md
@@ -1,14 +1,15 @@
 ## <a id="conv-service-resources"></a>Convention Service Resources
 
 There are several resources involved in the application of conventions to workloads and these 
-typically consumed by platform developers and operators rather than by application developers. 
-The resources include the following 
+are typically consumed by platform developers and operators rather than by application developers. 
+
+
 
 + [ClusterPodConvention](cluster-pod-convention.md) 
-  This is a `clusterpodconventions.conventions.carto.run` type resource. See an example below.
-  
+  This is a `conventions.carto.run/v1alpha1` type. An example is  provided below
+
   ```yaml
-    ---
+  ---
   apiVersion: conventions.carto.run/v1alpha1
   kind: ClusterPodConvention
   metadata:
@@ -23,16 +24,27 @@ The resources include the following
         namespace: sample-conventions
       clientConfig: 
         <admissionregistrationv1.WebhookClientConfig>
-  ```
- 
-  A single `ClusterPodConvention` can target a single or multiple workloads 
-  or even have multiple conventions being applied to a different types of workloads. 
-  The choice around how to apply conventions is solely at the discretion of the `Conventions Author`. 
+    ```
+  A `ClusterPodConvention` can target a single or multiple workloads of different types. 
+  It is also possible to have multiple conventions being applied to a single workload. 
+  It is at the discretion of the "Conventions Author" how a convention is applied.
 
+
+  To list out available conventions in your cluster, run the following `kubectl`command 
+    
+    ```bash 
+
+    ❯ kubectl get clusterpodconventions.conventions.carto.run
+
+      NAME                     AGE
+      appliveview-sample       23h
+      developer-conventions    23h
+      spring-boot-convention   23h
+    ``` 
 
 + [PodIntent](pod-intent.md) 
 
-  This is a `podintents.conventions.carto.run` type resource. See an example below.
+  This is a `conventions.carto.run/v1alpha1` resource. An example is provided below.
   ```yaml
   apiVersion: conventions.carto.run/v1alpha1
   kind: PodIntent
@@ -50,20 +62,29 @@ The resources include the following
     template: # enriched PodTemplateSpec
       <corev1.PodTemplateSpec>
     ```  
+  To list out available `PodIntent` resources in your cluster, run the following `kubectl` command
   
+  ```bash
+   # specify relevant namespace
+   kubectl get podintents.conventions.carto.run -n my-apps
+
+    NAME            READY   REASON               AGE
+    spring-sample   True    ConventionsApplied   8m5s
+  ```
   When a`PodIntent` is created, the `PodIntent` reconciler lists all `ClusterPodConventions` resources 
-  and applies them serially. To ensure the consistency of the enriched [`PodTemplateSpec`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-template-v1/#PodTemplateSpec), the list of `ClusterPodConventions`is sorted alphabetically 
-  by name before applying the conventions.
+  and applies them serially. To ensure the consistency of the enriched [PodTemplateSpec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-template-v1/#PodTemplateSpec), 
+  the list of `ClusterPodConventions`is sorted alphabetically by name before applying the conventions.
   
-  
-   >**Tip** : *You can use strategic naming to control the order in which the conventions are applied.*
+  >
+
+  >**Tip** : *You can use strategic naming to control the order in which the conventions are applied.*
 
   After the conventions are applied, the `Ready` status condition on the `PodIntent` resource is used 
   to indicate whether it is applied successfully.
   A list of all applied conventions is stored under the annotation `conventions.carto.run/applied-conventions`.
 
-There are also a few other reources within the inner workings of the convention services's `controller`
-and these include the following 
+There are also a few other resources available to the `Conventions Author` that are not persisted in your cluster 
+and these include 
 + [ImageConfig](image-config.md)
 + [PodConventionContextSpec](pod-convention-context-spec.md)
 + [PodConventionContextStatus](pod-convention-context-status.md)

--- a/convention-service/about.hbs.md
+++ b/convention-service/about.hbs.md
@@ -3,64 +3,37 @@
 >**Caution** This component is deprecated in favor of [Cartographer Conventions](../cartographer-conventions/about.md).
 
 The [Cartographer Conventions](../cartographer-conventions/about.md) component must be installed to add conventions to your pod.
-The v0.7.x version of the convention controller is a passive system that translates the CRDs to the [new group](../cartographer-conventions/reference/pod-intent.md).
-
 
 #### <a id="ootb-conventions"></a> Sample conventions
 
 There are several out-of-the-box conventions provided with a full profile installation of Tanzu Application Platform or individual component installation of the following packages.
 
-  ```shell
+  ```bash
     ❯ kubectl get pkgi -n tap-install | grep conventions
-      appliveview-conventions    conventions.appliveview.tanzu.vmware.com       1.3.0-build.1       Reconcile succeeded   2m5s
-      developer-conventions      developer-conventions.tanzu.vmware.com         0.7.0               Reconcile succeeded   2m5s
-      spring-boot-conventions    spring-boot-conventions.tanzu.vmware.com       0.4.1               Reconcile succeeded   2m5s
+      appliveview-conventions              conventions.appliveview.tanzu.vmware.com              1.5.0-build.2     Reconcile succeeded   6m21s
+      conventions-controller               controller.conventions.apps.tanzu.vmware.com          0.8.0             Reconcile succeeded   7m38s
+      developer-conventions                developer-conventions.tanzu.vmware.com                0.10.0-build.1    Reconcile succeeded   6m21s
+      spring-boot-conventions              spring-boot-conventions.tanzu.vmware.com              1.5.0-build.2     Reconcile succeeded   6m21s
 
-    ❯ kubectl get clusterpodconventions
-      Warning: conventions.apps.tanzu.vmware.com/v1alpha1 ClusterPodConvention is deprecated; use conventions.carto.run/v1alpha1 ClusterPodConvention instead
-      NAME                     READY   REASON   AGE
-      appliveview-sample       True    InSync   4m51s
-      developer-conventions    True    InSync   4m50s
-      spring-boot-convention   True    InSync   4m51s
+    ❯ kubectl get clusterpodconventions.conventions.carto.run                                                                                                                                            ⏎
+      NAME                     AGE
+      appliveview-sample       8m25s
+      developer-conventions    8m24s
+      spring-boot-convention   8m25s
   ```
 
 The webhook configuration for each convention is as follows:
 
 + Conventions for [AppLiveView](../app-live-view/about-app-live-view.hbs.md)
 
-  ```yaml
-  ...
-  # webhook configuration
-  apiVersion: conventions.apps.tanzu.vmware.com/v1alpha1
-  kind: ClusterPodConvention
-  ...
-  spec:
-    priority: Late
-    webhook:
-      clientConfig:
-        service:
-          name: appliveview-webhook
-          namespace: app-live-view-conventions
-  ```
 
   ```shell
-  ❯ kubectl get deployment.apps/appliveview-webhook -n app-live-view-conventions                                                     ⏎
-    NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
-    appliveview-webhook   1/1     1            1           8m45s
+  ❯ kubectl get deployment.apps/appliveview-webhook -n app-live-view-conventions                                                                                                                       ⏎
+  NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
+  appliveview-webhook   1/1     1            1           11m
   ```
 
 + [Developer conventions](../developer-conventions/about.hbs.md)
-
-  ```yaml
-  ...
-  # webhook configuration
-  spec:
-    webhook:
-      clientConfig:
-        service:
-          name: webhook
-          namespace: developer-conventions
-  ```
 
   ```shell
   ❯ kubectl get deployment.apps/webhook -n developer-conventions                                                                     ⏎
@@ -69,17 +42,6 @@ The webhook configuration for each convention is as follows:
   ```
 
 + [Spring boot conventions](../spring-boot-conventions/reference/CONVENTIONS.hbs.md)
-
-  ``` yaml
-    ...
-   # webhook configuration
-    spec:
-      webhook:
-        clientConfig:
-          service:
-            name: spring-boot-webhook
-            namespace: spring-boot-convention
-    ```
 
     ```shell
     ❯ kubectl get deployment.apps/spring-boot-webhook -n spring-boot-convention

--- a/partials/_view-package-config.hbs.md
+++ b/partials/_view-package-config.hbs.md
@@ -37,7 +37,6 @@ The following table summarizes the top-level keys used for package-specific conf
 |Application Live View Conventions|`appliveview-conventions`|
 |Cartographer|`cartographer`|
 |Cloud Native Runtimes|`cnrs`|
-|Convention controller|`convention_controller`|
 |Source Controller|`source_controller`|
 |Supply Chain|`supply_chain`|
 |Supply Chain Basic|`ootb_supply_chain_basic`|

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -34,3 +34,6 @@ This release has the following known issues, listed by area and component.
 
 The following features, listed by component, are deprecated.
 Deprecated features will remain on this list until they are retired from Tanzu Application Platform.
+
+#### <a id='1-5-0-convention-controller-dp'></a> Convention Controller
+- This component is now fully deprecated in this release and is now fully replaced by [Cartographer Conventions](https://github.com/vmware-tanzu/cartographer-conventions) which implements the `conventions.carto.run` API that implementes all the features that were avaialble in the Convention Controller component.


### PR DESCRIPTION
## Drop Convention Controller 
In 1.5.x Convention Controller is fully deprecated and removed from TAP builds 
### Changes made 
- update examples to ensure relevance to current API in use 
- remove any references to the convention controller component
- ensure that  the controller resource is referenced as the convention service's controller to avoid confusion with the deprecated convention controller component 

### Target release
Changes targeted for the 1.5.x0-dev branch as Convention Controller will be fully deprecated in TAP 1.5.0

