### PR TITLE
Removed kubernetes secret section from git repository creation in app…

### DIFF
--- a/tap-gui/plugins/application-accelerator-git-repo.hbs.md
+++ b/tap-gui/plugins/application-accelerator-git-repo.hbs.md
@@ -63,31 +63,6 @@ app_config:
         gitRepoCreation: false
 ```
 
-### <a id="k8s-secrets"></a> Use Kubernetes secrets
-
-To use Kubernetes secrets to set the values for `clientId` and `clientSecret`:
-
-1. Create the Kubernetes secret with the values that you want by running:
-
-   ```console
-   kubectl create secret githubOauthApp \
-   --from-literal=clientSecret=GITHUB-CLIENT-SECRET \
-   --from-literal=clientId=GITHUB-CLIENT-ID
-   ```
-
-2. Edit the `app-config.yaml` by using the environment variables. For example:
-
-   ```yaml
-   app_config:
-     auth:
-       environment: development
-       providers:
-         github:
-           development:
-           clientId: ${clientId}
-           clientSecret: ${clientSecret}
-   ```
-
 ## <a id="creating-project"></a> Create a Project
 
 To create a project:


### PR DESCRIPTION
… accelerator tap gui plugin

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches

This section is wrong in the docs
