### PR TITLE
Updates the namespace provisioner docs for TAP 1.5

### DIFF
--- a/namespace-provisioner/about.hbs.md
+++ b/namespace-provisioner/about.hbs.md
@@ -43,32 +43,30 @@ The following section describes how the list of desired developer namespaces is 
 controller and GitOps modes.
 
 Controller mode
-: 
+: In controller mode, the list of desired namespaces used by the `provisioner` application to create resources in, is maintained in the `desired-namespaces` ConfigMap. This ConfigMap is managed by the [Namespace Provisioner controller](#nsp-controller) and it provides a declarative way to indicate which namespaces should be populated with resources. The ConfigMap consists of a list of namespace objects, with a required `name` parameter, and optional additional parameters which are used as `data.values` for customizing defined resources.
 
-In controller mode, the list of desired namespaces used by the `provisioner` application to create resources in, is maintained in the `desired-namespaces` ConfigMap. This ConfigMap is managed by the [Namespace Provisioner controller](#nsp-controller) and it provides a declarative way to indicate which namespaces should be populated with resources. The ConfigMap consists of a list of namespace objects, with a required `name` parameter, and optional additional parameters which are used as `data.values` for customizing defined resources.
+    For example,
 
-For example,
-
-```yaml
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-    name: desired-namespaces
-    namespace: tap-namespace-provisioning
-    annotations:
-        kapp.k14s.io/create-strategy: fallback-on-update
-        namespace-provisioner.apps.tanzu.vmware.com/no-overwrite: "" #! This annotation tells the provisioner app to not override this configMap as this is your desired state.
-data:
-    namespaces.yaml: |
-        #@data/values
-        ---
-        namespaces:
-        - name: dev-ns1
-        # additional parameters about dev-ns1 added via label/annotations or GitOps
-        - name: dev-ns2
-        # additional parameters about dev-ns1 added via label/annotations or GitOps
-```
+    ```yaml
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+        name: desired-namespaces
+        namespace: tap-namespace-provisioning
+        annotations:
+            kapp.k14s.io/create-strategy: fallback-on-update
+            namespace-provisioner.apps.tanzu.vmware.com/no-overwrite: "" #! This annotation tells the provisioner app to not override this configMap as this is your desired state.
+    data:
+        namespaces.yaml: |
+            #@data/values
+            ---
+            namespaces:
+            - name: dev-ns1
+            # additional parameters about dev-ns1 added via label/annotations or GitOps
+            - name: dev-ns2
+            # additional parameters about dev-ns1 added via label/annotations or GitOps
+    ```
 
 GitOps mode
 : Description of GitOps mode

--- a/namespace-provisioner/ootb-supply-chain.md
+++ b/namespace-provisioner/ootb-supply-chain.md
@@ -180,6 +180,7 @@ Using workload yaml
           branch: main
         url: https://github.com/sample-accelerators/tanzu-java-web-app
   ```
+
 ## <a id='test-scan'></a>Testing & Scanning Supply Chain
 
 The Testing Scanning supply chain adds the `source-tester`, `source-scanner`, and `image-scanner` steps in the supply chain which tests the source code pulled by the supply chain and scans for CVEs on the source and the image built by the supply chain. For these new testing and scanning steps to work, the following additional resources must exist in the same namespace as the workload.

--- a/namespace-provisioner/use-case1.md
+++ b/namespace-provisioner/use-case1.md
@@ -117,4 +117,4 @@ Using workload yaml
         url: https://github.com/sample-accelerators/tanzu-java-web-app
   ```
 
->**Note**: `--param-yaml testing_pipeline_matching_labels` tells the supply chain to use the selector that matches the Java pipeline. To use the Python or Golang pipelines, use the selector that matches the language label in those resources.` --param scanning_source_policy="lax-scan-policy"` tells the supply chain to use the lax ScanPolicy for the workload.
+>**Note** `--param-yaml testing_pipeline_matching_labels` tells the supply chain to use the selector that matches the Java pipeline. To use the Python or Golang pipelines, use the selector that matches the language label in those resources.` --param scanning_source_policy="lax-scan-policy"` tells the supply chain to use the lax ScanPolicy for the workload.

--- a/namespace-provisioner/use-case3.md
+++ b/namespace-provisioner/use-case3.md
@@ -182,7 +182,7 @@ To configure the service account to work with private Git repositories, follow t
    - `host`, `username` and `password` values for HTTP based Git Authentication.
    - `ssh-privatekey, identity, identity_pub`, and `known_hosts` for SSH based Git Authentication.
 
-    >**Note**: stringData key of the secret must have **.yaml** or **.yml** suffix at the end.
+    >**Note** stringData key of the secret must have **.yaml** or **.yml** suffix at the end.
 
     Using HTTP(s) based Authentication
     : If using Username and Password for authentication.

--- a/namespace-provisioner/use-case4.md
+++ b/namespace-provisioner/use-case4.md
@@ -72,7 +72,7 @@ To configure the service account to work with private Git repositories, follow t
     - `host`, `username` and `password` values for HTTP based Git Authentication.
     - `ssh-privatekey, identity, identity_pub`, and `known_hosts` for SSH based Git Authentication.
 
-    >**Note**: stringData key of the secret must have **.yaml** or **.yml** suffix at the end.
+    >**Note** stringData key of the secret must have **.yaml** or **.yml** suffix at the end.
 
     ```yaml
     #! Example shows HTTP as well as SSH based authentication


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
