### PR TITLE
TAP 1.6.3 - modernize Tanzu CLI & plugin install to 1.0.0

### DIFF
--- a/install-tanzu-cli.hbs.md
+++ b/install-tanzu-cli.hbs.md
@@ -237,8 +237,10 @@ Install from a binary release
 
 There are a specific set of Tanzu CLI plugins which extend the Tanzu CLI Core with TAP-specific feature functionality.</br>
 These TAP-specific plugins can be installed as a group with a single command.</br>
-Versioned releases of the TAP-specific plugin group are available to supported each supported TAP release line 
+Versioned releases of the TAP-specific plugin group align to each supported TAP release line 
 so it's easy to switch between target TAP environments running different versions of the platform.
+
+The following commands can be utlized to search for, install, and verify Tanzu CLI plugin groups.
 
 The following commands can be utlized to search for, install, and verify Tanzu CLI plugin groups.
 

--- a/install-tanzu-cli.hbs.md
+++ b/install-tanzu-cli.hbs.md
@@ -240,10 +240,14 @@ These TAP-specific plugins can be installed as a group with a single command.</b
 Versioned releases of the TAP-specific plugin group are available to supported each supported TAP release line 
 so it's easy to switch between target TAP environments running different versions of the platform.
 
-The following commands can be utlized to search
+The following commands can be utlized to search for, install, and verify Tanzu CLI plugin groups.
 
 
-* List all TAP plugin group releases
+* List the versions of each plugin group available across Tanzu:
+    ```
+    tanzu plugin group search --show-details
+    ```
+* List the versions of the TAP-specific plugin group:
   ```console
   tanzu plugin group search --name vmware-tanzu/default --show-details
   ```
@@ -251,11 +255,7 @@ The following commands can be utlized to search
   ```console
   tanzu plugin install --group vmware-tap/default:v{{ vars.tap_version }}
   ```
-* List the plugins in group `v{{ vars.tap_version }}`
-  ```console
-  tanzu plugin group get vmware-tap/default:v{{ vars.tap_version }}
-  ```
-* Verify the plugin group list against the installed plugin list
+* Verify the plugin group list against the plugins that were installed
   ```console
   tanzu plugin group get vmware-tap/default:v{{ vars.tap_version }}
   ```
@@ -265,6 +265,7 @@ The following commands can be utlized to search
   
 For air-gapped installation, see the [Installing the Tanzu CLI in Internet-Restricted Environments](https://docs.vmware.com/en/VMware-Tanzu-CLI/{{ vars.tanzu-cli.url_version }}/tanzu-cli/index.html#internet-restricted-install) section of the Tanzu CLI
 documentation.
+
 
 ## Next steps
 

--- a/install-tanzu-cli.hbs.md
+++ b/install-tanzu-cli.hbs.md
@@ -244,9 +244,9 @@ The following commands can be utlized to search for, install, and verify Tanzu C
 
 
 * List the versions of each plugin group available across Tanzu:
-    ```
-    tanzu plugin group search --show-details
-    ```
+  ```console
+  tanzu plugin group search --show-details
+  ```
 * List the versions of the TAP-specific plugin group:
   ```console
   tanzu plugin group search --name vmware-tanzu/default --show-details

--- a/install-tanzu-cli.hbs.md
+++ b/install-tanzu-cli.hbs.md
@@ -72,21 +72,11 @@ To set the Kubernetes cluster context:
 The Tanzu CLI and plug-ins enable you to install and use the Tanzu Application Platform functions
 and features.
 
- From Tanzu Application Platform v{{ vars.tap_version }} and later, the Tanzu CLI and the CLI plug-ins
-required to interact with Tanzu Application Platform are released and distributed independently
-from Tanzu Application Platform itself.
-
-## <a id='cli-and-plugin'></a> Install or update the Tanzu CLI and plug-ins
-
-The Tanzu CLI and plug-ins enable you to install and use the Tanzu Application Platform functions
-and features.
-
 ### <a id="install-cli"></a> Install the Tanzu CLI
 
-Tanzu CLI core v1.0.0 is compatible with all releases of Tanzu Application Platform under support.
-Although the recommended approach for installing the CLI is via package manager (Chocolatey, 
-Homebrew, APT, YUM, and DNF are supported), compliance-forward customers can download and install Tanzu 
-CLI binary manually from Tanzu Network or VMware Customer Connect.
+The Tanzu CLI core v1.0.0 distributed with this release is forward and backward compatible with all releases of Tanzu Application Platform under support. Users can now run a single command to install the plugin group version matching the TAP release installed on any target TAP environment (see [Install Plugins](#install-plugins) for more information).
+
+Tanzu CLI is installable on Windows, Mac, or Linux OS via package manager and can also be downloaded and installed manually from Tanzu Network,  VMware Customer Connect, or GitHub.
 
 Basic installation instructions are provided below. For more information including how to install
 the Tanzu CLI and CLI plug-ins in Internet-restricted environments, see the 
@@ -166,7 +156,7 @@ Install using a package manager
       ```
 
 Install from a binary release
-: Complete the following steps:
+: To install the Tanzu CLI from a binary release:
   
   1. Download the Tanzu CLI binary from one of the following locations:
      * **VMware Tanzu Network**
@@ -245,13 +235,34 @@ Install from a binary release
 
 ### <a id="install-plugins"></a> Install Tanzu CLI Plug-ins
 
-For online installation, run the following command to install the CLI plug-ins required
-for Tanzu Application Platform:
+There are a specific set of Tanzu CLI plugins which extend the Tanzu CLI Core with TAP-specific feature functionality.</br>
+These TAP-specific plugins can be installed as a group with a single command.</br>
+Versioned releases of the TAP-specific plugin group are available to supported each supported TAP release line 
+so it's easy to switch between target TAP environments running different versions of the platform.
 
-```console
-tanzu plugin install --group vmware-tap/default:v{{ vars.tap_version }}
-```
+The following commands can be utlized to search
 
+
+* List all TAP plugin group releases
+  ```console
+  tanzu plugin group search --name vmware-tanzu/default --show-details
+  ```
+* Install the version of the TAP plugin group matching your target environment, e.g. 
+  ```console
+  tanzu plugin install --group vmware-tap/default:v{{ vars.tap_version }}
+  ```
+* List the plugins in group `v{{ vars.tap_version }}`
+  ```console
+  tanzu plugin group get vmware-tap/default:v{{ vars.tap_version }}
+  ```
+* Verify the plugin group list against the installed plugin list
+  ```console
+  tanzu plugin group get vmware-tap/default:v{{ vars.tap_version }}
+  ```
+  ```console
+  tanzu plugin list
+  ```
+  
 For air-gapped installation, see the [Installing the Tanzu CLI in Internet-Restricted Environments](https://docs.vmware.com/en/VMware-Tanzu-CLI/{{ vars.tanzu-cli.url_version }}/tanzu-cli/index.html#internet-restricted-install) section of the Tanzu CLI
 documentation.
 

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -37,16 +37,16 @@ OR add HTML or Markdown table
 
 The following issues, listed by component and area, are resolved in this release.
 
-#### <a id='1-6-3-COMPONENT-NAME-ri'></a> v1.6.3 resolved issues: COMPONENT-NAME
-
-- Resolved issue description.
-
----
-
 #### <a id='1-6-3-cli-ri'></a> v1.6.3 resolved issues: Tanzu CLI and plugins
 
 - This release includes Tanzu CLI v1.0.0 and a set of installable plugin groups that are versioned such that the CLI is compatible with every version of TAP under support.
   - See [Install Tanzu CLI](install-tanzu-cli.hbs.md) for more details.
+
+---
+
+#### <a id='1-6-3-COMPONENT-NAME-ri'></a> v1.6.3 resolved issues: COMPONENT-NAME
+
+- Resolved issue description.
 
 ---
 

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -46,7 +46,7 @@ The following issues, listed by component and area, are resolved in this release
 #### <a id='1-6-3-cli-ri'></a> v1.6.3 resolved issues: Tanzu CLI and plugins
 
 - This release includes Tanzu CLI v1.0.0 and a set of installable plugin groups that are versioned such that the CLI is compatible with every version of TAP under support.
-  - See the [Install Tanzu CLI]() for more detailed explanation of 
+  - See [Install Tanzu CLI](install-tanzu-cli.hbs.md) for more details.
 
 ---
 

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -43,6 +43,13 @@ The following issues, listed by component and area, are resolved in this release
 
 ---
 
+#### <a id='1-6-3-cli-ri'></a> v1.6.3 resolved issues: Tanzu CLI and plugins
+
+- This release includes Tanzu CLI v1.0.0 and a set installable plugin groups that are versioned such that the CLI is compatible with every version of TAP under support.
+  - See the [Install Tanzu CLI]() for more detailed explanation of 
+
+---
+
 ### <a id='1-6-3-known-issues'></a> v1.6.3 Known issues
 
 This release has the following known issues, listed by component and area.
@@ -99,12 +106,7 @@ The following table lists the supported component versions for this Tanzu Applic
 | Tanzu Developer Portal (formerly Tanzu Application Platform GUI) |         |
 | Tanzu Application Platform Telemetry                             |         |
 | Tanzu Build Service                                              |         |
-| Tanzu CLI                                                        |         |
-| Tanzu CLI Application Accelerator plug-in                        |         |
-| Tanzu CLI Apps plug-in                                           |         |
-| Tanzu CLI Build Service plug-in                                  |         |
-| Tanzu CLI Insight plug-in                                        |         |
-| Tanzu Service CLI plug-in                                        |         |
+| Tanzu CLI                                                        | 1.0.0        |
 | Tekton Pipelines                                                 |         |
 
 ---

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -45,7 +45,7 @@ The following issues, listed by component and area, are resolved in this release
 
 #### <a id='1-6-3-cli-ri'></a> v1.6.3 resolved issues: Tanzu CLI and plugins
 
-- This release includes Tanzu CLI v1.0.0 and a set installable plugin groups that are versioned such that the CLI is compatible with every version of TAP under support.
+- This release includes Tanzu CLI v1.0.0 and a set of installable plugin groups that are versioned such that the CLI is compatible with every version of TAP under support.
   - See the [Install Tanzu CLI]() for more detailed explanation of 
 
 ---

--- a/template_variables.yaml
+++ b/template_variables.yaml
@@ -7,5 +7,5 @@ template_variables:
   app-sso:
     version: 4.0
   tanzu-cli:
-    version: 0.90.1
-    url_version: 0.90.0
+    version: 1.0.0
+    url_version: 1.0


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

This change should go live when TAP 1.6.3 GA's
