### PR TITLE
Note that plugins are not compatible with carvel package sc

### DIFF
--- a/intellij-extension/about.hbs.md
+++ b/intellij-extension/about.hbs.md
@@ -39,7 +39,7 @@ This extension gives the following features.
   For more information about a typical monorepo setup, see
   [Working with microservices in a monorepo](using-the-extension.hbs.md#mono-repo).
 
--  **Note** The new variation of the out-of-the-box (OOTB) Basic supply chains, which output [Carvel packages](../scc/carvel-package-supply-chain.hbs.md) to enable configuring multiple runtime environment, is not yet supported in this plugin.
+-  **Note** The new variation of the out-of-the-box (OOTB) Basic supply chains: `source-to-url-package` and `basic-image-to-url-package`, which output [Carvel packages](../scc/carvel-package-supply-chain.hbs.md) to enable configuring multiple runtime environment, is not yet supported in this plugin.
 
 ## <a id="next-steps"></a> Next steps
 

--- a/intellij-extension/about.hbs.md
+++ b/intellij-extension/about.hbs.md
@@ -39,6 +39,8 @@ This extension gives the following features.
   For more information about a typical monorepo setup, see
   [Working with microservices in a monorepo](using-the-extension.hbs.md#mono-repo).
 
+-  **Note** The new variation of the out-of-the-box (OOTB) Basic supply chains, which output [Carvel packages](../scc/carvel-package-supply-chain.hbs.md) to enable configuring multiple runtime environment, is not yet supported in this plugin.
+
 ## <a id="next-steps"></a> Next steps
 
 [Follow the steps to install the extension](install.hbs.md).

--- a/vs-extension/about.hbs.md
+++ b/vs-extension/about.hbs.md
@@ -30,3 +30,5 @@ The extension has the following features:
   Deploy your workload straight to your Kubernetes cluster and, after you're finished using it, you
   can delete it. All the output for deleting a workload is filtered to its own output pane window
   within Visual Studio.
+
+**Note** The new variation of the out-of-the-box (OOTB) Basic supply chains, which output [Carvel packages](../scc/carvel-package-supply-chain.hbs.md) to enable configuring multiple runtime environment, is not yet supported in this plugin.

--- a/vs-extension/about.hbs.md
+++ b/vs-extension/about.hbs.md
@@ -31,4 +31,5 @@ The extension has the following features:
   can delete it. All the output for deleting a workload is filtered to its own output pane window
   within Visual Studio.
 
-**Note** The new variation of the out-of-the-box (OOTB) Basic supply chains, which output [Carvel packages](../scc/carvel-package-supply-chain.hbs.md) to enable configuring multiple runtime environment, is not yet supported in this plugin.
+**Note** The new variation of the out-of-the-box (OOTB) Basic supply chains: `source-to-url-package` and `basic-image-to-url-package`, which output [Carvel packages](../scc/carvel-package-supply-chain.hbs.md) to enable configuring multiple runtime environment, is not yet supported in this plugin.
+

--- a/vscode-extension/about.hbs.md
+++ b/vscode-extension/about.hbs.md
@@ -30,3 +30,5 @@ An environment’s similarity to production relies on keeping dependencies and o
 
 From the Tanzu Workloads panel you can see any workload found within the cluster and namespace
 specified in the current kubectl context.
+
+**Note** The new variation of the out-of-the-box (OOTB) Basic supply chains, which output [Carvel packages](../scc/carvel-package-supply-chain.hbs.md) to enable configuring multiple runtime environment, is not yet supported in this plugin.

--- a/vscode-extension/about.hbs.md
+++ b/vscode-extension/about.hbs.md
@@ -31,4 +31,5 @@ An environment’s similarity to production relies on keeping dependencies and o
 From the Tanzu Workloads panel you can see any workload found within the cluster and namespace
 specified in the current kubectl context.
 
-**Note** The new variation of the out-of-the-box (OOTB) Basic supply chains, which output [Carvel packages](../scc/carvel-package-supply-chain.hbs.md) to enable configuring multiple runtime environment, is not yet supported in this plugin.
+**Note** The new variation of the out-of-the-box (OOTB) Basic supply chains: `source-to-url-package` and `basic-image-to-url-package`, which output [Carvel packages](../scc/carvel-package-supply-chain.hbs.md) to enable configuring multiple runtime environment, is not yet supported in this plugin.
+


### PR DESCRIPTION
Add a note to VSCode, IntelliJ and Visual Studio plugins pages to indicate the carvel package new supply chains are not supported
