### PR TITLE
Update release notes about Contour bump

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -6,6 +6,12 @@ This topic contains release notes for Tanzu Application Platform v1.3
 
 **Release Date**: February 16, 2023
 
+### <a id='1-3-5-security-fix'></a> Security fixes
+#### <a id='1-3-5-contour-resolved-issues'></a> Contour
+
+- Bump to [Contour 1.22.3](https://github.com/projectcontour/contour/releases/tag/v1.22.3). Includes a bump to go [1.19.4](https://go.dev/doc/devel/release#go1.19.minor), which contains security fixes to the `net/http` and `os` packages.
+
+---
 ### <a id='1-3-5-breaking-changes'></a> Breaking changes
 
 #### <a id='scc-breaking-changes'></a> Supply Chain Choreographer


### PR DESCRIPTION
Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
This bump also happened in TAP 1.4.0, but I don't know if it was mentioned in the release notes. Is there a process for like a retroactive release note amendment? If so, this release note also belongs in 1-4-0. Or at least in the 1.4.0 section of the 1-4-1 release notes page.


It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
