### PR TITLE
Adds note to metadataStoreAutoconfiguration docs

### DIFF
--- a/tap-gui/plugins/scc-tap-gui.hbs.md
+++ b/tap-gui/plugins/scc-tap-gui.hbs.md
@@ -31,11 +31,10 @@ to the Tanzu Application Platform component Supply Chain Security Tools - Store 
 ### <a id="scan-auto"></a> Automatically connect Tanzu Application Platform GUI to the Metadata Store
 
 Tanzu Application Platform GUI has automation for enabling connection between
-Tanzu Application Platform GUI and SCST - Store.
-To use this automation, add it to the Tanzu Application Platform GUI section within your
-`tap-values.yaml` file.
-
-The default value for `tap_gui.metadataStoreAutoconfiguration` is `false`. See the following example:
+Tanzu Application Platform GUI and SCST - Store. By default this automation is
+active and requires no configuration. If you wish to deactivate this automation,
+add the following block to the Tanzu Application Platform GUI section within
+your `tap-values.yaml` file.
 
 ```yaml
 # tap-values.yaml
@@ -43,7 +42,7 @@ The default value for `tap_gui.metadataStoreAutoconfiguration` is `false`. See t
 # ...
 tap_gui:
   # ...
-  metadataStoreAutoconfiguration: true
+  metadataStoreAutoconfiguration: false
 ```
 
 This file change creates a service account for the connection with privileges scoped only to the
@@ -52,11 +51,72 @@ In addition it mounts the token of the service account into the Tanzu Applicatio
 pod and produces for you the `app_config` section necessary for Tanzu Application Platform GUI to
 communicate with SCST - Store.
 
-> **Note:** if your configuration includes a `/metadata-store` block the
-> automation **will not** create the kubernetes resources for used in
-> autoconfiguration nor will it overwrite the proxy block you provide. In order
-> to use the automation you must delete the block at
-> `tap_gui.app_config.proxy["/metadata-store"]`
+#### Troubleshooting
+
+In the course of debugging the automation, or to verify that the automation is
+active, it will be imperative to know which resources are created. The following
+commands reflect the different kubernetes resources that are created when
+`tap_gui.metadataStoreAutoconfiguration` is set to `true`.
+
+```shell
+kubectl -n tap-gui get serviceaccount metadata-store
+```
+
+```
+NAME             SECRETS   AGE
+metadata-store   1         <AGE>
+```
+
+```shell
+kubectl -n tap-gui get secret metadata-store-access-token
+```
+
+```
+NAME                          TYPE                                  DATA   AGE
+metadata-store-access-token   kubernetes.io/service-account-token   3      <AGE>
+```
+
+```shell
+kubectl -n tap-gui get clusterrole metadata-store-reader
+```
+
+```
+NAME                    CREATED AT
+metadata-store-reader   <CREATED AT TIME>
+```
+
+```shell
+kubectl -n tap-gui get clusterrolebinding read-metadata-store
+```
+
+```
+NAME                  ROLE                                AGE
+read-metadata-store   ClusterRole/metadata-store-reader   <AGE>
+```
+
+
+There is another condition that impacts whether or not the automation creates
+the necessary service account. If your configuration includes a
+`/metadata-store` block the automation **will not** create the kubernetes
+resources for used in autoconfiguration nor will it overwrite the proxy block
+you provide. In order to use the automation you must delete the block at
+`tap_gui.app_config.proxy["/metadata-store"]`
+
+For example, a `tap-values.yaml` file with the following contents
+
+```yaml
+# ...
+tap_gui:
+  # ...
+  app_config:
+    # ...
+    proxy:
+      '/metadata-store':
+        target: <SOMETHING>
+```
+
+**will not** create additional kubernetes resources as described above.
+
 
 ### <a id="scan-manual"></a> Manually connect Tanzu Application Platform GUI to the Metadata Store
 

--- a/tap-gui/plugins/scc-tap-gui.hbs.md
+++ b/tap-gui/plugins/scc-tap-gui.hbs.md
@@ -52,6 +52,12 @@ In addition it mounts the token of the service account into the Tanzu Applicatio
 pod and produces for you the `app_config` section necessary for Tanzu Application Platform GUI to
 communicate with SCST - Store.
 
+> **Note:** if your configuration includes a `/metadata-store` block the
+> automation **will not** create the kubernetes resources for used in
+> autoconfiguration nor will it overwrite the proxy block you provide. In order
+> to use the automation you must delete the block at
+> `tap_gui.app_config.proxy["/metadata-store"]`
+
 ### <a id="scan-manual"></a> Manually connect Tanzu Application Platform GUI to the Metadata Store
 
 To manually enable CVE scan results:


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
A slightly modified note could be added to 1-5-0, 1-5-1, 1-5-2. The automation works slightly differently on 1.5 which would be the following block
```markdown
> **Note:** if your configuration includes a `/metadata-store` block the
> automation **will not** overwrite the proxy block you provide. In order to use
> the automation you must delete the block at
> `tap_gui.app_config.proxy["/metadata-store"]`
```

basically it omits "create the kubernetes resources for used in autoconfiguration nor will it"

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
