### PR TITLE
Add scantemplates to k8s-reader role

### DIFF
--- a/tap-gui/cluster-view-setup.hbs.md
+++ b/tap-gui/cluster-view-setup.hbs.md
@@ -126,6 +126,7 @@ To set up a Service Account to view resources on a cluster:
       - sourcescans
       - imagescans
       - scanpolicies
+      - scantemplates
       verbs: ['get', 'watch', 'list']
     - apiGroups: ['tekton.dev']
       resources:


### PR DESCRIPTION
Without this additional permission the tap-gui will have the following log entry: 

```
{"ts":"2023-06-12T20:07:09.203Z","level":"warn","meta":{"service":"backstage","type":"plugin","plugin":"kubernetes"},"msg":"Received 403 status when fetching \"/apis/scanning.apps.tanzu.vmware.com/v1beta1/scantemplates\" from cluster \"build\"; body=[{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"scantemplates.scanning.apps.tanzu.vmware.com is forbidden: User \\\"system:serviceaccount:tap-gui:tap-gui-viewer\\\" cannot list resource \\\"scantemplates\\\" in API group \\\"scanning.apps.tanzu.vmware.com\\\" at the cluster scope\",\"reason\":\"Forbidden\",\"details\":{\"group\":\"scanning.apps.tanzu.vmware.com\",\"kind\":\"scantemplates\"},\"code\":403}\n]"}
``` 