### PR TITLE
docs(Source Controller): :memo: Updating Release notes for Source Con…

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -62,9 +62,9 @@ The following issues, listed by component and area, are resolved in this release
 
 #### <a id='1-4-3-grype-scanner-ri'></a> Source Controller
 
-- **Updated imgpkg API to v0.36.0 to fix Python function's revision:**
+- **Updated imgpkg API to v0.36.0 to fix file permission after extracting source tarball:**
 
-   The Revision was not getting generated for the Python function workload because of ProgressDeadlineExceeded. This led to ksvc revision not being generated and the app is inaccessible. This update fixes that problem.
+   The file permissions was stripped from source files while using IMGPKG version 0.25.0. This issue was fixed in IMGPKG v0.29.0+. As a result, Tanzu Source Controller is now patched with IMGPKG v0.36.0.
 
 ---
 

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -60,6 +60,12 @@ The following issues, listed by component and area, are resolved in this release
    This happened when parsing APK metadata to identify the installed OS packages if a package's list of provided
    files is empty.
 
+#### <a id='1-4-3-grype-scanner-ri'></a> Source Controller
+
+- **Updated imgpkg API to v0.36.0 to fix Python function's revision:**
+
+   The Revision was not getting generated for the Python function workload because of ProgressDeadlineExceeded. This led to ksvc revision not being generated and the app is inaccessible. This update fixes that problem.
+
 ---
 
 ### <a id='1-4-3-known-issues'></a> Known issues


### PR DESCRIPTION
…troller in 1.4.3

Outlining: Updated imgpkg API to v0.36.0 to fix Python function's revision:  The Revision was not getting generated for the Python function workload because of ProgressDeadlineExceeded. This led to ksvc revision not being generated and the app is inaccessible. This update fixes that problem.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
