### PR TITLE
Add caution note about requesting roles/groups scope from upstream OpenID provider

### DIFF
--- a/app-sso/service-operators/configure-authorization.hbs.md
+++ b/app-sso/service-operators/configure-authorization.hbs.md
@@ -73,6 +73,7 @@ kind: ClientRegistration
 # ...
 spec:
     scopes:
+    - name: "roles" # Must request special 'roles' scope
     - name: "hr.read"
     - name: "hr.write"
 ```
@@ -113,6 +114,7 @@ kind: ClientRegistration
 # ...
 spec:
     scopes:
+    - name: "roles" # Must request special 'roles' scope
     - name: "developer.read"
 ```
 
@@ -165,6 +167,7 @@ kind: ClientRegistration
 # ...
 spec:
   scopes:
+    - name: "roles" # Must request special 'roles' scope
     - name: "developer.read"
     - name: "developer.write"
     - name: "developer.delete"

--- a/app-sso/service-operators/configure-authorization.hbs.md
+++ b/app-sso/service-operators/configure-authorization.hbs.md
@@ -146,7 +146,7 @@ spec:
               - "developer.read"       # ^^
               - "developer.write"      # ^^
               - "developer.delete"     # ^^
-          rolesToScopes:
+            rolesToScopes:
             - fromRole: "hr"           # -> Role "hr" is mapped to "hr.read", "hr.write" scopes.
               toScopes:                #    Only users with "hr" role can be issued access token with these scopes.
                 - "hr.read"            # ^^

--- a/app-sso/service-operators/identity-providers.hbs.md
+++ b/app-sso/service-operators/identity-providers.hbs.md
@@ -99,10 +99,15 @@ spec:
   identityProviders:
     - name: "openid-idp"
       openid:
+        scopes:
+          - upstream-identity-providers-groups-claim # optional, based on identity provider
         roles:
           fromUpstream:
             claim: "upstream-identity-providers-groups-claim"
 ```
+
+> **Caution** Some OpenID providers, such as Okta OpenID, may require requesting the roles/groups scope from the
+> identity provider, and so it must be listed within `.openid.scopes` list.
 
 For every [ClientRegistration](../crds/clientregistration.hbs.md) that has the `roles` scope listed, the identity
 token will be populated with the `roles` claim:


### PR DESCRIPTION
…enID provider

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
