### PR TITLE
Add link to additional users setup from NSP ns setup

### DIFF
--- a/namespace-provisioner/legacy-manual-namespace-setup.hbs.md
+++ b/namespace-provisioner/legacy-manual-namespace-setup.hbs.md
@@ -7,7 +7,7 @@ To provision namespaces manually, complete the following steps:
 
 1. [Enable single user access](#single-user-access).
 
-2. (Optional) [Enable additional users with Kubernetes RBAC](#additional-user-access).
+2. (Optional) [Enable additional users with Kubernetes RBAC](#enable-additional-users-with-kubernetes-rbac).
 
 ## <a id='single-user-access'></a>Enable single user access
 
@@ -114,7 +114,7 @@ To provision namespaces manually, complete the following steps:
       - name: tap-registry
     ```
 
-## <a id='additional-user-access'></a>Enable additional users with Kubernetes RBAC
+## Enable additional users with Kubernetes RBAC
 
 Follow these steps to enable additional users in your namespace by using Kubernetes RBAC:
 

--- a/namespace-provisioner/legacy-manual-namespace-setup.hbs.md
+++ b/namespace-provisioner/legacy-manual-namespace-setup.hbs.md
@@ -118,7 +118,7 @@ To provision namespaces manually, complete the following steps:
 
 Follow these steps to enable additional users in your namespace by using Kubernetes RBAC:
 
-1. Before you begin, ensure that you have [enabled single user access](#single-user-access).
+1. Before you begin, ensure that you have [enabled single user access](#single-user-access) (**Skip this step** if you've set up your developer namespace using [Namespace Provisioner](provision-developer-ns.md)).
 2. Choose either of the following options to give developers namespace-level access and view access
    to the appropriate cluster-level resources:
 

--- a/namespace-provisioner/provision-developer-ns.md
+++ b/namespace-provisioner/provision-developer-ns.md
@@ -136,5 +136,6 @@ by Namespace Provisioner.
 Namespace Provisioner does not yet support enabling additional users with Kubernetes RBAC (support will be provided in an upcoming release).
 Until Namespace Provisioner support is provided, please follow the instructions [here](legacy-manual-namespace-setup.hbs.md#additional-user-access).
 
+----
   
 For more information, see the GitOps section of [Customize Installation of Namespace Provisioner](customize-installation.md).

--- a/namespace-provisioner/provision-developer-ns.md
+++ b/namespace-provisioner/provision-developer-ns.md
@@ -134,7 +134,7 @@ by Namespace Provisioner.
 ## <a id ='additional-users-k8s-rbac'></a>Enable additional users with Kubernetes RBAC
   
 Namespace Provisioner does not yet support enabling additional users with Kubernetes RBAC (support will be provided in an upcoming release).
-Until Namespace Provisioner support is provided, please follow the instructions [here|legacy-manual-namespace-setup.hbs.md#additional-user-access]
+Until Namespace Provisioner support is provided, please follow the instructions [here](legacy-manual-namespace-setup.hbs.md#additional-user-access).
 
   
 For more information, see the GitOps section of [Customize Installation of Namespace Provisioner](customize-installation.md).

--- a/namespace-provisioner/provision-developer-ns.md
+++ b/namespace-provisioner/provision-developer-ns.md
@@ -130,12 +130,10 @@ by Namespace Provisioner.
   NAME                CREATED AT
   limitrange/dev-lr   2023-03-08T04:22:20Z
   ```
+  
+  For more information, see the GitOps section of [Customize Installation of Namespace Provisioner](customize-installation.md).
 
 ## <a id ='additional-users-k8s-rbac'></a>Enable additional users with Kubernetes RBAC
   
 Namespace Provisioner does not yet support enabling additional users with Kubernetes RBAC (support will be provided in an upcoming release).
 Until Namespace Provisioner support is provided, please follow the instructions [here](legacy-manual-namespace-setup.hbs.md#additional-user-access).
-
-----
-  
-For more information, see the GitOps section of [Customize Installation of Namespace Provisioner](customize-installation.md).

--- a/namespace-provisioner/provision-developer-ns.md
+++ b/namespace-provisioner/provision-developer-ns.md
@@ -131,4 +131,10 @@ by Namespace Provisioner.
   limitrange/dev-lr   2023-03-08T04:22:20Z
   ```
 
-  For more information, see the GitOps section of [Customize Installation of Namespace Provisioner](customize-installation.md).
+## <a id ='additional-users-k8s-rbac'></a>Enable additional users with Kubernetes RBAC
+  
+Namespace Provisioner does not yet support enabling additional users with Kubernetes RBAC (support will be provided in an upcoming release).
+Until Namespace Provisioner support is provided, please follow the instructions [here|legacy-manual-namespace-setup.hbs.md#additional-user-access]
+
+  
+For more information, see the GitOps section of [Customize Installation of Namespace Provisioner](customize-installation.md).


### PR DESCRIPTION
# Special Request
Can you please check that the link I've added actually clicks through to the sub-section of the page it's targeting?
It's hard for me to know since I can't view it in the staging/live context. Thank you!

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

Please cherry pick these changes back to TAP 1.5
