### PR TITLE
Update URLs used for accelerator icon

### DIFF
--- a/application-accelerator/configuration.hbs.md
+++ b/application-accelerator/configuration.hbs.md
@@ -88,7 +88,7 @@ under the sub-path `spring-cloud-serverless`. For example:
 accelerator:
   displayName: Spring Cloud Serverless
   description: A simple Spring Cloud Function serverless app
-  iconUrl: https://raw.githubusercontent.com/simple-starters/icons/master/icon-cloud.png
+  iconUrl: https://raw.githubusercontent.com/vmware-tanzu/application-accelerator-samples/main/icons/icon-cloud.png
   tags:
   - java
   - spring
@@ -127,7 +127,7 @@ metadata:
 spec:
   displayName: My Spring Cloud Serverless
   description: My own Spring Cloud Function serverless app
-  iconUrl: https://raw.githubusercontent.com/simple-starters/icons/master/icon-cloud.png
+  iconUrl: https://raw.githubusercontent.com/vmware-tanzu/application-accelerator-samples/main/icons/icon-cloud.png
   tags:
     - spring
     - cloud
@@ -153,7 +153,7 @@ To use the Tanzu CLI, run:
 tanzu accelerator create my-spring-cloud-serverless --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --git-branch main --git-sub-path spring-cloud-serverless \
   --description "My own Spring Cloud Function serverless app" \
   --display-name "My Spring Cloud Serverless" \
-  --icon-url https://raw.githubusercontent.com/simple-starters/icons/master/icon-cloud.png \
+  --icon-url https://raw.githubusercontent.com/vmware-tanzu/application-accelerator-samples/main/icons/icon-cloud.png \
   --tags "spring,cloud,function,serverless"
 ```
 

--- a/application-accelerator/creating-accelerators/accelerator-yaml-sample.hbs.md
+++ b/application-accelerator/creating-accelerators/accelerator-yaml-sample.hbs.md
@@ -16,7 +16,7 @@ accelerator:
   description: Simple Hello World Rest Service based on Spring Boot
 
   # iconUrl: Optional, a nice colorful, icon for your accelerator to make it stand out visually.
-  iconUrl: https://raw.githubusercontent.com/simple-starters/icons/master/icon-cloud.png
+  iconUrl: https://raw.githubusercontent.com/vmware-tanzu/application-accelerator-samples/main/icons/icon-cloud.png
 
   # tags: A list of classification tags. The UI allows users to search for accelerators based on tags
   tags:

--- a/application-accelerator/creating-accelerators/accelerator-yaml.hbs.md
+++ b/application-accelerator/creating-accelerators/accelerator-yaml.hbs.md
@@ -20,7 +20,7 @@ For example:
 accelerator:
   displayName: Hello Fun
   description: A simple Spring Cloud Function serverless app
-  iconUrl: https://raw.githubusercontent.com/simple-starters/icons/master/icon-cloud.png
+  iconUrl: https://raw.githubusercontent.com/vmware-tanzu/application-accelerator-samples/main/icons/icon-cloud.png
   tags:
   - java
   - spring
@@ -198,7 +198,7 @@ You can also see the GitHub sample
 accelerator:
   displayName: Demo Input Types
   description: "Accelerator with options for each inputType"
-  iconUrl: https://raw.githubusercontent.com/simple-starters/icons/master/icon-cloud.png
+  iconUrl: https://raw.githubusercontent.com/vmware-tanzu/application-accelerator-samples/main/icons/icon-cloud.png
   tags: ["demo", "options"]
 
   options:

--- a/partials/application-accelerator/_configuration.hbs.md
+++ b/partials/application-accelerator/_configuration.hbs.md
@@ -86,7 +86,7 @@ under the sub-path `spring-cloud-serverless`. For example:
 accelerator:
   displayName: Spring Cloud Serverless
   description: A simple Spring Cloud Function serverless app
-  iconUrl: https://raw.githubusercontent.com/simple-starters/icons/master/icon-cloud.png
+  iconUrl: https://raw.githubusercontent.com/vmware-tanzu/application-accelerator-samples/main/icons/icon-cloud.png
   tags:
   - java
   - spring
@@ -125,7 +125,7 @@ metadata:
 spec:
   displayName: My Spring Cloud Serverless
   description: My own Spring Cloud Function serverless app
-  iconUrl: https://raw.githubusercontent.com/simple-starters/icons/master/icon-cloud.png
+  iconUrl: https://raw.githubusercontent.com/vmware-tanzu/application-accelerator-samples/main/icons/icon-cloud.png
   tags:
     - spring
     - cloud
@@ -151,7 +151,7 @@ To use the Tanzu CLI, run:
 tanzu accelerator create my-spring-cloud-serverless --git-repo https://github.com/vmware-tanzu/application-accelerator-samples --git-branch main --git-sub-path spring-cloud-serverless \
   --description "My own Spring Cloud Function serverless app" \
   --display-name "My Spring Cloud Serverless" \
-  --icon-url https://raw.githubusercontent.com/simple-starters/icons/master/icon-cloud.png \
+  --icon-url https://raw.githubusercontent.com/vmware-tanzu/application-accelerator-samples/main/icons/icon-cloud.png \
   --tags "spring,cloud,function,serverless"
 ```
 


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches

- This is for 1.6.0 docs
- This change can safely be backported to older docs as well
    - this only changes the icon URL to use the current samples repo:
    ```
    -  iconUrl: https://raw.githubusercontent.com/simple-starters/icons/master/icon-cloud.png
    +  iconUrl: https://raw.githubusercontent.com/vmware-tanzu/application-accelerator-samples/main/icons/icon-cloud.png
    ```
