### PR TITLE
Update Store Docs for TAP 1.5.1, 1.4.5, 1.3.8

### DIFF
--- a/scc/azure.hbs.md
+++ b/scc/azure.hbs.md
@@ -84,8 +84,8 @@ ootb_supply_chain_testing_scanning:
     server_address: https://dev.azure.com
     repository_owner: vmware-tanzu/tap
     repository_name: tap
-    pull-request:
-      server-kind: azure
+    pull_request:
+      server_kind: azure
 ```
 
 or the workload parameters:
@@ -143,11 +143,11 @@ Configure the template parameters as follows:
 To properly contruct the write path, the template parameter `gitops_server_kind` must be configured
 as `azure`. Configure `gitops_server_kind`:
 
-- Use the `gitops.pull-request.server-kind` tap-value during the Out of the Box Supply Chains package installation
+- Use the `gitops.pull_request.server_kind` tap-value during the Out of the Box Supply Chains package installation
 - or configure`gitops_server_kind` as a workload parameter
 
 > **Note** Even if the commit strategy is not pull-request, such as direct commits, to use an 
-Azure DevOps repository either the tap value `gitops.pull-request.server-kind` or the workload parameter
+Azure DevOps repository either the tap value `gitops.pull_request.server_kind` or the workload parameter
 `gitops_server_kind` must be configured to `azure`.
 
 For information about configuring the GitOps write operations, see

--- a/scst-store/additional.hbs.md
+++ b/scst-store/additional.hbs.md
@@ -14,6 +14,7 @@ This section includes the following topics:
 
 - [Troubleshooting upgrading](upgrading.hbs.md)
 - [Log configuration and usage](logs.hbs.md)
+- [Connecting to the Postgres Database](connect-to-database.hbs.md)
 
 ## Configuration
 

--- a/scst-store/connect-to-database.hbs.md
+++ b/scst-store/connect-to-database.hbs.md
@@ -1,0 +1,48 @@
+# Connecting to the Postgres Database
+
+To connect to the Postgres Database, you will need the following values:
+* database name
+* username
+* password
+* database host
+* database port
+* database CA certificate
+
+1. To obtain the database name, username, password, and CA cert, run the following commands:
+    ```shell
+    db_name=$(kubectl get secret postgres-db-secret -n metadata-store -o json | jq -r '.data.POSTGRES_DB' | base64 -d)
+    db_username=$(kubectl get secret postgres-db-secret -n metadata-store -o json | jq -r '.data.POSTGRES_USER' | base64 -d)
+    db_password=$(kubectl get secret postgres-db-secret -n metadata-store -o json | jq -r '.data.POSTGRES_PASSWORD' | base64 -d)
+   
+    db_ca_dir=$(mktemp -d -t ca-cert-XXXX)
+    db_ca_path="$db_ca_dir/ca.crt"
+    kubectl get secrets postgres-db-tls-cert -n metadata-store -o json | jq -r '.data."ca.crt"' | base64 -d > $db_ca_path
+    ```
+    If the password was auto-generated, the above `password` command will return an empty string. Instead, run the following command:
+    ```shell
+    db_password=$(kubectl get secret postgres-db-password -n metadata-store -o json | jq -r '.data.DB_PASSWORD' | base64 -d)
+    ```
+1. In a separate terminal, run the following command:
+
+    ```shell
+    kubectl port-forward service/metadata-store-db 5432:5432 -n metadata-store
+    ```
+
+    Set the database host and port values on the first terminal with the following:
+    
+    ```shell
+    db_host="localhost"
+    db_port=5432
+    ```
+    
+    To port forward to a different local port number, use the following command template:
+    
+    ```shell
+    kubectl port-forward service/metadata-store-db <LOCAL_PORT>:5432 -n metadata-store
+    ```
+
+With this setup, you can now connect to the database and make queries like the following example:
+```shell
+psql "host=$db_host port=$db_port user=$db_username dbname=$db_name sslmode=verify-ca sslrootcert=$db_ca_path" -c "SELECT * FROM images"
+```
+You could also use GUI clients such as [Postico](https://eggerapps.at/postico2/) or [DBeaver](https://dbeaver.io/) to interact with the database.


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
This change will need to go into respective branch for the following TAP releases:
TAP 1.5.1 (`1-5-1`)
TAP 1.4.5 (unavailable at the time of creating this MR)
TAP 1.3.8 (unavailable at the time of creating this MR)
