### PR TITLE
AppSSO - fix version for tap 1.5

### DIFF
--- a/template_variables.yaml
+++ b/template_variables.yaml
@@ -4,6 +4,6 @@ template_variables:
   url_version: 1.5
   hide_content: true
   app-sso:
-    version: 4.0.0
+    version: 3.1
   tanzu-cli:
     version: 0.28.1


### PR DESCRIPTION
AppSSO is erroneously published as version `4.0.0`, however `4.0.0` will be released in TAP 1.6

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)? Only for TAP 1.5.x publication

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
