### PR TITLE
[VSEE-970 Update properties table with new 1.5.0 configuration parameters

### DIFF
--- a/scst-scan/install-scst-scan.hbs.md
+++ b/scst-scan/install-scst-scan.hbs.md
@@ -44,6 +44,12 @@ When you install the SCST - Scan (Scan controller), you can configure the follow
 | metadataStore.authSecret.name | _n/a_ | string | Name of deployed secret with key auth_token | earlier than v1.2.0 |
 | retryScanJobsSecondsAfterError | 60 | integer | Seconds to wait before retrying errored scans | v1.3.1 and later |
 | caCertData | "" | string | The custom certificates trusted by the scans' connections. | v1.4.0 and later |
+| certIssuer | "" | string | The common certificate issuer for the cluster. | v1.5.0 and later |
+| controller.pullSecret | "controller-secret-ref" | string | Reference to the secret used for pulling the controller image from private registry. Set to empty if deploying from a public registry. | v1.5.0 and later |
+| docker.import | true | boolean | Import `controller.pullSecret` from another namespace (requires secretgen-controller). Set to false if the secret will already be present. | v1.5.0 and later |
+| kubeRbacProxy.certRef | "" | string | Reference to the secret which holds certificate for kube-rbac-proxy. The Certificate is used to enable secure connection to the metric proxy. | v1.5.0 and later |
+| kubeRbacProxy.tls.minVersion | "" | string | Minimum TLS version supported by kube-rbac-proxy. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants. | v1.5.0 and later |
+| kubeRbacProxy.tls.ciphers | empty array | array of strings | Comma-separated list of cipher suites for the server supported by kube-rbac-proxy. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants). | v1.5.0 and later |
 
 When you install the SCST - Scan (Grype scanner), you can configure the following optional properties:
 


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
None

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
