### PR TITLE
Update install-tbs.hbs.md

### DIFF
--- a/tanzu-build-service/install-tbs.hbs.md
+++ b/tanzu-build-service/install-tbs.hbs.md
@@ -26,7 +26,6 @@ Approximately 10&nbsp;GB of registry space is required when using the `full` dep
 
 ## <a id='deprecated-features'></a> Deprecated Features
 
-- **Automatic dependency updates:** For more information, see [Configure automatic dependency updates](#auto-updates-config).
 - **The Cloud Native Buildpack Bill of Materials (CNB BOM) format:** For more information, see [Deactivate the CNB BOM format](#deactivate-cnb-bom).
 
 ## <a id='tbs-tcli-install'></a> Install the Tanzu Build Service package


### PR DESCRIPTION
Removes reference to removed feature

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)? 
1.5 
This feature (automatic dependency updater) has been removed as of 1.5. 

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
