### PR TITLE
Update naming of data services

### DIFF
--- a/services-toolkit/how-to-guides/dynamic-provisioning-tanzu-postgresql.hbs.md
+++ b/services-toolkit/how-to-guides/dynamic-provisioning-tanzu-postgresql.hbs.md
@@ -1,8 +1,8 @@
-# Configure dynamic provisioning of VMware Tanzu Postgres service instances
+# Configure dynamic provisioning of VMware SQL with Postgres for Kubernetes service instances
 
 This Services Toolkit topic tells you how [service operators](../reference/terminology-and-user-roles.hbs.md#so)
 can set up dynamic provisioning.
-This enables app development teams to create self-serve VMware Tanzu Postgres service instances that
+This enables app development teams to create self-serve VMware SQL with Postgres service instances that
 are customized to meet their needs.
 
 If you are not already familiar with dynamic provisioning in Tanzu Application Platform,
@@ -19,9 +19,9 @@ Before you configure dynamic provisioning, you must have:
 
 ## <a id="config-dynamic-provisioning"></a> Configure dynamic provisioning
 
-To configure dynamic provisioning for VMware Tanzu Postgres services instances, you must:
+To configure dynamic provisioning for VMware SQL with Postgres services instances, you must:
 
-1. [Install the Tanzu VMware Postgres Operator](#install-postgres-operator)
+1. [Install the VMware SQL with Postgres Operator](#install-postgres-operator)
 2. [Set up the namespace](#set-up-namespace)
 3. [Create a CompositeResourceDefinition](#compositeresourcedef)
 4. [Create a Composition](#create-composition)
@@ -29,14 +29,14 @@ To configure dynamic provisioning for VMware Tanzu Postgres services instances, 
 6. [Configure RBAC](#configure-rbac)
 7. [Verify your configuration](#verify)
 
-### <a id="install-postgres-operator"></a> Install the Tanzu VMware Postgres Operator
+### <a id="install-postgres-operator"></a> Install the VMware SQL with Postgres Operator
 
-Install the Tanzu VMware Postgres Operator by following the steps in
+Install the VMware SQL with Postgres Operator by following the steps in
 [Installing a VMware Postgres Operator](https://docs.vmware.com/en/VMware-SQL-with-Postgres-for-Kubernetes/2.0/vmware-postgres-k8s/GUID-install-operator.html).
 
 ### <a id="set-up-namespace"></a> Set up the namespace
 
-This topic configures dynamic provisioning to provision all Tanzu Postgres service instances into the
+This topic configures dynamic provisioning to provision all postgres service instances into the
 same namespace. This namespace is named `tanzu-psql-service-instances`.
 
 To set up the namespace:
@@ -47,7 +47,7 @@ To set up the namespace:
     kubectl create namespace tanzu-psql-service-instances
     ```
 
-1. The Tanzu Postgres Operator also requires that a secret holding registry credentials exists in the
+1. The VMware SQL with Postgres Operator also requires that a secret holding registry credentials exists in the
    same namespace that the service instances will be created in.
    Ensure that the secret exists in the namespace by running:
 
@@ -322,7 +322,7 @@ To make the service discoverable to application teams:
       name: tanzu-psql
     spec:
       description:
-        short: VMware Tanzu Postgres
+        short: VMware SQL with Postgres
       provisioner:
         crossplane:
           compositeResourceDefinition: xpostgresqlinstances.database.tanzu.example.org
@@ -396,7 +396,7 @@ To configure access control with RBAC:
 
 ### <a id="verify"></a> Verify your configuration
 
-To verify your configuration, create a claim for a Tanzu Postgres service instance by running:
+To verify your configuration, create a claim for a postgres service instance by running:
 
 ```console
 tanzu service class-claim create tanzu-psql-1 --class tanzu-psql -p storageGB=5

--- a/services-toolkit/how-to-guides/index.hbs.md
+++ b/services-toolkit/how-to-guides/index.hbs.md
@@ -6,6 +6,6 @@ In this section:
 
 - [Authorize users and groups to claim from provisioner-based classes](authorize-claim-provisioner-classes.hbs.md)
 - [Configure dynamic provisioning of AWS RDS service instances](dynamic-provisioning-rds.hbs.md)
-- [Configure dynamic provisioning of VMware Tanzu Postgres service instances](dynamic-provisioning-tanzu-postgresql.hbs.md)
+- [Configure dynamic provisioning of VMware SQL with Postgres for Kubernetes service instances](dynamic-provisioning-tanzu-postgresql.hbs.md)
 - [Configure private registry and VMware Application Catalog (VAC) integration for Bitnami Services](../../bitnami-services/how-to-guides/configure-private-reg-integration.hbs.md)
 - [Troubleshooting and known limitations](troubleshooting.hbs.md)

--- a/services-toolkit/tutorials/abstracting-service-implementation.hbs.md
+++ b/services-toolkit/tutorials/abstracting-service-implementation.hbs.md
@@ -39,7 +39,7 @@ tailor the implementation of the PostgreSQL service to each of the clusters acco
 The `iterate` cluster has low level SLOs, so you want to offer an unmanaged PostgreSQL service backed by
 simple Helm chart.
 The `run-test` cluster has more robust requirements, so want to offer a PostgreSQL service backed
-by VMware Tanzu.
+by VMware SQL with Postgres for Kubernetes.
 The `run-production` cluster is critically important, so you want to use a fully managed,
 cloud-based PostgreSQL implementation there.
 
@@ -62,13 +62,13 @@ In this diagram:
 - In each cluster, the service operator creates a `ClusterInstanceClass` called postgres.
   - In the `iterate` cluster, this is a provisioner-based class that uses the services available in
     the Bitnami Services package to provision Helm instances of PostgreSQL.
-  - In the `run-test` cluster, this is a provisioner-based class that uses VMware Tanzu Postgres to
+  - In the `run-test` cluster, this is a provisioner-based class that uses VMware SQL with Postgres for Kubernetes to
     provision instances of PostgreSQL.
   - In the `run-production` cluster, this is a provisioner-based class that uses Amazon RDS to provision
     instances running in Amazon AWS RDS.
 - The app operator creates a `ClassClaim`. This is applied with a consuming workload.
   - When it is applied in `iterate` it resolves to a Helm chart instance.
-  - When it is promoted to `run-test` it resolves to a VMware Tanzu Postgres instance.
+  - When it is promoted to `run-test` it resolves to a VMware Postgres instance.
   - When it is promoted to `run-production` it resolves to an Amazon AWS RDS instance.
 - The definition of the `ClassClaim` remains identical across the clusters, which is easier for
   the application development team.
@@ -93,9 +93,9 @@ differing implementations of PostgreSQL depending on the cluster it is in.
 
 ### <a id="set-up-run-test"></a> Step 1: Set up the run-test cluster
 
-Configure the `run-test` cluster for dynamic provisioning of VMware Tanzu Postgres
+Configure the `run-test` cluster for dynamic provisioning of VMware Postgres
 service instances. To do that, see
-[Configure dynamic provisioning of VMware Tanzu Postgres service instances](../how-to-guides/dynamic-provisioning-tanzu-postgresql.hbs.md)
+[Configure dynamic provisioning of VMware SQL with Postgres for Kubernetes service instances](../how-to-guides/dynamic-provisioning-tanzu-postgresql.hbs.md)
 and complete the steps in the following sections only:
 
 1. [Install the Tanzu VMware Postgres Operator](../how-to-guides/dynamic-provisioning-tanzu-postgresql.hbs.md#install-postgres-operator)

--- a/services-toolkit/tutorials/setup-dynamic-provisioning.hbs.md
+++ b/services-toolkit/tutorials/setup-dynamic-provisioning.hbs.md
@@ -2,7 +2,7 @@
 
 In this Services Toolkit tutorial you learn how [service operators](../reference/terminology-and-user-roles.hbs.md#so)
 can set up a new, self-serve, and customized service for Tanzu Application Platform (commonly known as TAP).
-The example uses Tanzu RabbitMQ the service, but the steps and learnings can apply to almost any
+The example uses VMware RabbitMQ for Kubernetes, but the steps and learnings can apply to almost any
 other service.
 
 ## <a id="about"></a> About this tutorial
@@ -10,7 +10,7 @@ other service.
 **Target user role**:       Service Operator<br />
 **Complexity**:             Advanced<br />
 **Estimated time**:         60 minutes<br />
-**Topics covered**:         Dynamic Provisioning, Crossplane, Tanzu RabbitMQ Cluster Kubernetes
+**Topics covered**:         Dynamic Provisioning, Crossplane, VMware RabbitMQ for Kubernetes
 operator<br />
 **Learning outcomes**:      Ability to offer new, on-demand, and customized services in your
 Tanzu Application Platform clusters<br />

--- a/toc.hbs.md
+++ b/toc.hbs.md
@@ -482,7 +482,7 @@ docs.vmware.com is built.
       - [How-to guides](services-toolkit/how-to-guides/index.hbs.md)
           - [Authorize users and groups to claim from provisioner-based classes](services-toolkit/how-to-guides/authorize-claim-provisioner-classes.hbs.md)
           - [Configure dynamic provisioning of AWS RDS service instances](services-toolkit/how-to-guides/dynamic-provisioning-rds.hbs.md)
-          - [Configure dynamic provisioning of VMware Tanzu Postgres service instances](services-toolkit/how-to-guides/dynamic-provisioning-tanzu-postgresql.hbs.md)
+          - [Configure dynamic provisioning of VMware SQL with Postgres for Kubernetes service instances](services-toolkit/how-to-guides/dynamic-provisioning-tanzu-postgresql.hbs.md)
           - [Troubleshooting](services-toolkit/how-to-guides/troubleshooting.hbs.md)
       - [Reference](services-toolkit/reference/index.hbs.md)
           - [API Documentation](services-toolkit/reference/api/index.hbs.md)


### PR DESCRIPTION
## About

This PR updates naming from "VMware Tanzu RabbitMQ" to "VMware RabbitMQ for Kubernetes" and "VMware Tanzu Postgresql" to "VMware SQL with Postgres for Kubernetes"

Which other branches do you want a technical writer to cherry-pick this PR to (if any)? N/A