### PR TITLE
docs(Source Controller): :memo: Adding Resolved Issues for Source Con…

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -55,6 +55,17 @@ vulnerabilities.
 </table>
 
 ---
+### <a id='1-4-3-resolved-issues'></a> Resolved issues
+
+The following issues, listed by component and area, are resolved in this release.
+
+#### <a id='1-4-3-grype-scanner-ri'></a> Source Controller
+
+- **Updated imgpkg API to v0.36.0 to fix file permission after extracting source tarball:**
+
+   The file permissions was stripped from source files while using IMGPKG version 0.25.0. This issue was fixed in IMGPKG v0.29.0+. As a result, Tanzu Source Controller is now patched with IMGPKG v0.36.0.
+
+---
 
 ### <a id='1-3-7-known-issues'></a> Known issues
 


### PR DESCRIPTION
…troller on Release Notes

Updated imgpkg API to v0.36.0 to fix file permission after extracting source tarball:  The file permissions was stripped from source files while using IMGPKG version 0.25.0. This issue was fixed in IMGPKG v0.29.0+. As a result, Tanzu Source Controller is now patched with IMGPKG v0.36.0.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
