### PR TITLE
Fix incorrect TBS full deps docs

### DIFF
--- a/install-aws/profile.hbs.md
+++ b/install-aws/profile.hbs.md
@@ -382,11 +382,13 @@ you must install the `full` dependencies package.
 1. Create an ECR repository for Tanzu Build Service full dependencies by running:
 
     ```console
-    aws ecr create-repository --repository-name tbs-full-deps --region ${AWS_REGION}
+    aws ecr create-repository --repository-name full-deps-package-repo --region ${AWS_REGION}
     ```
 
 1. (Optional) If you have an existing installation of the full dependencies package from a version
 earlier than Tanzu Application Platform v{{ vars.tap_version }}, you must uninstall the full dependencies package and remove the package repository:
+
+    Note: These names may differ depending on your install
 
     Uninstall the package:
 
@@ -425,8 +427,8 @@ earlier than Tanzu Application Platform v{{ vars.tap_version }}, you must uninst
 1. Relocate the Tanzu Build Service full dependencies package repository by running:
 
     ```console
-    imgpkg copy -b registry.tanzu.vmware.com/tanzu-application-platform/full-tbs-deps-package-repo:VERSION \
-      --to-repo ${INSTALL_REGISTRY_HOSTNAME}/tbs-full-deps
+    imgpkg copy -b registry.tanzu.vmware.com/tanzu-application-platform/full-deps-package-repo:VERSION \
+      --to-repo ${INSTALL_REGISTRY_HOSTNAME}/full-deps-package-repo
     ```
 
     Where `VERSION` is the version of the `tap` package you retrieved in the previous step.
@@ -434,8 +436,8 @@ earlier than Tanzu Application Platform v{{ vars.tap_version }}, you must uninst
 1. Add the Tanzu Build Service full dependencies package repository by running:
 
     ```console
-    tanzu package repository add full-deps-repository \
-      --url ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/full-deps:VERSION \
+    tanzu package repository add full-deps-package-repo \
+      --url ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/full-deps-package-repo:VERSION \
       --namespace tap-install
     ```
 
@@ -444,7 +446,7 @@ earlier than Tanzu Application Platform v{{ vars.tap_version }}, you must uninst
 1. Install the full dependencies package by running:
 
     ```console
-    tanzu package install full-deps -p full-deps.buildservice.tanzu.vmware.com -v "> 0.0.0" -n tap-install --values-file PATH-TO-TAP-VALUES
+    tanzu package install full-deps -p full-deps.buildservice.tanzu.vmware.com -v "> 0.0.0" -n tap-install --values-file PATH-TO-TAP-VALUES-FILE
     ```
 
 For more information about the differences between `lite` and `full` dependencies, see

--- a/install-aws/resources.hbs.md
+++ b/install-aws/resources.hbs.md
@@ -298,7 +298,7 @@ cat << EOF > build-service-policy.json
                 "ecr:SetRepositoryPolicy"
             ],
             "Resource": [
-                "arn:aws:ecr:${AWS_REGION}:${AWS_ACCOUNT_ID}:repository/tbs-full-deps",
+                "arn:aws:ecr:${AWS_REGION}:${AWS_ACCOUNT_ID}:repository/full-deps-package-repo",
                 "arn:aws:ecr:${AWS_REGION}:${AWS_ACCOUNT_ID}:repository/tap-build-service",
                 "arn:aws:ecr:${AWS_REGION}:${AWS_ACCOUNT_ID}:repository/tap-images"
             ],
@@ -366,7 +366,7 @@ cat << EOF > workload-policy.json
                 "ecr:SetRepositoryPolicy"
             ],
             "Resource": [
-                "arn:aws:ecr:${AWS_REGION}:${AWS_ACCOUNT_ID}:repository/tbs-full-deps",
+                "arn:aws:ecr:${AWS_REGION}:${AWS_ACCOUNT_ID}:repository/full-deps-package-repo",
                 "arn:aws:ecr:${AWS_REGION}:${AWS_ACCOUNT_ID}:repository/tanzu-application-platform/*"
             ],
             "Effect": "Allow",

--- a/install-azure/profile.hbs.md
+++ b/install-azure/profile.hbs.md
@@ -400,26 +400,26 @@ To install the `full` dependencies package:
     ...
     ```
 
-1. Get the latest version of the `buildservice` package by running:
+1. Get the latest version of the `tap` package by running:
 
     ```console
-    tanzu package available list buildservice.tanzu.vmware.com --namespace tap-install
+    tanzu package available list tap.tanzu.vmware.com --namespace tap-install
     ```
 
 1. Relocate the Tanzu Build Service full dependencies package repository by running:
 
     ```console
-    imgpkg copy -b registry.tanzu.vmware.com/tanzu-application-platform/full-tbs-deps-package-repo:VERSION \
-      --to-repo ${INSTALL_REGISTRY_HOSTNAME}/tbs-full-deps
+    imgpkg copy -b registry.tanzu.vmware.com/tanzu-application-platform/full-deps-package-repo:VERSION \
+      --to-repo ${INSTALL_REGISTRY_HOSTNAME}/full-deps-package-repo
     ```
 
-    Where `VERSION` is the version of the `buildservice` package you retrieved in the previous step.
+    Where `VERSION` is the version of the `tap` package you retrieved in the previous step.
 
 1. Add the Tanzu Build Service full dependencies package repository by running:
 
     ```console
-    tanzu package repository add tbs-full-deps-repository \
-      --url ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/tbs-full-deps:VERSION \
+    tanzu package repository add full-deps-package-repo \
+      --url ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/full-deps-package-repo:VERSION \
       --namespace tap-install
     ```
 
@@ -428,10 +428,8 @@ To install the `full` dependencies package:
 1. Install the full dependencies package by running:
 
     ```console
-    tanzu package install full-tbs-deps -p full-tbs-deps.tanzu.vmware.com -v VERSION -n tap-install
+    tanzu package install full-deps -p full-deps.buildservice.tanzu.vmware.com -v "> 0.0.0" -n tap-install --values-file PATH-TO-TAP-VALUES-FILE
     ```
-
-    Where `VERSION` is the version of the `buildservice` package you retrieved earlier.
 
 ## <a id='access-tap-gui'></a> Access Tanzu Developer Portal
 

--- a/install-offline/tbs-offline-install-deps.hbs.md
+++ b/install-offline/tbs-offline-install-deps.hbs.md
@@ -5,7 +5,7 @@ on Tanzu Application Platform (commonly known as TAP).
 
 <!-- The below partial is in the docs-tap/partials directory -->
 
-{{> 'partials/full-deps' find_tap_version="1. Get the latest version of the Tanzu Build Service package by running:
+{{> 'partials/full-deps' find_tap_version="1. Get the latest version of the TAP package by running:
 
     ```console
     tanzu package available list tap.tanzu.vmware.com --namespace tap-install

--- a/install-online/profile.hbs.md
+++ b/install-online/profile.hbs.md
@@ -600,7 +600,7 @@ earlier than Tanzu Application Platform v1.6.1, you must uninstall the full depe
 
     ```console
     imgpkg copy -b registry.tanzu.vmware.com/tanzu-application-platform/full-deps-package-repo:VERSION \
-      --to-repo ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/full-deps
+      --to-repo ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/full-deps-package-repo
     ```
 
     Where `VERSION` is the version of the `tap` package you retrieved in the previous step.
@@ -608,8 +608,8 @@ earlier than Tanzu Application Platform v1.6.1, you must uninstall the full depe
 1. Add the Tanzu Build Service full dependencies package repository by running:
 
     ```console
-    tanzu package repository add full-deps-repository \
-      --url ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/full-deps:VERSION \
+    tanzu package repository add full-deps-package-repo \
+      --url ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/full-deps-package-repo:VERSION \
       --namespace tap-install
     ```
 
@@ -618,7 +618,7 @@ earlier than Tanzu Application Platform v1.6.1, you must uninstall the full depe
 1. Install the full dependencies package by running:
 
     ```console
-    tanzu package install full-deps -p full-deps.buildservice.tanzu.vmware.com -v "> 0.0.0" -n tap-install --values-file PATH-TO-TAP-VALUES
+    tanzu package install full-deps -p full-deps.buildservice.tanzu.vmware.com -v "> 0.0.0" -n tap-install --values-file PATH-TO-TAP-VALUES-FILE
     ```
 
 For more information about the differences between `lite` and `full` dependencies, see

--- a/install-openshift/profile.hbs.md
+++ b/install-openshift/profile.hbs.md
@@ -489,38 +489,36 @@ To install the `full` dependencies package:
       ...
     ```
 
-1. Get the latest version of the `buildservice` package by running:
+1. Get the latest version of the `tap` package by running:
 
     ```console
-    tanzu package available list buildservice.tanzu.vmware.com --namespace tap-install
+    tanzu package available list tap.tanzu.vmware.com --namespace tap-install
     ```
 
 1. Relocate the Tanzu Build Service full dependencies package repository by running:
 
     ```console
-    imgpkg copy -b registry.tanzu.vmware.com/tanzu-application-platform/full-tbs-deps-package-repo:VERSION \
-      --to-repo ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/tbs-full-deps
+    imgpkg copy -b registry.tanzu.vmware.com/tanzu-application-platform/full-deps-package-repo:VERSION \
+      --to-repo ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/full-deps-package-repo
     ```
 
-    Where `VERSION` is the version of the `buildservice` package you retrieved in the previous step.
+    Where `VERSION` is the version of the `tap` package you retrieved in the previous step.
 
 1. Add the Tanzu Build Service full dependencies package repository by running:
 
     ```console
-    tanzu package repository add tbs-full-deps-repository \
-      --url ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/tbs-full-deps:VERSION \
+    tanzu package repository add full-deps-package-repo \
+      --url ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/full-deps-package-repo:VERSION \
       --namespace tap-install
     ```
 
-    Where `VERSION` is the version of the `buildservice` package you retrieved earlier.
+    Where `VERSION` is the version of the `tap` package you retrieved earlier.
 
 1. Install the full dependencies package by running:
 
     ```console
-    tanzu package install full-tbs-deps -p full-tbs-deps.tanzu.vmware.com -v VERSION -n tap-install
+    tanzu package install full-deps -p full-deps.buildservice.tanzu.vmware.com -v "> 0.0.0" -n tap-install --values-file PATH-TO-TAP-VALUES-FILE
     ```
-
-    Where `VERSION` is the version of the `buildservice` package you retrieved earlier.
 
 ## <a id='access-tap-gui'></a> Access Tanzu Developer Portal
 

--- a/partials/_full-deps.hbs.md
+++ b/partials/_full-deps.hbs.md
@@ -12,10 +12,10 @@ To install `full` dependencies:
 
     ```console
     imgpkg copy -b registry.tanzu.vmware.com/tanzu-application-platform/full-deps-package-repo:VERSION \
-      --to-tar=tbs-full-deps.tar
-    # move tbs-full-deps.tar to environment with registry access
-    imgpkg copy --tar tbs-full-deps.tar \
-      --to-repo=INSTALL-REGISTRY-HOSTNAME/TARGET-REPOSITORY/tbs-full-deps
+      --to-tar=full-deps-package-repo.tar
+    # move full-deps-package-repo.tar to environment with registry access
+    imgpkg copy --tar full-deps-package-repo.tar \
+      --to-repo=INSTALL-REGISTRY-HOSTNAME/TARGET-REPOSITORY/full-deps-package-repo
     ```
 
     Where:
@@ -27,8 +27,8 @@ To install `full` dependencies:
 1. Add the Tanzu Build Service `full` dependencies package repository by running:
 
     ```console
-    tanzu package repository add tbs-full-deps-repository \
-      --url INSTALL-REGISTRY-HOSTNAME/TARGET-REPOSITORY/tbs-full-deps:VERSION \
+    tanzu package repository add full-deps-package-repo \
+      --url INSTALL-REGISTRY-HOSTNAME/TARGET-REPOSITORY/full-deps-package-repo:VERSION \
       --namespace tap-install
     ```
 
@@ -41,5 +41,5 @@ To install `full` dependencies:
 1. Install the `full` dependencies package by running:
 
     ```console
-    tanzu package install full-tbs-deps -p full-deps.buildservice.tanzu.vmware.com -v "> 0.0.0" -n tap-install --values-file PATH-TO-TAP-VALUES-FILE
+    tanzu package install full-deps -p full-deps.buildservice.tanzu.vmware.com -v "> 0.0.0" -n tap-install --values-file PATH-TO-TAP-VALUES-FILE
     ```

--- a/upgrading.hbs.md
+++ b/upgrading.hbs.md
@@ -131,7 +131,7 @@ Subsequent upgrades will not require a removal:
 
     ```console
     imgpkg copy -b registry.tanzu.vmware.com/tanzu-application-platform/full-deps-package-repo:VERSION \
-    --to-repo ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/tbs-full-deps
+    --to-repo ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/full-deps-package-repo
     ```
 
     Where `VERSION` is the version of the Tanzu Application Platform package you retrieved in the previous step.
@@ -139,15 +139,17 @@ Subsequent upgrades will not require a removal:
 3. Update the Tanzu Build Service  `full` dependencies package repository by running:
 
     ```console
-    tanzu package repository add full-deps-repository \
-      --url ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/tbs-full-deps:VERSION \
+    tanzu package repository add full-deps-package-repo \
+      --url ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REPO}/full-deps-package-repo:VERSION \
       --namespace tap-install
     ```
 
 4. Update the `full` dependencies package by running:
+    
+  NOTE: The values file is only needed for this command if you are installing this package for the first time or if the values have changed  
 
     ```console
-    tanzu package installed update full-deps -p full-deps.buildservice.tanzu.vmware.com -v VERSION -n tap-install
+    tanzu package install full-deps -p full-deps.buildservice.tanzu.vmware.com -v "> 0.0.0" -n tap-install --values-file PATH-TO-TAP-VALUES-FILE
     ```
 
 ### <a id="upgrade-order"></a> Multicluster upgrade order


### PR DESCRIPTION
This should be brought back to 1.6.1 and carried forward to all future versions. The current instructions will result in install failures and need to be replaced.