### PR TITLE
docs(air-gap-workload): simplify with write-only stringData

### DIFF
--- a/getting-started/air-gap-workload.hbs.md
+++ b/getting-started/air-gap-workload.hbs.md
@@ -31,19 +31,18 @@ To create a workload from Git through https, follow these steps:
      name: git-ca
      # namespace: default
    type: Opaque
-   data:
-     username: USERNAME-BASE64
-     password: PASSWORD-BASE64
+   stringData:
+     username: USERNAME
+     password: PASSWORD
      caFile: |
-       CADATA-BASE64
+       CADATA
    ```
 
    Where:
 
-   - `USERNAME-BASE64` is the base64 encoded user name.
-   - `PASSWORD-BASE64` is the base64 encoded password.
-   - `CADATA-BASE64` is the base64 encoded CA certificate for the
-   Git repository.
+   - `USERNAME` is the username.
+   - `PASSWORD` is the password.
+   - `CADATA` is the PEM-encoded CA certificate for the Git repository.
 
 3. To pass in a custom settings.xml for Java, create a file called `settings-xml.yaml`. For example:
 


### PR DESCRIPTION
# Target

`1.6.x`

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

This change qualifies for all previous versions which document how to "Deploy an air-gapped workload on Tanzu Application Platform" in a similar fashion.