### PR TITLE
[VSEE-1117] Add release notes for supply chain bug 1.6.1 with hardcoded clusterimagetemplate

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -527,6 +527,12 @@ This release has the following known issues, listed by component and area.
 #### <a id='1-6-1-scc-ki'></a> Supply Chain Choreographer
 
 - If the size of the resulting OpenAPIv3 specification exceeds a certain size, roughly 3KB, the Supply Chain does not function. If the operator is using the default Carvel Package parameters, they are fine with this value enabled. If they use custom Carvel Package parameters, they might run into this size limit. If they exceed the size limit, they can either deactivate this feature, or use a workaround. The workaround requires enabling a Tekton feature flag. See the [Tekton documentation](https://tekton.dev/docs/pipelines/additional-configs/#enabling-larger-results-using-sidecar-logs).
+- If a user attempts to update the `ootb_supply_chain_testing_scanning` field in their `tap-values.yaml` file to use a specified ClusterImageTemplate:
+  ```
+  ootb_supply_chain_testing_scanning:
+    image_scanner_template_name: CLUSTERIMAGETEMPLATE
+  ```
+  The ClusterSupplyChain `scanning-image-scan-to-url` cannot update because the ClusterSupplyChain is preset to `image-scanner-template`. The workaround is to create another ClusterSupplyChain that uses the intended ClusterImageTemplate.
 
 #### <a id='1-6-1-tap-gui-ki'></a> Tanzu Developer Portal (formerly named Tanzu Application Platform GUI)
 

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -532,7 +532,7 @@ This release has the following known issues, listed by component and area.
   ootb_supply_chain_testing_scanning:
     image_scanner_template_name: CLUSTERIMAGETEMPLATE
   ```
-  The ClusterSupplyChain `scanning-image-scan-to-url` cannot update because the ClusterSupplyChain is preset to `image-scanner-template`. The workaround is to create another ClusterSupplyChain that uses the intended ClusterImageTemplate.
+  The ClusterSupplyChain `scanning-image-scan-to-url` will not update because the ClusterSupplyChain is preset to `image-scanner-template`. The workaround is to modify the Out of the Box Supply template following the steps [here](./scc/authoring-supply-chains.hbs.md#modifying-an-out-of-the-box-supply-template).
 
 #### <a id='1-6-1-tap-gui-ki'></a> Tanzu Developer Portal (formerly named Tanzu Application Platform GUI)
 


### PR DESCRIPTION
Not sure why the preview in this MR doesn't work but it does here in my repo branch https://github.com/pivotal/docs-tap/compare/main...rxl7906:docs-tap:VSEE-1117?short_path=9707337#diff-9707337ff7669eeeef77ed0ea8d0331063a18d427f3a85ac04244bd8faa19979

The workaround has been tested in an SSP env and works.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
1.6.1 (aka main)

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
