### PR TITLE
Update release-notes.hbs.md

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -523,6 +523,10 @@ The following issues, listed by area and component, are resolved in this release
   - Fixed the UI error in the ALV request-mapping page that was caused by an unused style.
   - Fixed the ALV Request Mappings and Threads page to support Boot 3 apps.
 
+#### <a id='1-5-0-tbs-ri'></a> Tanzu Build Service
+
+- Builds no longer fails for upgrades on openshift version 4.11
+
 #### <a id="1-5-apps-plugin-ri"></a> Tanzu CLI Apps plug-in
 
 - Allow users to pass only `--git-commit` as Git the ref while creating a workload from a Git Repository.


### PR DESCRIPTION
Added to resolved notes  for TBS related to a fix for 1.5.0 related to openshift version upgrade 

Please apply the same release notes to 1.5.1 and 1.5.0

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
