### PR TITLE
update eks to 1.24 for TAP1.5.0 CNRS issue

### DIFF
--- a/aws-resources.hbs.md
+++ b/aws-resources.hbs.md
@@ -51,7 +51,7 @@ Where:
 To create an EKS cluster in the specified region, run:
 
 ```console
-eksctl create cluster --name $EKS_CLUSTER_NAME --managed --region $AWS_REGION --instance-types t3.xlarge --version 1.23 --with-oidc -N 5
+eksctl create cluster --name $EKS_CLUSTER_NAME --managed --region $AWS_REGION --instance-types t3.xlarge --version 1.24 --with-oidc -N 5
 ```
 
 Creating the control plane and node group can take anywhere from 30-60 minutes.


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches


The latest cnrs.tanzu.vmware.com in TAP 1.5.0  needs a newer Kubernetes (at least 1.24).
Hence update the AWS CLI to install EKS1.24