### PR TITLE
update known issues for CNR

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -46,6 +46,10 @@ The following issues, listed by area and component, are resolved in this release
 
 This release has the following known issues, listed by area and component.
 
+### <a id='1-5-0-cnrs-ki'></a> Cloud Native Runtimes
+
+* When using auto-tls (on by default), DomainMapping resouces must have names that are less than 63 characters. Otherwise, the DomainMapping will fail to become ready due to `CertificateNotReady`.
+
 ### <a id='1-5-0-deprecations'></a> Deprecations
 
 The following features, listed by component, are deprecated.


### PR DESCRIPTION
* Known issue with domainmappings, see https://vmware.slack.com/archives/C02D60T1ZDJ/p1677064059759279

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
This is also a problem in the TAP 1.4.x line. Can it be added to the 1.4.0 section of the release notes?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
