### PR TITLE
Removing basic auth flow from gitops sops

### DIFF
--- a/install-gitops/sops.hbs.md
+++ b/install-gitops/sops.hbs.md
@@ -97,9 +97,9 @@ Follow these steps to create a new Git repository:
 
 1. In a hosted Git service, for example, GitHub or GitLab, create a new respository.
 
-    This version of Tanzu GitOps RI supports authenticating to a hosted Git repository by using SSH as well as Basic Authentication.
+    This version of Tanzu GitOps RI supports authenticating to a hosted Git repository by using SSH.
 
-1. Initialize a new Git repository:
+2. Initialize a new Git repository:
 
     ```console
     mkdir -p $HOME/tap-gitops
@@ -109,15 +109,10 @@ Follow these steps to create a new Git repository:
     git remote add origin git@github.com:my-organization/tap-gitops.git
     ```
 
-1. Set up the authentication method:
+3. Set up the authentication method:
 
     SSH
     : Create a read-only deploy key for this new repository (recommended) or SSH key for an account with read access to this repository. The private portion of this key is referred to as `GIT_SSH_PRIVATE_KEY`.
-
-    Basic Authentication
-    : Have a username with read access to the Git repository and password or personal access token for the same user.
-
-    >**Important** Only use one of `ssh` or `Basic Authentication`, not both.
 
 ## <a id='download-tanzu-gitops-ri'></a>Download and unpack Tanzu GitOps Reference Implementation (RI)
 
@@ -396,15 +391,11 @@ Follow these steps to populate `tap-sensitive-values.sops.yaml` with credentials
                 username: MY-REGISTRY-USER
                 password: MY-REGISTRY-PASSWORD
             git:
-                # Only use one of `ssh` or `basic_auth`, not both.
                 ssh:
                     private_key: |
                         PRIVATE-KEY
                     known_hosts: |
                         HOST-LIST
-                basic_auth:
-                    username: MY-GIT-USERNAME
-                    password: MY-GIT-PASSWORD
     ```
 
     Where:
@@ -415,8 +406,6 @@ Follow these steps to populate `tap-sensitive-values.sops.yaml` with credentials
     - `MY-REGISTRY-PASSWORD` is the password for `MY-REGISTRY-USER`.
     - `PRIVATE-KEY` is the contents of an SSH private key file with read access to your Git repository. Only applies when you use `ssh`.
     - `HOST-LIST` is the list of known hosts for Git host service. Only applies when you use `ssh`.
-    - `MY-GIT-USERNAME` is the user with read access to your Git repository. Only applies when you use `basic_auth`.
-    - `MY-GIT-PASSWORD` is the password or personal access token for `MY-GIT-USERNAME`. Only applies when you use `basic_auth`.
 
     You can find the schema for Tanzu Sync credentials in `<GIT-REPO-ROOT>/clusters/<CLUSTER-NAME>/tanzu-sync/app/config/.tanzu-managed/schema--sops.yaml`
 
@@ -428,6 +417,7 @@ Follow these steps to generate the Tanzu Application Platform installation and T
 
     ```console
     export TAP_PKGR_REPO=TAP-PACKAGE-OCI-REPOSITORY
+    export SOPS_AGE_KEY=AGE-KEY
     ```
 
     Where:
@@ -435,11 +425,13 @@ Follow these steps to generate the Tanzu Application Platform installation and T
     - `TAP-PACKAGE-OCI-REPOSITORY` is the fully-qualified path to the OCI repository hosting the Tanzu Application Platform images.
     If the images are relocated as described in [Relocate images to a registry](#relocate-images-to-a-registry),
     this value is `${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/tap-packages`.
+    - `AGE-KEY` is the contents of the Age key generated earlier.
 
     Example of the Git repo hosted on GitHub:
 
     ```console
     export TAP_PKGR_REPO=registry.tanzu.vmware.com/tanzu-application-platform/tap-packages
+    export SOPS_AGE_KEY=$(cat $HOME/tmp-enc/key.txt)
     ```
 
 1. Generate the Tanzu Application Platform install and the Tanzu Sync configuration files by using the provided script:


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
