### PR TITLE
Improve docs to not reccomend exporting push secrets to all namespaces

### DIFF
--- a/install-online/profile.hbs.md
+++ b/install-online/profile.hbs.md
@@ -33,10 +33,12 @@ To relocate images from the VMware Tanzu Network registry to your registry:
     export IMGPKG_REGISTRY_USERNAME_0=MY-TANZUNET-USERNAME
     export IMGPKG_REGISTRY_PASSWORD_0=MY-TANZUNET-PASSWORD
     export IMGPKG_REGISTRY_HOSTNAME_1=MY-REGISTRY
-    export IMGPKG_REGISTRY_USERNAME_1=MY-REGISTRY-USER
-    export IMGPKG_REGISTRY_PASSWORD_1=MY-REGISTRY-PASSWORD
+    export IMGPKG_REGISTRY_USERNAME_1=MY-REGISTRY-PUSH-USER
+    export IMGPKG_REGISTRY_PASSWORD_1=MY-REGISTRY-PUSH-PASSWORD
     export INSTALL_REGISTRY_USERNAME=MY-REGISTRY-USER
     export INSTALL_REGISTRY_PASSWORD=MY-REGISTRY-PASSWORD
+    export INSTALL_REGISTRY_PUSH_USERNAME=MY-REGISTRY-PUSH-USER
+    export INSTALL_REGISTRY_PUSH_PASSWORD=MY-REGISTRY-PUSH-PASSWORD
     export INSTALL_REGISTRY_HOSTNAME=MY-REGISTRY
     export TAP_VERSION=VERSION-NUMBER
     export INSTALL_REPO=TARGET-REPOSITORY
@@ -44,9 +46,11 @@ To relocate images from the VMware Tanzu Network registry to your registry:
 
     Where:
 
-    - `MY-REGISTRY-USER` is the user with write access to `MY-REGISTRY`.
+    - `MY-REGISTRY-USER` is the user with read access to `MY-REGISTRY`.
     - `MY-REGISTRY-PASSWORD` is the password for `MY-REGISTRY-USER`.
     - `MY-REGISTRY` is your own container registry.
+    - `MY-REGISTRY-PUSH-USER` is the user with write access to `MY-REGISTRY`.
+    - `MY-REGISTRY-PUSH-PASSWORD` is the password for `MY-REGISTRY-PUSH-USER`.
     - `MY-TANZUNET-USERNAME` is the user with access to the images in the VMware Tanzu Network registry `registry.tanzu.vmware.com`.
     - `MY-TANZUNET-PASSWORD` is the password for `MY-TANZUNET-USERNAME`.
     - `VERSION-NUMBER` is your Tanzu Application Platform version. For example, `{{ vars.tap_version }}`.
@@ -94,7 +98,7 @@ To add the Tanzu Application Platform package repository to your cluster:
 
     This namespace keeps the objects grouped together logically.
 
-1. Create a registry secret by running:
+1. Create a registry pull secret by running:
 
     ```console
     tanzu secret registry add tap-registry \
@@ -103,16 +107,15 @@ To add the Tanzu Application Platform package repository to your cluster:
       --export-to-all-namespaces --yes --namespace tap-install
     ```
 
-1. Create a internal registry secret by running:
+1. Create a internal registry push secret by running:
 
     ```console
     tanzu secret registry add registry-credentials \
         --server   ${INSTALL_REGISTRY_HOSTNAME} \
-        --username ${INSTALL_REGISTRY_USERNAME} \
-        --password ${INSTALL_REGISTRY_PASSWORD} \
+        --username ${INSTALL_REGISTRY_PUSH_USERNAME} \
+        --password ${INSTALL_REGISTRY_PUSH_PASSWORD} \
         --namespace tap-install \
-        --export-to-all-namespaces \
-        --yes 
+        --yes
     ```
 
 1. Add the Tanzu Application Platform package repository to the cluster by running:
@@ -335,7 +338,7 @@ service's External IP address. It is not required to know the External IP addres
     - Google Cloud Registry has the form `kp_default_repository: "gcr.io/my-project/build-service"`.
 - `KP-DEFAULT-REPO-SECRET` is the secret with user credentials that can write to `KP-DEFAULT-REPO`. You can `docker push` to this location with this credential.
     - For Google Cloud Registry, use `kp_default_repository_username: _json_key`.
-    - You must create the secret before the installation. For example, you can use the `registry-credentials` secret created earlier.
+    - You must create the secret before the installation. This secret must be used only for this purpose and does not need to be exported to other namespaces. You can use the `registry-credentials` secret created earlier.
 - `KP-DEFAULT-REPO-SECRET-NAMESPACE` is the namespace where `KP-DEFAULT-REPO-SECRET` is created.
 - `K8S-DISTRO` (optional) is the type of Kubernetes infrastructure in use. It is only required if the distribution is OpenShift and must be used in coordination with `kubernetes_version`. Supported value: `openshift`.
 - `K8S-VERSION` (optional) is the Kubernetes version in use. You can use it independently or in coordination with `kubernetes_distribution`. For example, `1.24.x`, where `x` is the Kubernetes patch version.


### PR DESCRIPTION
This should probably be cherry picked to other branches since it seems to be a bit of a security hole that we recommend users export push secrets everywhere
