### PR TITLE
[VSEE-1081] Fix broken link to security context info

### DIFF
--- a/scst-scan/app-scanning-troubleshooting.hbs.md
+++ b/scst-scan/app-scanning-troubleshooting.hbs.md
@@ -87,4 +87,5 @@ If you encounter a permission error for accessing, opening, and writing to the f
 unsuccessful cred copy: ".git-credentials" from "/tekton/creds" to "/home/app-scanning": unable to open destination: open /home/app-scanning/.git-credentials: permission denied
 ```
 
-Ensure that the problematic step runs with [proper user and group ids](#pod-template-security-context).
+Ensure that the problematic step runs with
+[proper user and group ids](./ivs-create-your-own.hbs.md#security-context-user-and-group-ids).

--- a/scst-scan/ivs-create-your-own.hbs.md
+++ b/scst-scan/ivs-create-your-own.hbs.md
@@ -59,7 +59,7 @@ To customize an ImageVulnerabilityScan to use your scanner:
 
     To pass `spec.image` and `scanResults.location` to `args`, you can use `$(params.image)` and `$(params.scan-results-path)`.
 
-### <a id="user-group-ids"></a> Security Context: User and Group IDs
+  ### <a id="user-group-ids"></a> Security Context: User and Group IDs
   Since volumes on a Tekton pipeline are shared amongst steps, files created by one step should be consumable by the other steps. Therefore the scan controller applies the following security context to `pipelinerun.spec.podTemplate`:
 
   ```

--- a/scst-scan/ivs-create-your-own.hbs.md
+++ b/scst-scan/ivs-create-your-own.hbs.md
@@ -1,8 +1,7 @@
 # Bring your own scanner using an ImageVulnerabilityScan
 
 This topic tells you how to bring your own scanning using an `ImageVulnerabilityScan`.
-An `ImageVulnerabilityScan` allows you to scan with any scanner by defining your scan as a 
-[Tekton step](https://tekton.dev/docs/pipelines/tasks/#defining-steps).
+An `ImageVulnerabilityScan` allows you to scan with any scanner by defining your scan as a [Tekton step](https://tekton.dev/docs/pipelines/tasks/#defining-steps).
 
 ## <a id="sample-img-vuln"></a> Customize an ImageVulnerabilityScan
 
@@ -60,15 +59,16 @@ To customize an ImageVulnerabilityScan to use your scanner:
 
     To pass `spec.image` and `scanResults.location` to `args`, you can use `$(params.image)` and `$(params.scan-results-path)`.
 
-    Since volumes on a Tekton pipeline are shared amongst steps, files created by one step should be consumable by the other steps. Therefore the scan controller applies the following security context to `pipelinerun.spec.podTemplate`:
+### <a id="user-group-ids"></a> Security Context: User and Group IDs
+  Since volumes on a Tekton pipeline are shared amongst steps, files created by one step should be consumable by the other steps. Therefore the scan controller applies the following security context to `pipelinerun.spec.podTemplate`:
 
-    ```
-    runAsUser: 65534
-    fsGroup: 65534
-    runAsGroup: 65534
-    ```
+  ```
+  runAsUser: 65534
+  fsGroup: 65534
+  runAsGroup: 65534
+  ```
 
-    The `SCANNER-IMAGE` runs and manipulates files with user and group ids of `65534`.
+  The `SCANNER-IMAGE` runs and manipulates files with user and group ids of `65534`.
 
 ## <a id="img-vuln-config-options"></a> Configuration options
 


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
1.6.1 (aka main for now)

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
