### PR TITLE
Remove TKGs support for 1.6 for now

### DIFF
--- a/prerequisites.hbs.md
+++ b/prerequisites.hbs.md
@@ -101,18 +101,6 @@ providers:
     - vSphere
     - Baremetal
 - Tanzu Kubernetes Grid (commonly called TKG) multicloud. For more information, see [TKG documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html).
-- vSphere with Tanzu v8.0.1 or later.<br>
-For vSphere with Tanzu, you must configure pod security policies so Tanzu Application Platform controller pods can run as root.
-For more information, see [Kubernetes documentation](https://kubernetes.io/docs/concepts/policy/pod-security-policy/).
-
-    To set the pod security policies, run:
-
-    ```console
-    kubectl create clusterrolebinding default-tkg-admin-privileged-binding --clusterrole=psp:vmware-system-privileged --group=system:authenticated
-    ```
-
-    For more information about pod security policies on Tanzu for vSphere, see
-    [VMware vSphere Product Documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/vmware-vsphere-with-tanzu/GUID-CD033D1D-BAD2-41C4-A46F-647A560BAEAB.html).
 
 ## <a id="resource-requirements"></a>Resource requirements
 


### PR DESCRIPTION
Remove TKGs support for 1.6 for now as K8s 1.25 from TKGs(vsphere 8.0.x) are not concrete yet. Will add the support back once the GA of TKGs with k8s 1.25 happens.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
