### PR TITLE
Adds information about additional status fields for the API Descriptor

### DIFF
--- a/api-auto-registration/key-concepts.hbs.md
+++ b/api-auto-registration/key-concepts.hbs.md
@@ -125,7 +125,7 @@ To use an Ingress instead, here is an example from which your controller reads t
 
 When processing an APIDescriptor several fields are added to the `status`. One of these is `conditons`, which provide information useful for troubleshooting. The conditions are explained in the [Troubleshooting Guide](../api-auto-registration/troubleshooting.hbs.md).
 
-In addition to `conditions` the `status` contains a couple of other useful fields. Below you will a listing of these fields along with a brief explanation of what they contain.
+In addition to `conditions` the `status` contains a couple of other useful fields. Below you will find a listing of these fields along with a brief explanation of what they contain.
 
 ```yaml
 status:

--- a/api-auto-registration/key-concepts.hbs.md
+++ b/api-auto-registration/key-concepts.hbs.md
@@ -120,3 +120,16 @@ To use an Ingress instead, here is an example from which your controller reads t
         jsonPath: "{.spec.rules[1].host}"
         namespace: my-namespace # optional
 ```
+
+### <a id='status-fields'></a>APIDescriptor Status Fields
+
+When processing an APIDescriptor several fields are added to the `status`. One of these is `conditons`, which provide information useful for troubleshooting. The conditions are explained in the [Troubleshooting Guide](../api-auto-registration/troubleshooting.hbs.md).
+
+In addition to `conditions` the `status` contains a couple of other useful fields. Below you will a listing of these fields along with a brief explanation of what they contain.
+
+```yaml
+status:
+  registeredEntityURL:   # Url of the corresponding API Entity in TAP GUI
+  registeredTapUID:      # Unique identifier for the corresponding API Entity in TAP GUI
+  resolvedAPISpec:       # Full API Spec as retrieved by Api Auto Registration
+```


### PR DESCRIPTION
Adds information about additional status fields for the API Descriptor

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)? 1.3, 1.4, 1.5, 1.6

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
