### PR TITLE
adding support for TKGs with vSphere 8.0.1c

### DIFF
--- a/prerequisites.hbs.md
+++ b/prerequisites.hbs.md
@@ -102,6 +102,18 @@ providers:
     - vSphere
     - Baremetal
 - Tanzu Kubernetes Grid (commonly called TKG) with Standalone Management Cluster. For more information, see [TKG documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html).
+- vSphere with Tanzu v8.0.1c or later (with TAP 1.6.2 onwards).
+    - For vSphere with Tanzu, you must configure pod security policies so Tanzu Application Platform controller pods can run as root. 
+    For more information, see [Kubernetes documentation](https://kubernetes.io/docs/concepts/policy/pod-security-policy/).
+
+        To set the pod security policies, run:
+
+        ```console
+        kubectl create clusterrolebinding default-tkg-admin-privileged-binding --clusterrole=psp:vmware-system-privileged --group=system:authenticated
+        ```
+
+        For more information about pod security policies on Tanzu for vSphere, see
+        [VMware vSphere Product Documentation](https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-with-tanzu-tkg/GUID-3B7F5B44-E31D-4819-B166-C531D4ECAE7D.html).
 
 ## <a id="resource-requirements"></a>Resource requirements
 


### PR DESCRIPTION
adding support for TKGs with vSphere 8.0.1c as TKGs now supports k8s 1.25.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)? only into 1.6.2 docs.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
