### PR TITLE
Add docs for using ootb-supply-chain-basic Carvel Package Workflow

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -33,6 +33,10 @@ This topic contains release notes for Tanzu Application Platform v1.5.
 - Introduces standardized client authentication methods to `ClientRegistration` custom resource.
   For more information, see [ClientRegistration](app-sso/crds/clientregistration.hbs.md).
 
+#### <a id='1-5-0-scc-new-features'></a> Supply Chain Choreographer
+
+- Introduces ability to configure the OOTB Basic supply chain to [output Carvel Packages](scc/carvel-package-supply-chain.hbs.md). This feature is experimental.
+
 #### <a id='1-5-0-scst-policy-new-features'></a> Supply Chain Security Tools - Policy Controller
 
 - ClusterImagePolicy resync is triggered every 10 hours to get updated values from KMS.

--- a/scc/authoring-supply-chains.hbs.md
+++ b/scc/authoring-supply-chains.hbs.md
@@ -49,6 +49,12 @@ supply chains of the corresponding packages:
      - `workload.spec.image` text box set
   - ClusterSupplyChain/**source-to-url**
      - label `apps.tanzu.vmware.com/workload-type: web`
+  - ClusterSupplyChain/**basic-image-to-url-package (experimental)**
+     - label `apps.tanzu.vmware.com/workload-type: server`
+     - label `apps.tanzu.vmware.com/carvel-package-workflow: true`
+  - ClusterSupplyChain/**source-to-url-package (experimental)**
+     - label `apps.tanzu.vmware.com/workload-type: server`
+     - label `apps.tanzu.vmware.com/carvel-package-workflow: true`
 
 - _ootb-supply-chain-testing_
   - ClusterSupplyChain/**testing-image-to-url**
@@ -115,6 +121,10 @@ The following set of objects are provided by `ootb-templates`:
 - ClusterTask/**image-writer**
 - ClusterTemplate/**config-writer-template**
 - ClusterTemplate/**deliverable-template**
+- ClusterTask/**carvel-package (experimental)**
+- ClusterConfigTemplate/**carvel-package (experimental)**
+- ClusterTemplate/**package-config-writer-and-pull-requester-template (experimental)**
+- ClusterTemplate/**package-config-writer-template (experimental)**
 
 Before submitting your own, either ensure that the name and resource has no
 conflicts with those installed by `ootb-templates`, or exclude from the

--- a/scc/carvel-package-supply-chain.hbs.md
+++ b/scc/carvel-package-supply-chain.hbs.md
@@ -1,0 +1,107 @@
+# Carvel Package Workflow (Experimental)
+
+The [Out of the Box Basic Supply Chain](ootb-supply-chain-basic.hbs.md) package can be configured to output Carvel Packages to a GitOps repository. This feature is experimental and can be used alongside the existing Out of the Box Basic workflow.
+
+This document provides instructions for both an operator and developer on make use of the Carvel Package workflow.
+
+Note that as this feature is experimental, there are some limitations:
+1. Only the [Out of the Box Basic Supply Chain](ootb-supply-chain-basic.hbs.md) package is supported. The Testing and Scanning supply chains are not supported.
+2. Only workloads of type `server` are supported.
+
+## How To: Operator
+
+### Prerequisites
+
+- You will need access to a GitOps repository and credentials, as described in [GitOps versus RegistryOps](gitops-vs-regops.hbs.md#gitops).
+
+### Installation
+
+In `tap-values`, configure the [Out of the Box Basic Supply Chain](ootb-supply-chain-basic.hbs.md) package with the following parameters:
+
+1. (Required) Enable the Carvel Package workflow.
+
+    ```yaml
+    ootb_supply_chain_basic:
+      carvel_package:
+        workflow_enabled: true
+    ```
+
+2. (Optional) Set a GitOps subpath. This will determine the path in your GitOps repository to which Carvel Packages are written. See the [Carvel Package template](ootb-template-reference.hbs.md#carvel-package-experimental) for more information.
+
+    ```yaml
+    ootb_supply_chain_basic:
+      carvel_package:
+        workflow_enabled: true
+        gitops_subpath: path/to/my/dir
+    ```
+
+3. (Optional) Set a name suffix. This will determine the suffix of the name of the Carvel Package. See the [Carvel Package template](ootb-template-reference.hbs.md#carvel-package-experimental) for more information.
+
+    ```yaml
+    ootb_supply_chain_basic:
+      carvel_package:
+        workflow_enabled: true
+        gitops_subpath: path/to/my/dir
+        name_suffix: vmware.com
+    ```
+
+Then, in `tap-values`, configure the [Out of the Box Basic Supply Chain](ootb-supply-chain-basic.hbs.md) package with your GitOps parameters, as described in [GitOps versus RegistryOps](gitops-vs-regops.hbs.md#gitops).
+
+Finally, install the [Out of the Box Basic Supply Chain](ootb-supply-chain-basic.hbs.md) package.
+
+## How To: Developer
+
+### Prerequisites
+
+- Your operator will need to enable the Carvel Package workflow for the [Out of the Box Basic Supply Chain](ootb-supply-chain-basic.hbs.md) package, as described above.
+
+### Creating a Workload
+
+To utilize the Carvel Package workflow, you must add the label `apps.tanzu.vmware.com/carvel-package-workflow=true` to your workload.
+With the `tanzu` CLI, you can do so by using the following flag:
+
+- `--label apps.tanzu.vmware.com/carvel-package-workflow=true`
+
+For example:
+
+  ```bash
+  tanzu apps workload create tanzu-java-web-app \
+    --app tanzu-java-web-app \
+    --type server \
+    --label apps.tanzu.vmware.com/carvel-package-workflow=true \
+    --image IMAGE
+  ```
+
+Expect to see the following output:
+
+  ```console
+  Create workload:
+      1 + |---
+      2 + |apiVersion: carto.run/v1alpha1
+      3 + |kind: Workload
+      4 + |metadata:
+      5 + |  labels:
+      6 + |    app.kubernetes.io/part-of: tanzu-java-web-app
+      7 + |    apps.tanzu.vmware.com/carvel-package-workflow: "true"
+      8 + |    apps.tanzu.vmware.com/workload-type: server
+      9 + |  name: tanzu-java-web-app
+     10 + |  namespace: default
+     11 + |spec:
+     12 + |  image: IMAGE
+  ```
+
+You can override two parameters set by the operator:
+
+1. (Optional) Set a GitOps subpath. This will determine the path in your GitOps repository to which Carvel Packages are written. See the [Carvel Package template](ootb-template-reference.hbs.md#carvel-package-experimental) for more information.
+
+Set this parameter by modifying `workload.spec.params.carvel_package_gitops_subpath`. With the `tanzu` CLI, you can do so by using the following flag:
+
+- `--param carvel_package_gitops_subpath=path/to/my/dir`
+
+1. (Optional) Set a name suffix. This will determine the suffix of the name of the Carvel Package. See the [Carvel Package template](ootb-template-reference.hbs.md#carvel-package-experimental) for more information.
+
+Set this parameter by modifying `workload.spec.params.carvel_package_name_suffix`. With the `tanzu` CLI, you can do so by using the following flag:
+
+- `--param carvel_package_name_suffix=vmware.com`
+
+>**Note** You can optionally override GitOps parameters as described in [GitOps versus RegistryOps](gitops-vs-regops.hbs.md#gitops).

--- a/scc/git.hbs.md
+++ b/scc/git.hbs.md
@@ -4,7 +4,7 @@ The out of the box supply chains and delivery use Git in 3 ways:
 
 - To fetch the developers source code, using the [template](ootb-template-reference.hbs.md#source-template).
 - To store complete Kubernetes configuration, the "write" side of gitops, use 
-  [template 1](ootb-template-reference.hbs.md#config-writer-template) and [template 2](ootb-template-reference.hbs.md#config-writer-and-pull-requester-template).
+  [template 1](ootb-template-reference.hbs.md#config-writer-template), [template 2](ootb-template-reference.hbs.md#config-writer-and-pull-requester-template), [template 3 (experimental)](ootb-template-reference.hbs.md#package-config-writer-template-experimental), and [template 4 (experimental)](ootb-template-reference.hbs.md#package-config-writer-and-pull-requester-template-experimental).
 - To fetch stored Kubernetes configuration, the read side of gitops,
   from either the same or a different Kubernetes cluster, use the
   [template](ootb-template-reference.hbs.md#delivery-source-template).

--- a/scc/ootb-supply-chain-basic.hbs.md
+++ b/scc/ootb-supply-chain-basic.hbs.md
@@ -14,11 +14,13 @@ The supply chains included in this package perform the following:
   1. Building a container image out of the source code with Buildpacks
   1. Applying operator-defined conventions to the container definition
   1. Creating a deliverable object for deploying the application to a cluster
+    1. (Experimental) Alternatively, outputting a Carvel Package containing the application to a Git Repository
 
 - Using a prebuilt application image:
 
   1. Applying operator-defined conventions to the container definition
   1. Creating a deliverable object for deploying the application to a cluster
+    1. (Experimental) Alternatively, outputting a Carvel Package containing the application to a Git Repository
 
 
 ## <a id="prerequisites"></a> Prerequisites
@@ -227,3 +229,6 @@ of the supply chains), see the following sections:
 - [GitOps vs RegistryOps](gitops-vs-regops.md), for a description of the
   different ways of propagating the deployment configuration through external
   systems (Git repositories and image registries).
+
+- [Carvel Package Workflow (experimental)](carvel-package-workflow.md), for more information
+  about how to configure workloads to output Carvel Packages for delivery through Git repositories.

--- a/scc/ootb-supply-chain-reference.hbs.md
+++ b/scc/ootb-supply-chain-reference.hbs.md
@@ -340,6 +340,149 @@ Parameters provided:
 See [Install Out of the Box Supply Chain with Testing and Scanning](install-ootb-sc-wtest-scan.hbs.md)
 for information about setting tap-values at installation time.
 
+## Source-to-URL-Package (experimental)
+
+### Purpose
+
+- Fetches application source code,
+- builds it into an image,
+- bundles the Kubernetes configuration necessary to deploy the application into a Carvel Package,
+- and commits that Package to a Git Repository.
+
+### Resources
+
+This section describes the templates and their parameters.
+
+#### source-provider
+
+Refers to [source-template](ootb-template-reference.hbs.md#source-template).
+
+Parameters provided:
+
+- `serviceAccount` from tap-value `service_account`. Overridable by workload.
+- `gitImplementation` from tap-value `git_implementation`. NOT overridable by workload.
+
+#### image-provider
+
+Refers to [kaniko-template](ootb-template-reference.hbs.md#kaniko-template)
+when the workload provides a parameter `dockerfile`.
+Refers to [kpack-template](ootb-template-reference.hbs.md#kpack-template) otherwise.
+
+Parameters provided:
+
+- `serviceAccount` from tap-value `service_account`. Overridable by workload.
+- `registry` from tap-value `registry`. NOT overridable by workload.
+- `clusterBuilder` from tap-value `cluster_builder`. Overridable by workload.
+- `dockerfile` value `./Dockerfile`. Overridable by workload.
+- `docker_build_context` value `./`. Overridable by workload.
+- `docker_build_extra_args` value `[]`. Overridable by workload.
+
+#### carvel-package
+
+Refers to [carvel-package](ootb-template-reference.hbs.md#carvel-package-experimental).
+
+Parameters provided:
+
+- `serviceAccount` from tap-value `service_account`. Overridable by workload.
+- `registry` from tap-value `registry`. NOT overridable by workload.
+
+#### package-config-writer
+
+Refers to the
+[package-config-writer-and-pull-requester-template](ootb-template-reference.hbs.md#package-config-writer-and-pull-requester-template-experimental)
+when the tap-value `gitops.commit_strategy` is `pull_request`.
+Otherwise, this resource refers to the [package-config-writer-template](ootb-template-reference.hbs.md#package-config-writer-template-experimental)
+
+Parameters provided:
+
+- `serviceAccount` from tap-value `service_account`. Overridable by workload.
+- `registry` from tap-value `registry`. NOT overridable by workload.
+
+#### Common Resources
+
+- [Config-Provider](#config-provider)
+- [App-Config](#app-config)
+- [Service-Bindings](#service-bindings)
+- [Api-Descriptors](#api-descriptors)
+
+### Parameters provided to all resources
+
+- `maven_repository_url` from tap-value `maven.repository.url`. NOT overridable by workload.
+- `maven_repository_secret_name` from tap-value `maven.repository.secret_name`. NOT overridable by workload.
+- `carvel_package_gitops_subpath` from tap-value `carvel_package.gitops_subpath`. Overridable by workload.
+- `carvel_package_name_suffix` from tap-value `carvel_package.name_suffix`. Overridable by workload.
+- See [Params provided by all Supply Chains to all Resources](#params-provided-by-all-supply-chains-to-all-resources)
+
+### Package
+
+[Out of the Box Supply Chain Basic](ootb-supply-chain-basic.hbs.md)
+
+### More Information
+
+See [Install Out of the Box Supply Chain Basic](install-ootb-sc-basic.hbs.md)
+for information about setting tap-values at installation time.
+
+## Basic-Image-to-URL-Package (experimental)
+
+- Fetches a prebuilt image,
+- bundles the Kubernetes configuration necessary to deploy the application into a Carvel Package,
+- and commits that Package to a Git Repository.
+
+### Resources
+
+#### image-provider
+
+Refers to [image-provider-template](ootb-template-reference.hbs.md#image-provider-template).
+
+Parameters provided:
+
+- `serviceAccount` from tap-value `service_account`. Overridable by workload.
+
+#### carvel-package
+
+Refers to [carvel-package](ootb-template-reference.hbs.md#carvel-package-experimental).
+
+Parameters provided:
+
+- `serviceAccount` from tap-value `service_account`. Overridable by workload.
+- `registry` from tap-value `registry`. NOT overridable by workload.
+
+#### package-config-writer
+
+Refers to the
+[package-config-writer-and-pull-requester-template](ootb-template-reference.hbs.md#package-config-writer-and-pull-requester-template-experimental)
+when the tap-value `gitops.commit_strategy` is `pull_request`.
+Otherwise, this resource refers to the [package-config-writer-template](ootb-template-reference.hbs.md#package-config-writer-template-experimental)
+
+Parameters provided:
+
+- `serviceAccount` from tap-value `service_account`. Overridable by workload.
+- `registry` from tap-value `registry`. NOT overridable by workload.
+
+#### Common Resources
+
+- [Config-Provider](#config-provider)
+- [App-Config](#app-config)
+- [Service-Bindings](#service-bindings)
+- [Api-Descriptors](#api-descriptors)
+- [Config-Writer](#config-writer)
+- [Deliverable](#deliverable)
+
+### Parameters provided to all resources
+
+- `carvel_package_gitops_subpath` from tap-value `carvel_package.gitops_subpath`. Overridable by workload.
+- `carvel_package_name_suffix` from tap-value `carvel_package.name_suffix`. Overridable by workload.
+- See [Params provided by all Supply Chains to all Resources](#params-provided-by-all-supply-chains-to-all-resources)
+
+### Package
+
+[Out of the Box Supply Chain Basic](ootb-supply-chain-basic.hbs.md)
+
+### More Information
+
+See [Install Out of the Box Supply Chain Basic](install-ootb-sc-basic.hbs.md)
+for information about setting tap-values at installation time.
+
 ## Resources Common to All OOTB Supply Chains
 
 ### config-provider

--- a/scc/ootb-template-reference.hbs.md
+++ b/scc/ootb-template-reference.hbs.md
@@ -18,6 +18,7 @@ Source](building-from-source.hbs.md).
 - [Source-to-URL](ootb-supply-chain-reference.hbs.md#source-to-url) in the `source-provider` step.
 - [Source-Test-to-URL](ootb-supply-chain-reference.hbs.md#source-test-to-url) in the `source-provider` step.
 - [Source-Test-Scan-to-URL](ootb-supply-chain-reference.hbs.md#source-test-scan-to-url) in the `source-provider` step.
+- [Source-to-URL-Package (experimental)](ootb-supply-chain-reference.hbs.md#source-to-url-package-experimental) in the `source-provider` step.
 
 ### Creates
 
@@ -357,6 +358,7 @@ available to other resources in the supply chain.
 - [Basic-Image-to-URL](ootb-supply-chain-reference.hbs.md#basic-image-to-url) in the image-provider step.
 - [Testing-Image-to-URL](ootb-supply-chain-reference.hbs.md#testing-image-to-url) in the image-provider step.
 - [Scanning-Image-Scan-to-URL](ootb-supply-chain-reference.hbs.md#scanning-image-scan-to-url) in the image-provider step.
+- [Basic-Image-to-URL-Package (experimental)](ootb-supply-chain-reference.hbs.md#basic-image-to-url-package-experimental) in the image-provider step.
 
 These are used as the `image-provider` resource.
 
@@ -412,6 +414,7 @@ Builds an container image from source code using [cloud native buildpacks](https
 - [Source-to-URL](ootb-supply-chain-reference.hbs.md#source-to-url) in the image-provider step.
 - [Source-Test-to-URL](ootb-supply-chain-reference.hbs.md#source-test-to-url) in the image-provider step.
 - [Source-Test-Scan-to-URL](ootb-supply-chain-reference.hbs.md#source-test-scan-to-url) in the image-provider step.
+- [Source-to-URL-Package (experimental)](ootb-supply-chain-reference.hbs.md#source-to-url-package-experimental) in the image-provider step.
 
 These are used as the `image-provider` resource when the workload parameter `dockerfile` is not defined.
 
@@ -518,6 +521,7 @@ Build an image for source code that includes a Dockerfile.
 - [Source-to-URL](ootb-supply-chain-reference.hbs.md#source-to-url) in the image-provider step.
 - [Source-Test-to-URL](ootb-supply-chain-reference.hbs.md#source-test-to-url) in the image-provider step.
 - [Source-Test-Scan-to-URL](ootb-supply-chain-reference.hbs.md#source-test-scan-to-url) in the image-provider step.
+- [Source-to-URL-Package (experimental)](ootb-supply-chain-reference.hbs.md#source-to-url-package-experimental) in the image-provider step.
 
 These are used as the `image-provider` resource when the workload parameter `dockerfile` is defined.
 
@@ -677,6 +681,8 @@ which are applied to the cluster.
 - [Testing-Image-to-URL](ootb-supply-chain-reference.hbs.md#testing-image-to-url) in the config-provider step.
 - [Source-Test-Scan-to-URL](ootb-supply-chain-reference.hbs.md#source-test-scan-to-url) in the config-provider step.
 - [Scanning-Image-Scan-to-URL](ootb-supply-chain-reference.hbs.md#scanning-image-scan-to-url) in the config-provider step.
+- [Source-to-URL-Package (experimental)](ootb-supply-chain-reference.hbs.md#source-to-url-package-experimental) in the config-provider step.
+- [Basic-Image-to-URL-Package (experimental)](ootb-supply-chain-reference.hbs.md#basic-image-to-url-package-experimental) in the config-provider step.
 
 ### Creates
 
@@ -844,6 +850,8 @@ define a Kubernetes Deployment and a Kubernetes Service.
 - [Testing-Image-to-URL](ootb-supply-chain-reference.hbs.md#testing-image-to-url) in the app-config step.
 - [Source-Test-Scan-to-URL](ootb-supply-chain-reference.hbs.md#source-test-scan-to-url) in the app-config step.
 - [Scanning-Image-Scan-to-URL](ootb-supply-chain-reference.hbs.md#scanning-image-scan-to-url) in the app-config step.
+- [Source-to-URL-Package (experimental)](ootb-supply-chain-reference.hbs.md#source-to-url-package-experimental) in the app-config step.
+- [Basic-Image-to-URL-Package (experimental)](ootb-supply-chain-reference.hbs.md#basic-image-to-url-package-experimental) in the app-config step.
 
 ### Creates
 
@@ -900,6 +908,8 @@ to the set of Kubernetes configuration files.
 - [Testing-Image-to-URL](ootb-supply-chain-reference.hbs.md#testing-image-to-url) in the service-bindings step.
 - [Source-Test-Scan-to-URL](ootb-supply-chain-reference.hbs.md#source-test-scan-to-url) in the service-bindings step.
 - [Scanning-Image-Scan-to-URL](ootb-supply-chain-reference.hbs.md#scanning-image-scan-to-url) in the service-bindings step.
+- [Source-to-URL-Package (experimental)](ootb-supply-chain-reference.hbs.md#source-to-url-package-experimental) in the service-bindings step.
+- [Basic-Image-to-URL-Package (experimental)](ootb-supply-chain-reference.hbs.md#basic-image-to-url-package-experimental) in the service-bindings step.
 
 ### Creates
 
@@ -952,12 +962,14 @@ Kubernetes objects to deploy such that API auto registration takes place.
 
 ### Used by
 
-- [Source-to-URL](ootb-supply-chain-reference.hbs.md#source-to-url) in the service-bindings step.
-- [Basic-Image-to-URL](ootb-supply-chain-reference.hbs.md#basic-image-to-url) in the service-bindings step.
-- [Source-Test-to-URL](ootb-supply-chain-reference.hbs.md#source-test-to-url) in the service-bindings step.
-- [Testing-Image-to-URL](ootb-supply-chain-reference.hbs.md#testing-image-to-url) in the service-bindings step.
-- [Source-Test-Scan-to-URL](ootb-supply-chain-reference.hbs.md#source-test-scan-to-url) in the service-bindings step.
-- [Scanning-Image-Scan-to-URL](ootb-supply-chain-reference.hbs.md#scanning-image-scan-to-url) in the service-bindings step.
+- [Source-to-URL](ootb-supply-chain-reference.hbs.md#source-to-url) in the api-descriptors step.
+- [Basic-Image-to-URL](ootb-supply-chain-reference.hbs.md#basic-image-to-url) in the api-descriptors step.
+- [Source-Test-to-URL](ootb-supply-chain-reference.hbs.md#source-test-to-url) in the api-descriptors step.
+- [Testing-Image-to-URL](ootb-supply-chain-reference.hbs.md#testing-image-to-url) in the api-descriptors step.
+- [Source-Test-Scan-to-URL](ootb-supply-chain-reference.hbs.md#source-test-scan-to-url) in the api-descriptors step.
+- [Scanning-Image-Scan-to-URL](ootb-supply-chain-reference.hbs.md#scanning-image-scan-to-url) in the api-descriptors step.
+- [Source-to-URL-Package (experimental)](ootb-supply-chain-reference.hbs.md#source-to-url-package-experimental) in the api-descriptors step.
+- [Basic-Image-to-URL-Package (experimental)](ootb-supply-chain-reference.hbs.md#basic-image-to-url-package-experimental) in the api-descriptors step.
 
 ### Creates
 
@@ -1918,3 +1930,517 @@ A [kapp App](https://carvel.dev/kapp-controller/docs/v0.41.0/app-overview/).
 For details about RBAC and how `kapp-controller` makes use of the ServiceAccount provided through the Deliverable's
 `serviceAccount` parameter,
 see [kapp-controller's Security Model](https://carvel.dev/kapp-controller/docs/v0.41.0/security-model/).
+
+## carvel-package (experimental)
+
+### Purpose
+
+Bundles Kubernetes configuration into a Carvel Package.
+
+### Used by
+
+- [Source-to-URL-Package (experimental)](ootb-supply-chain-reference.hbs.md#source-to-url-package-experimental) in the carvel-package step.
+- [Basic-Image-to-URL-Package (experimental)](ootb-supply-chain-reference.hbs.md#basic-image-to-url-package-experimental) in the carvel-package step.
+
+### Creates
+
+A taskrun.tekton.dev which provides configuration to a Tekton ClusterTask to bundle Kubernetes configuration into a Carvel Package.
+
+This template uses the [`lifecycle: tekton`](https://cartographer.sh/docs/v0.6.0/lifecycle/)
+flag to create new immutable objects rather than updating the previous object.
+
+### Parameters
+
+<table>
+  <tr>
+    <th>Parameter name</th>
+    <th>Meaning</th>
+    <th>Example</th>
+  </tr>
+
+  <tr>
+    <td><code>serviceAccount<code></td>
+    <td>
+      Name of the service account to use for providing Docker credentials.
+      The service account must exist in the same namespace as the Workload.
+      The service account must have a secret associated with the credentials.
+      See <a href="https://tekton.dev/docs/pipelines/auth/#configuring-authentication-for-docker">Configuring
+      authentication for Docker</a> in the Tekton documentation.
+    </td>
+    <td>
+      <pre>
+      - name: serviceAccount
+        value: default
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>registry<code></td>
+    <td>
+      Specification of the registry server and repository in which the built image is placed.
+    </td>
+    <td>
+      <pre>
+      - name: registry
+        value:
+          server: index.docker.io
+          repository: web-team
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>carvel_package_gitops_subpath<code></td>
+    <td>
+      Specifies the subpath to which Carvel Packages should be written.
+    </td>
+    <td>
+      <pre>
+      - name: carvel_package_gitops_subpath
+        value: path/to/my/dir
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>carvel_package_name_suffix<code></td>
+    <td>
+      Specifies the suffix to append to the Carvel Package name. The format is WORKLOAD_NAME.WORKLOAD_NAMESPACE.carvel_package_name_suffix The full Carvel Package name must be a valid DNS subdomain name as defined in RFC 1123.
+    </td>
+    <td>
+      <pre>
+      - name: carvel_package_name_suffix
+        value: vmware.com
+      </pre>
+    </td>
+  </tr>
+</table>
+
+### More Information
+
+To read more about `lifecycle:tekton`,
+read [Cartographer Lifecycle](https://cartographer.sh/docs/v0.6.0/lifecycle/).
+
+## package-config-writer-template (experimental)
+
+### Purpose
+
+Persist in an external git repository the Carvel Package Kubernetes configuration passed to the template.
+
+### Used by
+
+- [Source-to-URL-Package (experimental)](ootb-supply-chain-reference.hbs.md#source-to-url-package-experimental) in the config-writer step.
+- [Basic-Image-to-URL-Package (experimental)](ootb-supply-chain-reference.hbs.md#basic-image-to-url-package-experimental) in the config-writer step.
+
+### Creates
+
+A runnable which creates a Tekton TaskRun that refers either to the Tekton Task `git-writer`.
+
+### Parameters
+
+<table>
+  <tr>
+    <th>Parameter name</th>
+    <th>Meaning</th>
+    <th>Example</th>
+  </tr>
+
+  <tr>
+    <td><code>serviceAccount<code></td>
+    <td>
+      Name of the service account which provides the credentials to the registry or repository.
+      The service account must exist in the same namespace as the Workload.
+    </td>
+    <td>
+      <pre>
+      - name: serviceAccount
+        value: default
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_branch<code></td>
+    <td>
+      Name of the branch to push the configuration to.
+    </td>
+    <td>
+      <pre>
+      - name: gitops_branch
+        value: main
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_user_name<code></td>
+    <td>
+      User name to use in the commits.
+    </td>
+    <td>
+      <pre>
+      - name: gitops_user_name
+        value: "Alice Lee"
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_user_email<code></td>
+    <td>
+      User email address to use in the commits.
+    </td>
+    <td>
+      <pre>
+      - name: gitops_user_email
+        value: alice@example.com
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_commit_message<code></td>
+    <td>
+      Message to write as the body of the commits produced for pushing configuration to the Git repository.
+    </td>
+    <td>
+      <pre>
+      - name: gitops_commit_message
+        value: "ci bump"
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_repository<code></td>
+    <td>
+      The full repository URL to which the configuration is committed.
+      <b>DEPRECATED</b>
+    </td>
+    <td>
+      <pre>
+      - name: gitops_repository
+        value: "https://github.com/vmware-tanzu/cartographer"
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_repository_prefix<code></td>
+    <td>
+      The prefix of the repository URL.
+      <b>DEPRECATED</b>
+    </td>
+    <td>
+      <pre>
+      - name: gitops_repository
+        value: "https://github.com/vmware-tanzu/"
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_server_address<code></td>
+    <td>
+      The server URL of the Git repository to which configuration is applied.
+    </td>
+    <td>
+      <pre>
+      - name: gitops_server_address
+        value: "https://github.com/"
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_repository_owner<code></td>
+    <td>
+      The owner/organization to which the repository belongs.
+    </td>
+    <td>
+      <pre>
+      - name: gitops_repository_owner
+        value: vmware-tanzu
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_repository_name<code></td>
+    <td>
+      The name of the repository.
+    </td>
+    <td>
+      <pre>
+      - name: gitops_repository_name
+        value: cartographer
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>registry<code></td>
+    <td>
+      Specification of the registry server and repository in which the configuration is placed.
+    </td>
+    <td>
+      <pre>
+      - name: registry
+        value:
+          server: index.docker.io
+          repository: web-team
+          ca_cert_data:
+            -----BEGIN CERTIFICATE-----
+            MIIFXzCCA0egAwIBAgIJAJYm37SFocjlMA0GCSqGSIb3DQEBDQUAMEY...
+            -----END CERTIFICATE-----
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>carvel_package_gitops_subpath<code></td>
+    <td>
+      Specifies the subpath to which Carvel Packages should be written.
+    </td>
+    <td>
+      <pre>
+      - name: carvel_package_gitops_subpath
+        value: path/to/my/dir
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>carvel_package_name_suffix<code></td>
+    <td>
+      Specifies the suffix to append to the Carvel Package name. The format is WORKLOAD_NAME.WORKLOAD_NAMESPACE.carvel_package_name_suffix The full Carvel Package name must be a valid DNS subdomain name as defined in RFC 1123.
+    </td>
+    <td>
+      <pre>
+      - name: carvel_package_name_suffix
+        value: vmware.com
+      </pre>
+    </td>
+  </tr>
+</table>
+
+### More Information
+
+See [Gitops vs RegistryOps](gitops-vs-regops.hbs.md) for more information about the operation of this template
+and of the [package-config-writer-and-pull-requester-template (experimental)](#package-config-writer-and-pull-requester-template-experimental).
+
+## package-config-writer-and-pull-requester-template (experimental)
+
+### Purpose
+Persist the passed in Carvel Package Kubernetes configuration to a branch in a repository and open a pull request to another branch.
+(This process allows for manual review of configuration before deployment to a cluster)
+
+### Used by
+
+- [Source-to-URL-Package (experimental)](ootb-supply-chain-reference.hbs.md#source-to-url-package-experimental) in the config-writer step.
+- [Basic-Image-to-URL-Package (experimental)](ootb-supply-chain-reference.hbs.md#basic-image-to-url-package-experimental) in the config-writer step.
+
+### Creates
+
+A runnable which provides configuration to the ClusterRunTemplate `commit-and-pr-pipelinerun` to create a
+Tekton TaskRun. The Tekton TaskRun refers to the Tekton Task `commit-and-pr`.
+
+### Parameters
+
+<table>
+  <tr>
+    <th>Parameter name</th>
+    <th>Meaning</th>
+    <th>Example</th>
+  </tr>
+
+  <tr>
+    <td><code>serviceAccount<code></td>
+    <td>
+      Name of the service account which provides the credentials to the registry or repository.
+      The service account must exist in the same namespace as the Workload.
+    </td>
+    <td>
+      <pre>
+      - name: serviceAccount
+        value: default
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_commit_branch<code></td>
+    <td>
+      Name of the branch to which configuration is pushed.
+    </td>
+    <td>
+      <pre>
+      - name: gitops_commit_branch
+        value: feature
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_branch<code></td>
+    <td>
+      Name of the branch to which a pull request is opened.
+    </td>
+    <td>
+      <pre>
+      - name: gitops_branch
+        value: main
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_user_name<code></td>
+    <td>
+      User name to use in the commits.
+    </td>
+    <td>
+      <pre>
+      - name: gitops_user_name
+        value: "Alice Lee"
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_user_email<code></td>
+    <td>
+      User email address to use in the commits.
+    </td>
+    <td>
+      <pre>
+      - name: gitops_user_email
+        value: alice@example.com
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_commit_message<code></td>
+    <td>
+      Message to write as the body of the commits produced for pushing configuration to the Git repository.
+    </td>
+    <td>
+      <pre>
+      - name: gitops_commit_message
+        value: "ci bump"
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_pull_request_title<code></td>
+    <td>
+      Title of the pull request to be opened.
+    </td>
+    <td>
+      <pre>
+      - name: gitops_pull_request_title
+        value: "ready for review"
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_pull_request_body<code></td>
+    <td>
+      Body of the pull request to be opened.
+    </td>
+    <td>
+      <pre>
+      - name: gitops_pull_request_body
+        value: "generated by supply chain"
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_server_address<code></td>
+    <td>
+      The server URL of the Git repository to which configuration is applied.
+    </td>
+    <td>
+      <pre>
+      - name: gitops_server_address
+        value: "https://github.com/"
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_repository_owner<code></td>
+    <td>
+      The owner/organization to which the repository belongs.
+    </td>
+    <td>
+      <pre>
+      - name: gitops_repository_owner
+        value: vmware-tanzu
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_repository_name<code></td>
+    <td>
+      The name of the repository.
+    </td>
+    <td>
+      <pre>
+      - name: gitops_repository_name
+        value: cartographer
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>gitops_server_kind<code></td>
+    <td>
+      The kind of Git provider
+    </td>
+    <td>
+      <pre>
+      - name: gitops_server_kind
+        value: gitlab
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>carvel_package_gitops_subpath<code></td>
+    <td>
+      Specifies the subpath to which Carvel Packages should be written.
+    </td>
+    <td>
+      <pre>
+      - name: carvel_package_gitops_subpath
+        value: path/to/my/dir
+      </pre>
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>carvel_package_name_suffix<code></td>
+    <td>
+      Specifies the suffix to append to the Carvel Package name. The format is WORKLOAD_NAME.WORKLOAD_NAMESPACE.carvel_package_name_suffix The full Carvel Package name must be a valid DNS subdomain name as defined in RFC 1123.
+    </td>
+    <td>
+      <pre>
+      - name: carvel_package_name_suffix
+        value: vmware.com
+      </pre>
+    </td>
+  </tr>
+
+</table>
+
+### More Information
+
+See [Gitops vs RegistryOps](gitops-vs-regops.hbs.md) for more information about the operation of this template
+and of the [package-config-writer-template (experimental)](#package-config-writer-template-experimental).

--- a/scc/workload-reference.hbs.md
+++ b/scc/workload-reference.hbs.md
@@ -20,6 +20,7 @@ OOTB Supply Chains use the following workload labels:
   [Source-Test-Scan-to-URL](ootb-supply-chain-reference.hbs.md#source-test-scan-to-url).
 - `apps.tanzu.vmware.com/workload-type` by [all supply chains](ootb-supply-chain-reference.hbs.md).
 - `apis.apps.tanzu.vmware.com/register-api` by the [Api-Descriptors Template](ootb-template-reference.hbs.md#api-descriptors).
+- `apps.tanzu.vmware.com/carvel-package-workflow` by [source-to-url-package (experimental)](ootb-supply-chain-reference.hbs.md#source-to-url-package-experimental) and [basic-image-to-url-package (experimental)](ootb-supply-chain-reference.hbs.md#basic-image-to-url-experimental).
 
 ## Parameters
 
@@ -103,6 +104,12 @@ The reference for the template details which supply chains include the template.
 - gitops_pull_request_title: [config-writer-and-pull-requester-template](ootb-template-reference.hbs.md#config-writer-and-pull-requester-template)
 - gitops_pull_request_body: [config-writer-and-pull-requester-template](ootb-template-reference.hbs.md#config-writer-and-pull-requester-template)
 - gitops_server_kind: [config-writer-and-pull-requester-template](ootb-template-reference.hbs.md#config-writer-and-pull-requester-template)
+- carvel_package_gitops_subpath (experimental): [carvel-package](ootb-template-reference.hbs.md#carvel-package-experimental),
+  [package-config-writer-template](ootb-template-reference.hbs.md#package-config-writer-template-experimental),
+  [package-config-writer-and-pull-requester-template](ootb-template-reference.hbs.md#package-config-writer-and-pull-requester-template-experimental)
+- carvel_package_name_suffix (experimental): [carvel-package](ootb-template-reference.hbs.md#carvel-package-experimental),
+  [package-config-writer-template](ootb-template-reference.hbs.md#package-config-writer-template-experimental),
+  [package-config-writer-and-pull-requester-template](ootb-template-reference.hbs.md#package-config-writer-and-pull-requester-template-experimental)
 
 ## Service Account
 

--- a/toc.md
+++ b/toc.md
@@ -428,6 +428,7 @@ docs.vmware.com is built.
           - [Use an existing image in Your Supply Chain](scc/pre-built-image.hbs.md)
           - [Authenticate Git](scc/git-auth.hbs.md)
           - [Author Supply Chains](scc/authoring-supply-chains.hbs.md)
+          - [Output Carvel Packages from your Supply Chain](scc/carvel-package-supply-chain.hbs.md)
       - [Reference guides](scc/scc-reference.hbs.md)
           - [Events Reference](scc/events.hbs.md)
           - [Workload Reference](scc/workload-reference.hbs.md)


### PR DESCRIPTION
This PR is for TAP 1.5 only.

We introduced a new guide on how to use this workflow at scc/carvel-package-supply-chain.hbs.md. I'm not sure if that was the right spot or if there should be separate guides for operator/developer, so let me know if there's anything that I need to correct! Thanks.


