### PR TITLE
appsso: clarify response_type code with CORS

### DIFF
--- a/app-sso/how-to-guides/app-operators/secure-spa-workload.hbs.md
+++ b/app-sso/how-to-guides/app-operators/secure-spa-workload.hbs.md
@@ -56,6 +56,9 @@ Follow these steps to fetch the single-page Angular app source code:
     git push origin main -u
     ```
 
+>**Note:** For public clients, the `Authserver` **only** supports `response_type=code` ("Authorization Code Flow")
+> because public clients (single page apps) cannot safely store sensitive information like client secrets.
+
 1. Push the resulting directory to the remote Git repository.
 
 ## <a id='create-namespace'></a> Create a namespace for workloads

--- a/app-sso/how-to-guides/service-operators/cors.hbs.md
+++ b/app-sso/how-to-guides/service-operators/cors.hbs.md
@@ -90,6 +90,9 @@ Public clients supporting Authorization Code with PKCE flow ensure that:
   Public clients do not provide a Client Secret because they are not tailored to
   retain any secrets in public view.
 
+>**Note:** For public clients, the `Authserver` **only** supports `response_type=code` ("Authorization Code Flow")
+> because public clients cannot safely store sensitive information like client secrets.
+
 ## <a id="refs"></a>References
 
 - [Proof Key for Code Exchange (PKCE) specification](https://www.rfc-editor.org/rfc/rfc7636.html).


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

- 1.5.3
- 1.4.8
- 1.4.7

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
