### PR TITLE
Add opt-in Source Scan note

### DIFF
--- a/getting-started/add-test-and-security.hbs.md
+++ b/getting-started/add-test-and-security.hbs.md
@@ -170,6 +170,8 @@ the workload must be updated to point at your Tekton pipeline.
 
 To install OOTB Supply Chain with Testing and Scanning:
 
+>**Note** In the test and scan supply chain, the source scanning capability has been changed to opt-in and will be skipped by default starting in Tanzu Application Platform 1.6.  See [here](../scst-scan/scan-types.md) for more information.
+
 1. Supply Chain Security Tools (SCST) - Scan is installed as part of the Tanzu Application Platform profiles.
 Verify that both Scan Controller and Grype Scanner are installed by running:
 

--- a/scst-scan/scan-types.hbs.md
+++ b/scst-scan/scan-types.hbs.md
@@ -1,0 +1,30 @@
+# Scan Types
+
+The out-of-box test and scan supply chain supports two scan types:  Source Scan and Image Scan.
+
+## Source Scan
+
+The source scan step in the test and scan supply chain performs a "Software Composition Analysis" (SCA) scan to inspect the open source dependencies of an application for vulnerabilities.  This is typically performed by inspecting the file that the language uses for dependency declaration.  For example:
+
+| Language | Dependency File |
+| ---- | ---- |
+| Spring | pom.xml |
+| .Net | deps.json |
+| Node.JS | packages.json |
+| Python | requirements.txt| 
+
+Rather than declare specific dependency versions, some languages such as Spring/Java and .Net resolve dependency versions at build time.  For these language, performing a SCA scan on the declaration file stored in source code does not produce meaningful results, often creating false positives or even worse, false negatives.
+
+Due to this, starting with TAP 1.6, the source scan step has been moved to an opt-in step in the supply chain.  To add source scan to the supply chain, follow the steps below.
+
+### Adding Source Scan to a Supply Chain
+
+There are two methods for adding source scan to a supply chain. 
+
+#### Creating a Custom Supply Chain from the existing test + scan supply chain
+
+Steps TBD
+
+#### Applying an overlay in the install values.yaml
+
+Steps TBD


### PR DESCRIPTION
Adding a quick explanation for why source scan was moved to opt-in for default supply chain and placeholder for instructions on how to add source scan back in to supply chain.  This is temporary for bug bash and steps will be added within the next week.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
None.  Just main branch.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
