### PR TITLE
[1.6.x] Align gitops upgrade commit version with {{ vars.tap_version }}

### DIFF
--- a/install-gitops/upgrading.hbs.md
+++ b/install-gitops/upgrading.hbs.md
@@ -106,7 +106,7 @@ Follow these steps to upgrade to the latest patch:
 1. Commit the upgrade configurations:
 
     ```console
-    git add . && git commit -m "Upgrade TAP to version 1.6.1"
+    git add . && git commit -m "Upgrade TAP to {{ vars.tap_version }}"
     git push
     ```
 


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
