### PR TITLE
DRAFT: Add grype known issue in 1.4.x

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -433,6 +433,11 @@ For more information, see [Troubleshoot API Auto Registration](api-auto-registra
   The vulnerabilities are still found during the image scan after the binaries are built and packaged
   as images.
 
+- **Scanning some Alpine-based container images will fail:**
+
+  A bug in Syft causes the scanner to crash while parsing APK metadata to identify installed OS packages if a package's list of provided files is empty.
+  Fixed in 1.4.3 and 1.5.0.
+
 #### <a id="1-4-0-nsp-ki"></a> Namespace Provisioner
 
 - A deleted namespace may remain in a `Terminating` state indefinitely under certain conditions. For


### PR DESCRIPTION
The version of syft included in TAP 1.4.0 panics on some Alpine-based images

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
1.4.0, 1.4.1, 1.4.2

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
