### PR TITLE
Learning Center: Command to get the image id dynamically 

### DIFF
--- a/learning-center/workshop-content/building-an-image.hbs.md
+++ b/learning-center/workshop-content/building-an-image.hbs.md
@@ -7,7 +7,7 @@ This topic explains how to include an extra system, third-party tool, or configu
 The structure of the `Dockerfile` in the sample workshop template is:
 
 ```text
-FROM registry.tanzu.vmware.com/tanzu-application-platform/tap-packages@sha256:a8870aa60b45495d298df5b65c69b3d7972608da4367bd6e69d6e392ac969dd4
+FROM registry.tanzu.vmware.com/tanzu-application-platform/tap-packages@sha256:xxxxxxxxxxxxxxxxxxxxxxx
 
 COPY --chown=1001:0 . /home/eduk8s/
 
@@ -18,22 +18,21 @@ RUN fix-permissions /home/eduk8s
 
 The default `Dockerfile` action is to:
 
-  - Copy all files from a registry to the `/home/eduk8s` directory. You must build the custom workshop images on the `registry.tanzu.vmware.com/tanzu-application-platform/tap-packages@sha256:a8870aa60b45495d298df5b65c69b3d7972608da4367bd6e69d6e392ac969dd4` workshop image. You can do this directly or you can also create an intermediate base image to install extra packages required by a number of different workshops. The `--chown=1001:0` option ensures that files are owned by the appropriate user and group.
+  - Copy all files from a registry to the `/home/eduk8s` directory. You must build the custom workshop images on the base environment image according to the TAP version. To get the image ID you should use the command:
+  
+  ```text 
+  kubectl get ds -n learningcenter learningcenter-prepull -o=jsonpath="{.spec.template.spec.initContainers[0].image}" 
+  ```
+
+  - That command will retrive the image id, E.g: `registry.tanzu.vmware.com/tanzu-application-platform/tap-packages@sha256:a8870aa60b45495d298df5b65c69b3d7972608da4367bd6e69d6e392ac969dd4`. 
+   
+   You can do this directly or you can also create an intermediate base image to install extra packages required by a number of different workshops. The `--chown=1001:0` option ensures that files are owned by the appropriate user and group.
   - The `workshop` subdirectory is moved to `/opt/workshop` so that it is not visible to the user. This subdirectory is in an area searchable for workshop content, in addition to `/home/eduk8s/workshop`.
 
 To customize your `Dockerfile`:
 
   - You can ignore other files or directories from the repository, by listing them in the `.dockerignore` file.
   - You can include `RUN` statements in the `Dockerfile` to run custom-build steps, but the `USER` inherited from the base image has user ID `1001` and is not the `root` user.
-
-## <a id="base-images-version-tags"></a>Base images and version tags
-
-The sample `Dockerfile` provided above and the GitHub repository workshop templates reference the workshop base image as follows:
-
-```text
-registry.tanzu.vmware.com/tanzu-application-platform/tap-packages@sha256:a8870aa60b45495d298df5b65c69b3d7972608da4367bd6e69d6e392ac969dd4
-```
-
 
 ## <a id="custom-workshop-base-imgs"></a>Custom workshop base images
 
@@ -44,7 +43,7 @@ The following Dockerfile example creates a Java JDK11-customized image:
 ```text
 ARG IMAGE_REPOSITORY=dev.registry.tanzu.vmware.com/learning-center
 FROM ${IMAGE_REPOSITORY}/pkgs-java-tools as java-tools
-FROM registry.tanzu.vmware.com/tanzu-application-platform/tap-packages@sha256:a8870aa60b45495d298df5b65c69b3d7972608da4367bd6e69d6e392ac969dd4
+FROM registry.tanzu.vmware.com/tanzu-application-platform/tap-packages@sha256:xxxxxxxxxxxxxxxxxx
 COPY --from=java-tools --chown=1001:0 /opt/jdk11 /opt/java
 COPY --from=java-tools --chown=1001:0 /opt/gradle /opt/gradle
 COPY --from=java-tools --chown=1001:0 /opt/maven /opt/maven


### PR DESCRIPTION
Changing the docs to use a way to get the image id dynamically on LC
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?  1-5-3, 1-4-7 and 1-3-10

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches 
