### PR TITLE
add arch=amd64 to apt setup

### DIFF
--- a/install-tanzu-cli.hbs.md
+++ b/install-tanzu-cli.hbs.md
@@ -132,7 +132,7 @@ Install using a package manager
          sudo apt-get update
          sudo apt-get install -y ca-certificates curl gpg
          curl -fsSL https://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub | sudo gpg --dearmor -o /etc/apt/keyrings/tanzu-archive-keyring.gpg
-         echo "deb [signed-by=/etc/apt/keyrings/tanzu-archive-keyring.gpg] https://storage.googleapis.com/tanzu-cli-os-packages/apt tanzu-cli-jessie main" | sudo tee /etc/apt/sources.list.d/tanzu.list
+         echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/tanzu-archive-keyring.gpg] https://storage.googleapis.com/tanzu-cli-os-packages/apt tanzu-cli-jessie main" | sudo tee /etc/apt/sources.list.d/tanzu.list
          sudo apt-get update
          sudo apt-get install -y tanzu-cli
 


### PR DESCRIPTION
In order to avoid the following warning from apt update command, the `arch=amd64` should be added to the `tanzu.list` file.

```
N: Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'https://storage.googleapis.com/tanzu-cli-os-packages/apt tanzu-cli-jessie InRelease' doesn't support architecture 'i386'
```
