### PR TITLE
docs(app-sso): ClientRegistration.spec.redirectURIs is no longer defaulted

### DIFF
--- a/app-sso/reference/api/clientregistration.hbs.md
+++ b/app-sso/reference/api/clientregistration.hbs.md
@@ -20,7 +20,7 @@ metadata:
 spec:
   authServerSelector: # required
     matchLabels: { }
-  redirectURIs: # required
+  redirectURIs: # optional
     - ""
   scopes: # optional
     - name: ""

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -105,6 +105,8 @@ This release includes the following changes, listed by component and area.
 
 - Remove the field `AuthServer.spec.tls.disabled` and use `AuthServer.spec.tls.deactivated` instead.
 
+- The field `ClientRegistration.spec.redirectURIs` is no longer defaulted to `["http:127.0.0.0:8080"]`.
+
 #### <a id='1-6-0-flux-sc-bc'></a> FluxCD Source Controller
 
 - The format of the `status.artifact.revision` value in the `GitRepository` resource's 


### PR DESCRIPTION

[#185246367]

# Target

`1.6.x`

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

_