### PR TITLE
[VSEE-1067] Remove metadataStore block

### DIFF
--- a/multicluster/reference/tap-values-build-sample.hbs.md
+++ b/multicluster/reference/tap-values-build-sample.hbs.md
@@ -43,14 +43,6 @@ ootb_supply_chain_testing_scanning: # Optional if the corresponding shared keys 
     repository: "REPO-NAME"
   gitops:
     ssh_secret: "SSH-SECRET-KEY" # (Optional) Defaults to "".
-metadataStore:
-  url: METADATA-STORE-URL-ON-VIEW-CLUSTER
-  caSecret:
-      name: store-ca-cert
-      importFromNamespace: metadata-store-secrets
-  authSecret:
-      name: store-auth-token
-      importFromNamespace: metadata-store-secrets
 scanning:
   metadataStore:
     url: "" # Configuration is moved, so set this string to empty.


### PR DESCRIPTION
Summary:
* Remove metadataStore block because it doesn't belong to any component in this tap-values.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
1.6

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
