### PR TITLE
add ACS to profiles page

### DIFF
--- a/about-package-profiles.hbs.md
+++ b/about-package-profiles.hbs.md
@@ -46,6 +46,18 @@ Tanzu Application Platform is a modular, composable platform that comprises the 
   configurations and enable fleets of developers to use them. This helps ease operator concerns about
   whether developers are implementing their best practices.
 
+- **[Application Configuration Service](application-configuration-service/about.hbs.md)**
+
+  Application Configuration Service provides a Kubernetes-native experience to enable the runtime 
+  configuration of existing Spring applications that were previously leveraged by using
+  Spring Cloud Config Server.Application Configuration Service provides a Kubernetes-native 
+  experience to enable the runtime configuration of existing Spring applications that were previously
+  leveraged by using Spring Cloud Config Server.
+
+  Application Configuration Service is compatible with the existing Git repository configuration 
+  management approach.
+  It filters runtime configuration for any application by using slices that produce Secrets.
+
 - **[Application Live View](app-live-view/about-app-live-view.md)**
 
   Application Live View is a lightweight insight and troubleshooting tool that helps application

--- a/application-configuration-service/about.hbs.md
+++ b/application-configuration-service/about.hbs.md
@@ -13,8 +13,7 @@ configuration properties for applications.
 
 Application Configuration Service is compatible with the existing Git repository configuration
 management approach.
-It filters runtime configuration for any application by using slices that produce secrets and
-ConfigMaps.
+It filters runtime configuration for any application by using slices that produce Secrets.
 
 For more information about Application Configuration Service, see the
 [Application Configuration Service for VMware Tanzu documentation](https://docs.vmware.com/en/Application-Configuration-Service-for-VMware-Tanzu/2.0/acs/GUID-overview.html).


### PR DESCRIPTION
For merge into `main` as part of including Application Configuration Service in TAP 1.5
