### PR TITLE
adding TKGs support starting from vsphere8

### DIFF
--- a/prerequisites.hbs.md
+++ b/prerequisites.hbs.md
@@ -101,6 +101,18 @@ providers:
     - vSphere
     - Baremetal
 - Tanzu Kubernetes Grid multicloud.
+- vSphere with Tanzu v8.0.1 or later.<br>
+For vSphere with Tanzu, pod security policies must be configured so that Tanzu Application Platform controller pods can run as root.
+For more information, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/policy/pod-security-policy/).
+
+    To set the pod security policies, run:
+
+    ```console
+    kubectl create clusterrolebinding default-tkg-admin-privileged-binding --clusterrole=psp:vmware-system-privileged --group=system:authenticated
+    ```
+
+    For more information about pod security policies on Tanzu for vSphere, see
+    [Using Pod Security Policies with Tanzu Kubernetes Clusters in VMware vSphere Product Documentation](https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-with-tanzu-tkg/GUID-3B7F5B44-E31D-4819-B166-C531D4ECAE7D.html).
 
 ## <a id="resource-requirements"></a>Resource requirements
 


### PR DESCRIPTION
adding TKGs support starting from vsphere8

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
1.5.0 live docs
1.5.1 branch

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
