### PR TITLE
Add link to docs for acc server URL

### DIFF
--- a/getting-started/create-app-accelerator.hbs.md
+++ b/getting-started/create-app-accelerator.hbs.md
@@ -160,7 +160,7 @@ that the resulting project is generated as expected.
     parameters passed in through the `--options` field, and outputs the project to a specified
     directory.
 
-    >**Important** This step requires that the `accelerator` endpoint is exposed and accessible.
+    >**Important** This step requires that the `TANZU-APPLICATION-ACCELERATOR-URL` endpoint is exposed and accessible. See: [Server API connections for operators and developers](../cli-plugins/accelerator/overview.hbs.md#server-api-connections-for-operators-and-developers).
 
     ```bash
     tanzu accelerator generate-from-local \


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

This is for TAP 1.5 and also 1.4 docs

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
