### PR TITLE
Adds docs for Workloads trusting custom CAs for AppSSO AuthServer

### DIFF
--- a/app-sso/app-operators/register-an-app-with-app-sso.hbs.md
+++ b/app-sso/app-operators/register-an-app-with-app-sso.hbs.md
@@ -47,6 +47,8 @@ Workload is aware of AppSSO. How does that work?
 - To make your Workload aware of AppSSO (i.e. that your application shall now rely on AppSSO for authentication and
   authorization requests), you must [specify a service resource claim](#add-a-service-resource-claim-to-your-workload)
   which produces the necessary credentials for your Workload to consume.
+- (Optional) [Ensure Workload will trust AuthServer](../service-operators/workload-trust-custom-ca.hbs.md). This step
+  is **required** when your TAP installation is using the default self-signed certificate `ClusterIssuer`.
 
 The following sections elaborate on both of the concepts in detail.
 

--- a/app-sso/app-operators/tutorials/securing-first-workload.hbs.md
+++ b/app-sso/app-operators/tutorials/securing-first-workload.hbs.md
@@ -104,6 +104,8 @@ Follow these steps to deploy the sample application:
 1. [Create a namespace for workloads](#create-namespace).
 1. [Apply a client registration](#apply-client-registration).
 1. [Create a resource claim for the workload](#create-resource-claim).
+1. (Optional) [Ensure Workload will trust AuthServer](../../service-operators/workload-trust-custom-ca.md)
+   1. This step is **required** when your TAP installation is using the default self-signed certificate `ClusterIssuer`.
 1. [Deploy the workload](#deploy-workload).
 
 ### <a id="create-namespace"></a>Create a namespace for workloads
@@ -222,9 +224,6 @@ Follow the `Workload` logs:
 ```shell
 tanzu apps workload tail appsso-starter-java --namespace workloads
 ```
-
->**Caution** If your Workload fails to trust the AuthServer due to custom TLS certificates, you must provide additional parameters to your Workload. 
-For more information, see ['`Workload` does not trust `AuthServer`](../../troubleshoot.hbs.md#issue-workload-trust-authserver).
 
 After the status of the workload reaches the `Ready` state, you can navigate to the URL provided, which looks similar to:
 

--- a/app-sso/service-operators/index.hbs.md
+++ b/app-sso/service-operators/index.hbs.md
@@ -14,6 +14,7 @@ The following sections outline the essential steps to configure a fully operatio
 - [Issuer URI and TLS](./issuer-uri-and-tls.md)
 - [TLS scenario guides](./tls-scenario-guides.hbs.md)
 - [CA certificates](./ca-certs.md)
+- [Configuring Workloads to trust a custom CA](./workload-trust-custom-ca.hbs.md)
 - [Identity providers](./identity-providers.md)
 - [Token signatures](./token-signature.md)
 - [Storage](./storage.hbs.md)

--- a/app-sso/service-operators/issuer-uri-and-tls.hbs.md
+++ b/app-sso/service-operators/issuer-uri-and-tls.hbs.md
@@ -201,7 +201,7 @@ spec:
 
 >**Caution** Deactivating TLS is unsafe and not recommended for production.
 
-## <a id="trust-custom-ca"></a>Allow `Workloads` to trust a custom CA `AuthServer`
+## <a id="trust-custom-ca"></a> Allow `Workloads` to trust a custom CA `AuthServer`
 
 If your `AuthServer` obtains a certificate from a custom CA, its consumers do not trust it by default. You can
 enable App Operators' `Workloads` to trust your `AuthServer` by exporting a `ca-certificates` service
@@ -241,7 +241,7 @@ spec:
 ```
 
 This templates a `ca-certificates` service binding `Secret` which `Workload` can claim to trust the custom CA. It does
-not contain the CA's private and is generally safe to share.
+not contain the CA's private key and is generally safe to share.
 
 However, be careful, this example exports to all namespace on the cluster. If this does not comply with your policies,
 then adjust the target namespaces if required.

--- a/app-sso/service-operators/workload-trust-custom-ca.hbs.md
+++ b/app-sso/service-operators/workload-trust-custom-ca.hbs.md
@@ -1,0 +1,100 @@
+# Configuring Workloads to trust a custom Certificate Authority (CA)
+
+If your `ClientRegistration` selects an `AuthServer` which serves a certificate from a custom CA, then your `Workload`
+will not trust it by default, as the certificate is not issued by a trusted certificate authority from the `Workload`'s
+perspective. 
+
+**To establish trust between a `Workload` and an `AuthServer`, the following steps are involved**:
+
+1. Service Operator exports the custom CA certificate `Secret` resource from the namespace in which it is issued.
+2. Service Operator imports the custom CA certificate `Secret` to the namespace in which the `Workload` is created.
+3. The `Workload` being deployed is appended a service resource claim, denoting the custom CA certificate `Secret` in the workload namespace.
+
+> **Note** Steps below are mandatory if TAP is installed with the default self-signed `ClusterIssuer` resource, in which the CA is custom.
+
+## Step 1: Exporting custom CA certificate Secret
+
+A `ca-certificates` service binding `Secret` allows to configure trust for custom CAs.
+
+For detailed information on exporting CA certificate Secrets, see [Allow `Workloads` to trust a custom CA `AuthServer`](./issuer-uri-and-tls.md#trust-custom-ca).
+
+_Example_: create a `ca-certificates`-type ServiceBinding Secret from template and offer TAP's default self-signed CA
+certificate Secret to workloads namespace
+
+```yaml
+---
+apiVersion: secretgen.carvel.dev/v1alpha1
+kind: SecretTemplate
+metadata:
+  name: tap-ca-cert
+  namespace: cert-manager                     # the namespace in which your custom CA Secret resides
+spec:
+  inputResources:
+    - name: tap-ingress-selfsigned-root-ca
+      ref:
+        apiVersion: v1                        # the custom CA certificate Secret
+        kind: Secret                          # ^^
+        name: tap-ingress-selfsigned-root-ca  # ^^
+  template:
+    data:
+      ca.crt: $(.tap-ingress-selfsigned-root-ca.data.tls\.crt)
+    stringData:
+      type: ca-certificates
+---
+apiVersion: secretgen.carvel.dev/v1alpha1
+kind: SecretExport
+metadata:
+  name: tap-ca-cert           # the name of the SecretTemplate that created the "ca-certificates" Secret
+  namespace: cert-manager     # the namespace in which TAP's self-signed ClusterIssuer stores its CA cert Secret
+spec:
+  toNamespace: my-apps        # the namespace in which Workloads are deployed
+```
+
+## Step 2: Importing custom CA certificate Secret
+
+Once the custom CA certificate Secret has been exported from its original namespace, we can import it into the
+workloads' namespace.
+
+_Example_: accept TAP's default self-signed CA certificate Secret offer
+
+```yaml
+---
+apiVersion: secretgen.carvel.dev/v1alpha1
+kind: SecretImport
+metadata:
+  name: tap-ca-cert
+  namespace: my-apps            # the namespace in which Workloads are deployed
+spec:
+  fromNamespace: cert-manager   # the namespace in which your custom CA certificate Secret resides
+```
+
+## Step 3: Appending custom CA certificate Secret reference to Workload
+
+With custom CA certificate available in the workloads' namespace, we can now append it to the Workload as a service 
+resource claim:
+
+_Example_: appending custom CA certificate Secret as a resource claim
+
+```yaml
+
+---
+apiVersion: carto.run/v1alpha1
+kind: Workload
+# ...
+spec:
+  serviceClaims:
+    - name: ca-cert
+      ref:
+        apiVersion: v1    # The custom CA Secret template that is imported into the workloads' namespace
+        kind: Secret      # ^^
+        name: tap-ca-cert # ^^
+    # ...
+```
+
+Alternatively, you can provide the workload with a `--service-ref` parameter for the same effect:
+
+```shell
+--service-ref "ca-cert=v1:Secret:tap-ca-cert"
+```
+
+For more information about secretgen-controller and its APIs, see [secretgen-controller documentation](https://github.com/vmware-tanzu/carvel-secretgen-controller) in GitHub.

--- a/app-sso/troubleshoot.hbs.md
+++ b/app-sso/troubleshoot.hbs.md
@@ -49,50 +49,6 @@ client secret of an identity provider is misconfigured.
 
 Validate the `spec.OpenId.clientSecretRef`.
 
-## <a id='issue-workload-trust-authserver'> `Workload` does not trust `AuthServer`
-
-If your `ClientRegistration` selects an `AuthServer` which serves a certificate from a custom CA, then your `Workload`
-will not trust it by default.
-
-A `ca-certificates` service binding `Secret` allows to configure trust for custom CAs. 
-Your Service Operator can export this resource for you. 
-For more information, see [Allow `Workloads` to trust a custom CA `AuthServer`](service-operators/issuer-uri-and-tls.md#trust-custom-ca).
-
-Once they have exported a `ca-certificates` service binding `Secret`, we can import it and add another service claim to
-the `Workload` to configure trust:
-
-```yaml
----
-apiVersion: secretgen.carvel.dev/v1alpha1
-kind: SecretImport
-metadata:
-  name: custom-ca-cert
-  namespace: my-workloads
-spec:
-  fromNamespace: "<?>" # Your service operator can tell you which namespace to import from
-
----
-apiVersion: carto.run/v1alpha1
-kind: Workload
-# ...
-spec:
-  serviceClaims:
-    - name: authservers-ca-cert
-      ref:
-        apiVersion: v1
-        kind: Secret
-        name: custom-ca-cert
-    # ...
-```
-
-You can also provide the workload with a `--service-ref` parameter:
-
-```shell
---service-ref "authservers-ca-cert=v1:Secret:custom-ca-cert"
-```
-
-For more information about secretgen-controller and its APIs, see [secretgen-controller documentation](https://github.com/vmware-tanzu/carvel-secretgen-controller) in GitHub.
-
 ## Misconfigured redirect URI
 
 ### Problem:

--- a/toc.md
+++ b/toc.md
@@ -268,6 +268,7 @@ docs.vmware.com is built.
             - [Issuer URI and TLS](app-sso/service-operators/issuer-uri-and-tls.hbs.md)
             - [TLS scenario guides](app-sso/service-operators/tls-scenario-guides.hbs.md)
             - [CA certificates](app-sso/service-operators/ca-certs.hbs.md)
+            - [Configuring Workloads to trust a custom CA](app-sso/service-operators/workload-trust-custom-ca.hbs.md)
             - [Identity providers](app-sso/service-operators/identity-providers.hbs.md)
             - [Token signatures](app-sso/service-operators/token-signature.hbs.md)
             - [Storage](app-sso/service-operators/storage.hbs.md)


### PR DESCRIPTION
Which other branches do you want a technical writer to cherry-pick this PR to (if any)? TAP 1.4.x and TAP 1.5.x


It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
