### PR TITLE
Removes instructions to set service_type to ClusterIP for TAP GUI

### DIFF
--- a/app-live-view/improved-security-and-access-control.hbs.md
+++ b/app-live-view/improved-security-and-access-control.hbs.md
@@ -217,7 +217,6 @@ plug-in, take the following steps.
 1. Create `tap-gui-values.yaml` and paste in the following code:
 
     ```yaml
-    service_type: ClusterIP
     ingressEnabled: true
     ingressDomain: "INGRESS-DOMAIN"
     app_config:

--- a/install-aws/profile.hbs.md
+++ b/install-aws/profile.hbs.md
@@ -1,6 +1,6 @@
 # Install Tanzu Application Platform package and profiles on AWS
 
-This topic tells you how to install Tanzu Application Platform (commonly known as TAP) 
+This topic tells you how to install Tanzu Application Platform (commonly known as TAP)
 packages from your Tanzu Application Platform package repository on to AWS.
 
 Before installing the packages, ensure you have:
@@ -233,7 +233,6 @@ ootb_templates:
   iaas_auth: true
 
 tap_gui:
-  service_type: ClusterIP # If shared.ingress_domain is set earlier, this must be set to ClusterIP.
   app_config:
     catalog:
       locations:

--- a/install-azure/profile.hbs.md
+++ b/install-azure/profile.hbs.md
@@ -1,6 +1,6 @@
 # Install Tanzu Application Platform package and profiles on Azure
 
-This topic tells you how to install Tanzu Application Platform (commonly known as TAP) 
+This topic tells you how to install Tanzu Application Platform (commonly known as TAP)
 packages from your Tanzu Application Platform package repository on to Azure.
 
 Before installing the packages, ensure you have:
@@ -85,60 +85,60 @@ To relocate images from the VMware Tanzu Network registry to the ACR registry:
     $ tanzu package available list --namespace tap-install
     / Retrieving available packages...
       NAME                                                 DISPLAY-NAME                                                              SHORT-DESCRIPTION
-      accelerator.apps.tanzu.vmware.com                    Application Accelerator for VMware Tanzu                                  Used to create new projects and configurations.          
-      api-portal.tanzu.vmware.com                          API portal                                                                A unified user interface for API discovery and exploration at scale.          
-      apis.apps.tanzu.vmware.com                           API Auto Registration for VMware Tanzu                                    A TAP component to automatically register API exposing workloads as API entities          
-                                                                                                                                     in TAP GUI.                                                                                       
-      backend.appliveview.tanzu.vmware.com                 Application Live View for VMware Tanzu                                    App for monitoring and troubleshooting running apps         
-      buildservice.tanzu.vmware.com                        Tanzu Build Service                                                       Tanzu Build Service enables the building and automation of containerized         
-                                                                                                                                     software workflows securely and at scale.                                                         
-      carbonblack.scanning.apps.tanzu.vmware.com           VMware Carbon Black for Supply Chain Security Tools - Scan                Default scan templates using VMware Carbon Black   
-      cartographer.tanzu.vmware.com                        Cartographer                                                              Kubernetes native Supply Chain Choreographer.           
-      cnrs.tanzu.vmware.com                                Cloud Native Runtimes                                                     Cloud Native Runtimes is a serverless runtime based on Knative           
-      connector.appliveview.tanzu.vmware.com               Application Live View Connector for VMware Tanzu                          App for discovering and registering running apps          
-      controller.conventions.apps.tanzu.vmware.com         Convention Service for VMware Tanzu                                       Convention Service enables app operators to consistently apply desired runtime           
-                                                                                                                                     configurations to fleets of workloads.                                                            
-      controller.source.apps.tanzu.vmware.com              Tanzu Source Controller                                                   Tanzu Source Controller enables workload create/update from source code.          
-      conventions.appliveview.tanzu.vmware.com             Application Live View Conventions for VMware Tanzu                        Application Live View convention server          
-      developer-conventions.tanzu.vmware.com               Tanzu App Platform Developer Conventions                                  Developer Conventions           
-      eventing.tanzu.vmware.com                            Eventing                                                                  Eventing is an event-driven architecture platform based on Knative Eventing           
-      external-secrets.apps.tanzu.vmware.com               External Secrets Operator                                                 External Secrets Operator is a Kubernetes operator that integrates external    
-                                                                                                                                     secret management systems.                                                                        
+      accelerator.apps.tanzu.vmware.com                    Application Accelerator for VMware Tanzu                                  Used to create new projects and configurations.
+      api-portal.tanzu.vmware.com                          API portal                                                                A unified user interface for API discovery and exploration at scale.
+      apis.apps.tanzu.vmware.com                           API Auto Registration for VMware Tanzu                                    A TAP component to automatically register API exposing workloads as API entities
+                                                                                                                                     in TAP GUI.
+      backend.appliveview.tanzu.vmware.com                 Application Live View for VMware Tanzu                                    App for monitoring and troubleshooting running apps
+      buildservice.tanzu.vmware.com                        Tanzu Build Service                                                       Tanzu Build Service enables the building and automation of containerized
+                                                                                                                                     software workflows securely and at scale.
+      carbonblack.scanning.apps.tanzu.vmware.com           VMware Carbon Black for Supply Chain Security Tools - Scan                Default scan templates using VMware Carbon Black
+      cartographer.tanzu.vmware.com                        Cartographer                                                              Kubernetes native Supply Chain Choreographer.
+      cnrs.tanzu.vmware.com                                Cloud Native Runtimes                                                     Cloud Native Runtimes is a serverless runtime based on Knative
+      connector.appliveview.tanzu.vmware.com               Application Live View Connector for VMware Tanzu                          App for discovering and registering running apps
+      controller.conventions.apps.tanzu.vmware.com         Convention Service for VMware Tanzu                                       Convention Service enables app operators to consistently apply desired runtime
+                                                                                                                                     configurations to fleets of workloads.
+      controller.source.apps.tanzu.vmware.com              Tanzu Source Controller                                                   Tanzu Source Controller enables workload create/update from source code.
+      conventions.appliveview.tanzu.vmware.com             Application Live View Conventions for VMware Tanzu                        Application Live View convention server
+      developer-conventions.tanzu.vmware.com               Tanzu App Platform Developer Conventions                                  Developer Conventions
+      eventing.tanzu.vmware.com                            Eventing                                                                  Eventing is an event-driven architecture platform based on Knative Eventing
+      external-secrets.apps.tanzu.vmware.com               External Secrets Operator                                                 External Secrets Operator is a Kubernetes operator that integrates external
+                                                                                                                                     secret management systems.
       fluxcd.source.controller.tanzu.vmware.com            Flux Source Controller                                                    The source-controller is a Kubernetes operator, specialised in artifacts
-                                                                                                                                     acquisition from external sources such as Git, Helm repositories and S3 buckets.                  
-      grype.scanning.apps.tanzu.vmware.com                 Grype for Supply Chain Security Tools - Scan                              Default scan templates using Anchore Grype           
-      learningcenter.tanzu.vmware.com                      Learning Center for Tanzu Application Platform                            Guided technical workshops           
-      metadata-store.apps.tanzu.vmware.com                 Supply Chain Security Tools - Store                                       Post SBoMs and query for image, package, and vulnerability metadata.          
-      namespace-provisioner.apps.tanzu.vmware.com          Namespace Provisioner                                                     Automatic Provisioning of Developer Namespaces.           
-      ootb-delivery-basic.tanzu.vmware.com                 Tanzu App Platform Out of The Box Delivery Basic                          Out of The Box Delivery Basic.          
-      ootb-supply-chain-basic.tanzu.vmware.com             Tanzu App Platform Out of The Box Supply Chain Basic                      Out of The Box Supply Chain Basic.          
-      ootb-supply-chain-testing-scanning.tanzu.vmware.com  Tanzu App Platform Out of The Box Supply Chain with Testing and Scanning  Out of The Box Supply Chain with Testing and Scanning.         
-      ootb-supply-chain-testing.tanzu.vmware.com           Tanzu App Platform Out of The Box Supply Chain with Testing               Out of The Box Supply Chain with Testing.         
-      ootb-templates.tanzu.vmware.com                      Tanzu App Platform Out of The Box Templates                               Out of The Box Templates.          
-      policy.apps.tanzu.vmware.com                         Supply Chain Security Tools - Policy Controller                           Policy Controller enables defining of a policy to restrict unsigned container           
-                                                                                                                                     images.                                                                                           
-      scanning.apps.tanzu.vmware.com                       Supply Chain Security Tools - Scan                                        Scan for vulnerabilities and enforce policies directly within Kubernetes native          
-                                                                                                                                     Supply Chains.                                                                                    
-      service-bindings.labs.vmware.com                     Service Bindings for Kubernetes                                           Service Bindings for Kubernetes implements the Service Binding Specification.          
-      services-toolkit.tanzu.vmware.com                    Services Toolkit                                                          The Services Toolkit enables the management, lifecycle, discoverability and          
-                                                                                                                                     connectivity of Service Resources (databases, message queues, DNS records,                        
-                                                                                                                                     etc.).                                                                                            
-      snyk.scanning.apps.tanzu.vmware.com                  Snyk for Supply Chain Security Tools - Scan                               Default scan templates using Snyk   
-      spring-boot-conventions.tanzu.vmware.com             Tanzu Spring Boot Conventions Server                                      Default Spring Boot convention server.          
-      sso.apps.tanzu.vmware.com                            AppSSO                                                                    Application Single Sign-On for Tanzu          
-      tap-auth.tanzu.vmware.com                            Default roles for Tanzu Application Platform                              Default roles for Tanzu Application Platform         
-      tap-gui.tanzu.vmware.com                             Tanzu Application Platform GUI                                            web app graphical user interface for Tanzu Application Platform          
-      tap-telemetry.tanzu.vmware.com                       Telemetry Collector for Tanzu Application Platform                        Tanzu Application Plaform Telemetry  
-      tap.tanzu.vmware.com                                 Tanzu Application Platform                                                Package to install a set of TAP components to get you started based on your use    
-                                                                                                                                     case.                                                                                             
-      tekton.tanzu.vmware.com                              Tekton Pipelines                                                          Tekton Pipelines is a framework for creating CI/CD systems.    
-      workshops.learningcenter.tanzu.vmware.com            Workshop Building Tutorial                                                Workshop Building Tutorial      
+                                                                                                                                     acquisition from external sources such as Git, Helm repositories and S3 buckets.
+      grype.scanning.apps.tanzu.vmware.com                 Grype for Supply Chain Security Tools - Scan                              Default scan templates using Anchore Grype
+      learningcenter.tanzu.vmware.com                      Learning Center for Tanzu Application Platform                            Guided technical workshops
+      metadata-store.apps.tanzu.vmware.com                 Supply Chain Security Tools - Store                                       Post SBoMs and query for image, package, and vulnerability metadata.
+      namespace-provisioner.apps.tanzu.vmware.com          Namespace Provisioner                                                     Automatic Provisioning of Developer Namespaces.
+      ootb-delivery-basic.tanzu.vmware.com                 Tanzu App Platform Out of The Box Delivery Basic                          Out of The Box Delivery Basic.
+      ootb-supply-chain-basic.tanzu.vmware.com             Tanzu App Platform Out of The Box Supply Chain Basic                      Out of The Box Supply Chain Basic.
+      ootb-supply-chain-testing-scanning.tanzu.vmware.com  Tanzu App Platform Out of The Box Supply Chain with Testing and Scanning  Out of The Box Supply Chain with Testing and Scanning.
+      ootb-supply-chain-testing.tanzu.vmware.com           Tanzu App Platform Out of The Box Supply Chain with Testing               Out of The Box Supply Chain with Testing.
+      ootb-templates.tanzu.vmware.com                      Tanzu App Platform Out of The Box Templates                               Out of The Box Templates.
+      policy.apps.tanzu.vmware.com                         Supply Chain Security Tools - Policy Controller                           Policy Controller enables defining of a policy to restrict unsigned container
+                                                                                                                                     images.
+      scanning.apps.tanzu.vmware.com                       Supply Chain Security Tools - Scan                                        Scan for vulnerabilities and enforce policies directly within Kubernetes native
+                                                                                                                                     Supply Chains.
+      service-bindings.labs.vmware.com                     Service Bindings for Kubernetes                                           Service Bindings for Kubernetes implements the Service Binding Specification.
+      services-toolkit.tanzu.vmware.com                    Services Toolkit                                                          The Services Toolkit enables the management, lifecycle, discoverability and
+                                                                                                                                     connectivity of Service Resources (databases, message queues, DNS records,
+                                                                                                                                     etc.).
+      snyk.scanning.apps.tanzu.vmware.com                  Snyk for Supply Chain Security Tools - Scan                               Default scan templates using Snyk
+      spring-boot-conventions.tanzu.vmware.com             Tanzu Spring Boot Conventions Server                                      Default Spring Boot convention server.
+      sso.apps.tanzu.vmware.com                            AppSSO                                                                    Application Single Sign-On for Tanzu
+      tap-auth.tanzu.vmware.com                            Default roles for Tanzu Application Platform                              Default roles for Tanzu Application Platform
+      tap-gui.tanzu.vmware.com                             Tanzu Application Platform GUI                                            web app graphical user interface for Tanzu Application Platform
+      tap-telemetry.tanzu.vmware.com                       Telemetry Collector for Tanzu Application Platform                        Tanzu Application Plaform Telemetry
+      tap.tanzu.vmware.com                                 Tanzu Application Platform                                                Package to install a set of TAP components to get you started based on your use
+                                                                                                                                     case.
+      tekton.tanzu.vmware.com                              Tekton Pipelines                                                          Tekton Pipelines is a framework for creating CI/CD systems.
+      workshops.learningcenter.tanzu.vmware.com            Workshop Building Tutorial                                                Workshop Building Tutorial
     ```
 
 ## <a id='install-profile'></a> Install your Tanzu Application Platform profile
 
-The `tap.tanzu.vmware.com` package installs predefined sets of packages based on your profile settings 
-by using the package manager installed by Tanzu Cluster Essentials. 
+The `tap.tanzu.vmware.com` package installs predefined sets of packages based on your profile settings
+by using the package manager installed by Tanzu Cluster Essentials.
 For more information about profiles, see [Components and installation profiles](../about-package-profiles.md).
 
 To create a registry secret and add it to a developer namespace:
@@ -195,15 +195,15 @@ Where:
 - `INGRESS-DOMAIN` is the subdomain for the host name that you point at the `tanzu-shared-ingress`
 service's External IP address.
 - `GIT-CATALOG-URL` is the path to the `catalog-info.yaml` catalog definition file.
-  You can download either a blank or populated catalog file from the 
-  [Tanzu Application Platform product page](https://network.pivotal.io/products/tanzu-application-platform/#/releases/1239018). 
+  You can download either a blank or populated catalog file from the
+  [Tanzu Application Platform product page](https://network.pivotal.io/products/tanzu-application-platform/#/releases/1239018).
   Otherwise, you can use a Backstage-compliant catalog that was built and posted on the Git infrastructure.
-- `MY-DEV-NAMESPACE` is the name of the developer namespace. 
-  SCST - Store exports secrets to the namespace, and SCST - Scan deploys the `ScanTemplates` there. 
-  This allows the scanning feature to run in this namespace. 
-  If there are multiple developer namespaces, use `ns_for_export_app_cert: "*"` 
+- `MY-DEV-NAMESPACE` is the name of the developer namespace.
+  SCST - Store exports secrets to the namespace, and SCST - Scan deploys the `ScanTemplates` there.
+  This allows the scanning feature to run in this namespace.
+  If there are multiple developer namespaces, use `ns_for_export_app_cert: "*"`
   to export the SCST - Store CA certificate to all namespaces.
-- `TARGET-REGISTRY-CREDENTIALS-SECRET` is the name of the secret that contains 
+- `TARGET-REGISTRY-CREDENTIALS-SECRET` is the name of the secret that contains
   the credentials to pull an image from the registry for scanning.
 
 For Azure, the default settings creates a classic LoadBalancer.
@@ -248,7 +248,6 @@ ootb_delivery_basic:
 tap_gui:
   ingressEnabled: true
   ingressDomain: tap.com
-  service_type: ClusterIP # NodePort for distributions that don't support LoadBalancer
   app_config:
     supplyChain:
       enablePlugin: true
@@ -376,9 +375,9 @@ To install the `full` dependencies package:
 
 ## <a id='access-tap-gui'></a> Access Tanzu Application Platform GUI
 
-To access Tanzu Application Platform GUI, you can use the host name that you configured earlier. 
-This host name is pointed at the shared ingress. 
-To configure LoadBalancer for Tanzu Application Platform GUI, 
+To access Tanzu Application Platform GUI, you can use the host name that you configured earlier.
+This host name is pointed at the shared ingress.
+To configure LoadBalancer for Tanzu Application Platform GUI,
 see [Access Tanzu Application Platform GUI](../tap-gui/accessing-tap-gui.hbs.md).
 
 You're now ready to start using Tanzu Application Platform GUI.

--- a/install-offline/profile.hbs.md
+++ b/install-offline/profile.hbs.md
@@ -1,6 +1,6 @@
 # Install Tanzu Application Platform in your air-gapped environment
 
-This topic tells you how to install Tanzu Application Platform (commonly known as TAP) 
+This topic tells you how to install Tanzu Application Platform (commonly known as TAP)
 on your Kubernetes cluster and registry that are air-gapped from external traffic.
 
 Before installing the packages, ensure that you have completed the following tasks:
@@ -304,7 +304,6 @@ appliveview_connector:
       -----END CERTIFICATE-----
 
 tap_gui:
-  service_type: ClusterIP
   app_config:
     kubernetes:
       serviceLocatorMethod:

--- a/install-online/profile.hbs.md
+++ b/install-online/profile.hbs.md
@@ -1,6 +1,6 @@
 # Install Tanzu Application Platform package and profiles
 
-This topic tells you how to install Tanzu Application Platform 
+This topic tells you how to install Tanzu Application Platform
 (commonly known as TAP) packages from your Tanzu Application Platform package repository.
 
 Before installing the packages, ensure you have:
@@ -297,8 +297,7 @@ buildservice:
     namespace: "KP-DEFAULT-REPO-SECRET-NAMESPACE"
 
 tap_gui:
-  service_type: ClusterIP # If the shared.ingress_domain is set as earlier, this must be set to ClusterIP.
-  metadataStoreAutoconfiguration: true # Create a service account, the Kubernetes control plane token and the requisite app_config block to enable communications between Tanzu Application Platform GUI and SCST - Store.
+  metadataStoreAutoconfiguration: true # Creates a service account, the Kubernetes control plane token and the requisite app_config block to enable communications between Tanzu Application Platform GUI and SCST - Store.
   app_config:
     catalog:
       locations:

--- a/install-openshift/profile.hbs.md
+++ b/install-openshift/profile.hbs.md
@@ -1,6 +1,6 @@
 # Install Tanzu Application Platform on your OpenShift clusters
 
-This topic tells you how to install Tanzu Application Platform (commonly known as TAP) 
+This topic tells you how to install Tanzu Application Platform (commonly known as TAP)
 packages on your OpenShift clusters.
 
 Before installing the packages, ensure you have:
@@ -282,7 +282,6 @@ buildservice:
     namespace: tap-install
 
 tap_gui:
-  service_type: ClusterIP # If the shared.ingress_domain is set earlier, this must be set to ClusterIP.
   app_config:
     catalog:
       locations:

--- a/multicluster/reference/tap-values-view-sample.hbs.md
+++ b/multicluster/reference/tap-values-view-sample.hbs.md
@@ -23,7 +23,6 @@ contour:
       type: LoadBalancer # NodePort can be used if your Kubernetes cluster doesn't support LoadBalancing.
 
 tap_gui:
-  service_type: ClusterIP
   app_config:
     catalog:
       locations:

--- a/tap-gui/accessing-tap-gui.hbs.md
+++ b/tap-gui/accessing-tap-gui.hbs.md
@@ -61,9 +61,6 @@ Retrieve this IP address by running:
     ```yaml
     shared:
       ingress_domain: "example.com"
-
-    tap_gui:
-      service_type: ClusterIP
     ```
 
 1. Update your other host names in the `tap_gui` section of your `tap-values.yaml` with the new host
@@ -74,7 +71,6 @@ name. For example:
       ingress_domain: "example.com"
 
     tap_gui:
-      service_type: ClusterIP
     # Existing tap-values.yaml above
       app_config:
         app:

--- a/tap-gui/install-tap-gui.hbs.md
+++ b/tap-gui/install-tap-gui.hbs.md
@@ -54,10 +54,9 @@ To install Tanzu Application Platform GUI on a compliant Kubernetes cluster:
 
     For more information about values schema options, see the individual product documentation.
 
-1. Create `tap-gui-values.yaml` and paste in the following code:
+1. Create `tap-gui-values.yaml` and paste in the following YAML:
 
     ```yaml
-    service_type: ClusterIP
     ingressEnabled: true
     ingressDomain: "INGRESS-DOMAIN"
     app_config:


### PR DESCRIPTION
That's been the default since TAP 1.0

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
Any of them

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
