### PR TITLE
Adds display name field for OpenID and SAML providers in AuthServer CR (TAP 1.7)

### DIFF
--- a/app-sso/how-to-guides/service-operators/identity-providers.hbs.md
+++ b/app-sso/how-to-guides/service-operators/identity-providers.hbs.md
@@ -44,6 +44,7 @@ spec:
     - name: my-oidc-provider
       openID:
         issuerURI: https://openid.example.com
+        displayName: "MyOIDC Provider"
         clientID: my-client-abcdef
         clientSecretRef:
           name: my-openid-client-secret
@@ -84,6 +85,7 @@ Where:
   curl -s "https://openid.example.com/.well-known/openid-configuration" | jq -r ".issuer"
   ```
 
+- `.openID.displayName` (optional): a user-friendly display name for the provider that is rendered on the login page.
 - `.openID.scopes`: The scopes requested to the issuer in the authorization request. Its value must contain `"openid"`. Other common `openID.scopes` values include `"profile"` and `"email"`.
 - `.openID.clientSecretRef`: The issuer's client secret. The value of `clientSecretRef` must be a `Secret` with the entry `clientSecret`.
 - `.openID.authorizationUri` (optional): The URI for performing an authorization request and obtaining an `authorization_code`.
@@ -606,13 +608,15 @@ spec:
   - name: my-saml-provider
     saml:
       metadataURI: https://saml.example.com/sso/saml/metadata # required
+      displayName: "My SAML provider" # optional
       idToken: # optional
         claims:
           - fromUpstream: "" # SAML attribute
             toClaim: ""      # claim that is part of an AppSSO id_token
 ```
 
-`.saml.idToken.claims` field allows for mapping a SAML attribute from an upstream SAML identity provider to the current authorization server. See [Identity token claims mapping](#id-token-claims-mapping) for more details.
+- `.saml.displayName` (optional): a user-friendly display name for the provider that is rendered on the login page.
+- `.saml.idToken.claims`: allows for mapping a SAML attribute from an upstream SAML identity provider to the current authorization server. See [Identity token claims mapping](#id-token-claims-mapping) for more details.
 
 ### <a id='saml-external-groups-mapping'></a> SAML external groups mapping
 

--- a/app-sso/reference/api/authserver.hbs.md
+++ b/app-sso/reference/api/authserver.hbs.md
@@ -81,7 +81,10 @@ spec:
         name: ""
   identityProviders: # optional
     # each must be one and only one of internalUnsafe, ldap, openID or saml
-    - name: "" # must be unique
+    - name: "" # > must be unique
+               # > must follow DNS Subdomain formatting (RFC 1123)
+               #    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+               # > must not start with 'client' or 'unknown'
       internalUnsafe: # requires annotation `sso.apps.tanzu.vmware.com/allow-unsafe-identity-provider: ""`
         users:
           - username: ""
@@ -103,7 +106,10 @@ spec:
               - fromRole: ""
                 toScopes:
                   - ""
-    - name: "" # must be unique
+    - name: "" # > must be unique
+               # > must follow DNS Subdomain formatting (RFC 1123)
+               #    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+               # > must not start with 'client' or 'unknown'
       ldap:
         server:
           scheme: ""
@@ -147,7 +153,10 @@ spec:
             subTree: false
             depth: 0
           roleAttribute: "" # deprecated, use 'ldap.roles.fromUpstream.attribute' instead.
-    - name: "" # must be unique
+    - name: "" # > must be unique
+               # > must follow DNS Subdomain formatting (RFC 1123)
+               #    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+               # > must not start with 'client' or 'unknown'
       openID:
         issuerURI: ""
         displayName: "" # optional, must be between 2 and 32 characters in length
@@ -174,7 +183,10 @@ spec:
               - fromRole: ""
                 toScopes:
                 - ""
-    - name: "" # must be unique
+    - name: "" # > must be unique
+               # > must follow DNS Subdomain formatting (RFC 1123)
+               #    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+               # > must not start with 'client' or 'unknown'
       saml:
         metadataURI: ""
         displayName: "" # optional, must be between 2 and 32 characters in length

--- a/app-sso/reference/api/authserver.hbs.md
+++ b/app-sso/reference/api/authserver.hbs.md
@@ -150,6 +150,7 @@ spec:
     - name: "" # must be unique
       openID:
         issuerURI: ""
+        displayName: "" # optional, must be between 2 and 32 characters in length
         clientID: ""
         clientSecretRef:
           name: ""
@@ -176,6 +177,7 @@ spec:
     - name: "" # must be unique
       saml:
         metadataURI: ""
+        displayName: "" # optional, must be between 2 and 32 characters in length
         roles: # optional
           fromUpstream:
             attribute: "" # required
@@ -428,6 +430,7 @@ spec:
     - name: okta
       openID:
         issuerURI: https://dev-xxxxxx.okta.com
+        displayName: "Okta"
         clientID: xxxxxxxxxxxxx
         clientSecretRef:
           name: okta-client-secret


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)? TAP 1.7 only

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
