### PR TITLE
Adds internal unsafe IdP field removal in AuthServers docs

### DIFF
--- a/app-sso/reference/api/authserver.hbs.md
+++ b/app-sso/reference/api/authserver.hbs.md
@@ -86,10 +86,6 @@ spec:
         users:
           - username: ""
             password: ""
-            givenName: ""
-            familyName: ""
-            email: ""
-            emailVerified: false
             claims: # optional
               custom_claim: ""
               another_custom_claim: ""

--- a/app-sso/reference/upgrades.hbs.md
+++ b/app-sso/reference/upgrades.hbs.md
@@ -18,7 +18,18 @@ tanzu package installed update PACKAGE-INSTALLATION-NAME -p sso.apps.tanzu.vmwar
 
 ## <a id="migration-guides"></a>Migration guides
 
-### <a id="v3-to-v3_1">`v3.0.0` to `v3.1.0`
+### <a id="v4-to-v5"> `v4.0.x` to `v5.0.x`
+
+VMware recommends that you recreate your `AuthServers` after upgrading your
+AppSSO to `v5.0.x` with the following changes:
+
+- `AuthServer` resource definition
+  - Migrate field `.spec.identityProviders[*].internalUnsafe.users[*].givenName` to `.spec.identityProviders[*].internalUnsafe.users[*].claims.given_name`
+  - Migrate field `.spec.identityProviders[*].internalUnsafe.users[*].familyName` to `.spec.identityProviders[*].internalUnsafe.users[*].claims.family_name`
+  - Migrate field `.spec.identityProviders[*].internalUnsafe.users[*].email` to `.spec.identityProviders[*].internalUnsafe.users[*].claims.email`
+  - Migrate field `.spec.identityProviders[*].internalUnsafe.users[*].emailVerified` to `.spec.identityProviders[*].internalUnsafe.users[*].claims.email_verified`
+
+### <a id="v3-to-v3_1"> `v3.0.0` to `v3.1.0`
 
 VMware recommends that you recreate your `AuthServers` after upgrading your
 AppSSO to `v3.1.0` with the following changes:

--- a/template_variables.yaml
+++ b/template_variables.yaml
@@ -5,6 +5,6 @@ template_variables:
   hide_content: true
   staging_toggle: docs-staging
   app-sso:
-    version: 4.0
+    version: 5.0
   tanzu-cli:
     version: 0.28.1


### PR DESCRIPTION
TODO:

- [ ] Wait until TAP 1.7 release notes are templated, and then add field removal to those.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)? TAP 1.7 only

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
