### PR TITLE
Update Spring Cloud Gateway install command

### DIFF
--- a/spring-cloud-gateway/install-spring-cloud-gateway.hbs.md
+++ b/spring-cloud-gateway/install-spring-cloud-gateway.hbs.md
@@ -60,7 +60,7 @@ Default values
 
     ```console
     tanzu package install spring-cloud-gateway \
-      --package-name spring-cloud-gateway.tanzu.vmware.com \
+      --package spring-cloud-gateway.tanzu.vmware.com \
       --version VERSION-NUMBER \
       --namespace tap-install
     ```
@@ -69,7 +69,7 @@ Default values
 
     ```console
     $ tanzu package install spring-cloud-gateway \
-        --package-name spring-cloud-gateway.tanzu.vmware.com \
+        --package spring-cloud-gateway.tanzu.vmware.com \
         --version 2.0.0 \
         --namespace tap-install
 
@@ -91,7 +91,7 @@ Overriding values
 
     ```console
     tanzu package install spring-cloud-gateway \
-      --package-name spring-cloud-gateway.tanzu.vmware.com \
+      --package spring-cloud-gateway.tanzu.vmware.com \
       --version VERSION-NUMBER \
       --namespace tap-install \
       --values-file values.yml


### PR DESCRIPTION
In Tanzu CLI v0.90.0 --package-name got removed in favor of --package

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It should be backported to 1.6 and 1.5 as well.
Perhaps the docs team wants to verify if other parts of the documentation are also out of date in regard to this parameter.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
