### PR TITLE
Removed the ‘toggle’ input type from Documentation

### DIFF
--- a/application-accelerator/creating-accelerators/accelerator-yaml-sample.hbs.md
+++ b/application-accelerator/creating-accelerators/accelerator-yaml-sample.hbs.md
@@ -66,7 +66,6 @@ accelerator:
         # Related to the dataType but somewhat independent, this identifies the type
         # of widget shown in the ui. Available types are:
         # - text - the default
-        # - toggle (boolean on/off control)
         # - textarea (single text value with larger input that allows linebreaks)
         # - checkbox - multivalue selection from choices
         # - select - single value selection from choices


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
