### PR TITLE
updated OpenShift versions

### DIFF
--- a/install-openshift/profile.hbs.md
+++ b/install-openshift/profile.hbs.md
@@ -324,9 +324,9 @@ service's External IP address.
     * Harbor has the form `kp_default_repository: "my-harbor.io/my-project/build-service"`.
     * Docker Hub has the form `kp_default_repository: "my-dockerhub-user/build-service"` or `kp_default_repository: "index.docker.io/my-user/build-service"`.
     * Google Cloud Registry has the form `kp_default_repository: "gcr.io/my-project/build-service"`.
-- `K8S-VERSION` is the Kubernetes version used by your OpenShift cluster. It must be in the form of `1.24.x` or `1.25.x`, where `x` stands for the patch version. Examples:
-    - Red Hat OpenShift Container Platform v4.11 uses the Kubernetes version `1.24.1`.
+- `K8S-VERSION` is the Kubernetes version used by your OpenShift cluster. It must be in the form of `1.25.x` or `1.26.x`, where `x` stands for the patch version. Examples:
     - Red Hat OpenShift Container Platform v4.12 uses the Kubernetes version `1.25.2`.
+    - Red Hat OpenShift Container Platform v4.13 uses the Kubernetes version `1.26.3`.
 - `SERVER-NAME` is the host name of the registry server. Examples:
     * Harbor has the form `server: "my-harbor.io"`.
     * Docker Hub has the form `server: "index.docker.io"`.


### PR DESCRIPTION
updated OpenShift versions

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)? 1.6.1 and Main.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
