### PR TITLE
docs(tap-gui): don't say "external" ClusterIssuer

### DIFF
--- a/tap-gui/tls/cert-manager-clusterissuer.hbs.md
+++ b/tap-gui/tls/cert-manager-clusterissuer.hbs.md
@@ -1,4 +1,4 @@
-# Configure a TLS certificate by using cert-manager and an external ClusterIssuer
+# Configure a TLS certificate by using cert-manager and a ClusterIssuer
 
 This topic tells you how to use cert-manager to create a certificate issuer and then generate a
 certificate for Tanzu Application Platform GUI (commonly called TAP GUI) to use based on that issuer.

--- a/tap-gui/tls/overview.hbs.md
+++ b/tap-gui/tls/overview.hbs.md
@@ -38,4 +38,4 @@ The following topics describe different ways to configure TLS:
 
 - [Configuring a TLS certificate by using an existing certificate](enable-tls-existing-cert.hbs.md)
 - [Configuring a TLS certificate by using a self-signed certificate](enable-self-signed-cert.hbs.md)
-- [Configuring a TLS certificate by using cert-manager and an external ClusterIssuer](cert-mngr-ext-clusterissuer.hbs.md)
+- [Configuring a TLS certificate by using cert-manager and a ClusterIssuer](cert-manager-clusterissuer.hbs.md)

--- a/toc.hbs.md
+++ b/toc.hbs.md
@@ -662,7 +662,7 @@ docs.vmware.com is built.
          - [Overview of enabling TLS](tap-gui/tls/overview.hbs.md)
          - [Configure by using an existing certificate](tap-gui/tls/enable-tls-existing-cert.hbs.md)
          - [Configure by using a self-signed certificate](tap-gui/tls/enable-self-signed-cert.hbs.md)
-         - [Configure by using cert-manager and external ClusterIssuer](tap-gui/tls/cert-mngr-ext-clusterissuer.hbs.md)
+         - [Configure by using cert-manager and ClusterIssuer](tap-gui/tls/cert-manager-clusterissuer.hbs.md)
       - [Upgrade Tanzu Application Platform GUI](tap-gui/upgrades.hbs.md)
       - [Troubleshoot Tanzu Application Platform GUI](tap-gui/troubleshooting.hbs.md)
     - [Tanzu Application Platform Telemetry](telemetry/overview.hbs.md)


### PR DESCRIPTION
The idea of an "external" (Cluster)Issuer is a specific concept of cert-manager. It refers to (Cluster)Issuer which are maintained out-of-tree. This makes it possible to extend cert-manager with implementations for almost any CA. (See:
https://cert-manager.io/docs/configuration/external/)

Hence, the phrase "external ClusterIssuer" is misleading as it is used by TAP GUI's TLS docs. Just saying "ClusterIssuer" is better and just as precise.

⚠️ This should be a approved by a member of TAP-GUI as this is an unsolicited, external 😄  contribution.

---

# Target

`1.6.x`

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

_