### PR TITLE
Added known issue for grype prior to 1.4.3

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -127,6 +127,11 @@ This release has the following known issues, listed by area and component.
   are still found during the image scan after the binaries are built and
   packaged as images.
 
+- **Scanning some Alpine-based container images will fail with a panic:**
+
+  A bug in Syft causes the scanner to crash with index out of range, while parsing APK metadata to identify installed OS packages if a package's list of provided files is empty.
+  This problem is resolved in Supply Chain Security Tools - Scan (Grype) version `1.4.1` or in the Tanzu Application Platform version `1.5.0+`.
+
 ---
 
 ## <a id='1-4-1'></a> v1.4.1


### PR DESCRIPTION
This known issue is meant for all TAP versions prior to 1.4.3

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

- 1.4.0
- 1.4.1
- 1.4.2

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
