### PR TITLE
Add deprecation notice for git.gitImplementation

### DIFF
--- a/application-accelerator/creating-accelerators/accelerator-crd.hbs.md
+++ b/application-accelerator/creating-accelerators/accelerator-crd.hbs.md
@@ -35,7 +35,7 @@ The `Accelerator` CRD _spec_ defined in the `AcceleratorSpec` type has the follo
 | tags | An array of strings defining attributes of the Accelerator that can be used in a search. | Optional (*) |
 | git | Defines the accelerator source Git repository. | Optional (***) |
 | git.url | The repository URL, can be a HTTP/S or SSH address. | Optional (***) |
-| git.gitImplementation | Determines which git client library to use. The default setting is to go-git. Valid values are ('go-git', 'libgit2'). | Optional (**) |
+| git.gitImplementation | Determines which git client library to use. The default setting is to go-git. Valid values are ('go-git', 'libgit2'). Deprecated: gitImplementation is deprecated now that ''go-git'' is the only supported implementation. | Optional (**) |
 | git.ignore | Overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default of `.git/` is used. | Optional (**) |
 | git.interval | The interval at which to inquire for repository updates. If not provided the default setting is 10 minuets. There is an additional refresh interval (currently 10s) involved before accelerators can appear in the UI. There might be a 10s delay before changes are reflected in the UI.*| Optional (**) |
 | git.ref | Git reference to checkout and monitor for changes, the default is main branch. | Optional (**) |
@@ -69,6 +69,7 @@ The `Fragment` CRD _spec_ defined in the `FragmentSpec` type has the following f
 | displayName | DisplayName is a short descriptive name used for a Fragment. | Optional |
 | git | Defines the fragment source Git repository. | Required |
 | git.url | The repository URL, can be a HTTP/S or SSH address. | Required |
+| git.gitImplementation | Determines which git client library to use. The default setting is to go-git. Valid values are ('go-git', 'libgit2'). Deprecated: gitImplementation is deprecated now that ''go-git'' is the only supported implementation. | Optional (**) |
 | git.ignore | Overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default of `.git/` is used. | Optional (**) |
 | git.interval | The interval at which to inquire for repository updates. If not provided the default is 10 min.| Optional (**) |
 | git.ref | Git reference to checkout and monitor for changes, the default is main branch. | Optional (**) |


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches

This is a change for TAP 1.6.0