### PR TITLE
Update prerequisites.hbs.md for OpenShift and Vsphere with Tanzu support

### DIFF
--- a/prerequisites.hbs.md
+++ b/prerequisites.hbs.md
@@ -97,11 +97,11 @@ providers:
 - Minikube.
     - Reference the [resource requirements](#resource-requirements) in the following section.
     - Hyperkit driver is supported on macOS only. Docker driver is not supported.
-- Red Hat OpenShift Container Platform v4.11 or v4.12.
+- Red Hat OpenShift Container Platform v4.12 or v4.13.
     - vSphere
     - Baremetal
 - Tanzu Kubernetes Grid (commonly called TKG) multicloud. For more information, see [TKG documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html).
-- vSphere with Tanzu v7.0 U3f or later.<br>
+- vSphere with Tanzu v8.0.1 or later.<br>
 For vSphere with Tanzu, you must configure pod security policies so Tanzu Application Platform controller pods can run as root.
 For more information, see [Kubernetes documentation](https://kubernetes.io/docs/concepts/policy/pod-security-policy/).
 


### PR DESCRIPTION
OpenShift 4.12 and 4.13 will be supported.
Vsphere 8 with Tanzu will support TKR 1.25 ~July 2023.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
Only into 1.6 branch.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
