### PR TITLE
Fix incorrect file extension

### DIFF
--- a/services-toolkit/tutorials/setup-dynamic-provisioning.hbs.md
+++ b/services-toolkit/tutorials/setup-dynamic-provisioning.hbs.md
@@ -96,7 +96,7 @@ Operator for Kubernetes.
 Use `kapp` to install the operator by running:
 
 ```console
-kapp -y deploy --app rmq-operator --file https://github.com/rabbitmq/cluster-operator/releases/latest/download/cluster-operator.yaml
+kapp -y deploy --app rmq-operator --file https://github.com/rabbitmq/cluster-operator/releases/latest/download/cluster-operator.yml
 ```
 
 This causes a new API Group/Version of `rabbitmq.com/v1beta1` and Kind named `RabbitmqCluster` to


### PR DESCRIPTION
To deploy the RabbitMQ Cluster Operator the file name is `cluster-operator.yml`, not `.yaml`. For confirmation see https://github.com/rabbitmq/cluster-operator/releases/

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
All going back to `1-5-0`

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
