### PR TITLE
Remove TKGs for now as Vsphere 8 and 7

### DIFF
--- a/prerequisites.hbs.md
+++ b/prerequisites.hbs.md
@@ -101,18 +101,6 @@ providers:
     - vSphere
     - Baremetal
 - Tanzu Kubernetes Grid multicloud.
-- vSphere with Tanzu v7.0 U3f or later.<br>
-For vSphere with Tanzu, pod security policies must be configured so that Tanzu Application Platform controller pods can run as root.
-For more information, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/policy/pod-security-policy/).
-
-    To set the pod security policies, run:
-
-    ```console
-    kubectl create clusterrolebinding default-tkg-admin-privileged-binding --clusterrole=psp:vmware-system-privileged --group=system:authenticated
-    ```
-
-    For more information about pod security policies on Tanzu for vSphere, see
-    [Using Pod Security Policies with Tanzu Kubernetes Clusters in VMware vSphere Product Documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/vmware-vsphere-with-tanzu/GUID-CD033D1D-BAD2-41C4-A46F-647A560BAEAB.html).
 
 ## <a id="resource-requirements"></a>Resource requirements
 


### PR DESCRIPTION
Remove TKGs for now as Vsphere 8 and 7 both cant support TKR 1.24 as of now. will be adding it back when we start supporting it in future.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
