### PR TITLE
docs(app-sso): don't base64-encode the token signature key twice

### DIFF
--- a/app-sso/tutorials/service-operators/token-signature.hbs.md
+++ b/app-sso/tutorials/service-operators/token-signature.hbs.md
@@ -198,14 +198,10 @@ You can generate an RSA key yourself using OpenSSL. Here are the steps:
 2. Create a Secret resource by using the key generated earlier in this procedure:
 
    ```shell
-   # Base64 encode the key files
-   cat privatekey.pem | base64 > privatekey-base64.pem
-   cat publickey.pem | base64 > publickey-base64.pem
-   
    # Create Secret resource
    kubectl create secret generic my-key \
-    --from-file=key.pem=privatekey-base64.pem \
-    --from-file=pub.pem=publickey-base64.pem \
+    --from-file=key.pem=privatekey.pem \
+    --from-file=pub.pem=publickey.pem \
     --namespace default
    ```
 


### PR DESCRIPTION
# Target

`1.6.x`

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

This needs to be backported as far as AppSSO's documentation reaches. Ty! ❤️ 