### PR TITLE
Specify amr deploy bug in 1.5.1 release notes

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -78,6 +78,12 @@ This release has the following known issues, listed by component and area.
   The workaround is to set up a standard Kubernetes secret with a user-id and password to authenticate
   to ECR, instead of binding Tanzu Source Controller to an AWS IAM role to pull images from ECR.
 
+#### <a id='1-5-1-scst-store'></a> SCST - Store
+
+- In TAP 1.5.1, attempting to deploy the Store with AMR does not work. When installing TAP, under `amr` in 
+  the `metadata_store` section, specifying `deploy: true` is supposed to deploy AMR along with the Store. 
+  However, this is not the case with TAP 1.5.1. This is a known bug and will be fixed in future releases.
+
 ---
 
 ## <a id='1-5-0'></a> v1.5.0


### PR DESCRIPTION
In TAP 1.5.1 there is a bug with the scst store, AMR deploy does not work. 

I was told to make a doc JIRA and update the release notes with this issue. I've made this [JIRA ticket](https://jira.eng.vmware.com/browse/TAAP-1432), please let me know if this is correct or if it's another JIRA I should be making