### PR TITLE
VSEE | Removed reference to prepackaged trivy clusterimagetemplate 

### DIFF
--- a/scst-scan/app-scanning-alpha.hbs.md
+++ b/scst-scan/app-scanning-alpha.hbs.md
@@ -257,10 +257,9 @@ To create a ClusterImageTemplate to which you can incorporate a scanner of your 
 
 #### <a id="config-supply-chain"></a> Configuring the supply chain
 
-The `ImageVulnerabilityScan` can integrate with the [Out of the Box Supply Chain with Testing and Scanning](../scc/ootb-supply-chain-testing-scanning.hbs.md) by using either a user created ClusterImageTemplate or the following packaged ClusterImageTemplates:
+The `ImageVulnerabilityScan` can integrate with the [Out of the Box Supply Chain with Testing and Scanning](../scc/ootb-supply-chain-testing-scanning.hbs.md) by using either a user created ClusterImageTemplate or the following packaged ClusterImageTemplate:
 
 - `image-vulnerability-scan-grype`
-- `image-vulnerability-scan-trivy`
 
 **Note** SCST - Scan 2.0 is in beta and active keychains and workspace bindings are not modifiable in the packaged ClusterImageTemplates.
 


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
- 1.6 only

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
