### PR TITLE
Add release notes for TAP GUI for TAP 1.5.2

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -30,6 +30,17 @@ The following issues, listed by component and area, are resolved in this release
 - Old `TaskRuns` associated with scans are now deleted to reduce memory consumption.
 - Added support for `ConfigMaps` in custom `ScanTemplates`.
 
+#### <a id='1-5-2-tap-gui-ri'></a> Tanzu Application Platform GUI
+
+- Simplified the default content security policy to remove violations from fonts.googleapis.com.
+
+#### <a id="1-5-2-tap-gui-plug-in-ri"></a> Tanzu Application Platform GUI plug-ins
+
+- **Security Analysis GUI Plug-in:**
+  - **CVE Details:** The impacted workload count in the widget now matches the table.
+  - **Security Analysis Dashboard:** Snyk CVE IDs are no longer overlapped by the Highest Reach Critical Vulnerabilities chart.
+  - **Package Details:** Removed extra versions from Workload Builds using Package table.
+
 ---
 
 ### <a id='1-5-2-known-issues'></a> Known issues


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
None, just for TAP 1.5.2

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
