### PR TITLE
appsso: add signing key size constraint

### DIFF
--- a/app-sso/how-to-guides/service-operators/configure-token-signature.hbs.md
+++ b/app-sso/how-to-guides/service-operators/configure-token-signature.hbs.md
@@ -123,6 +123,8 @@ You can generate an RSA key yourself using OpenSSL. Here are the steps:
 
    > More [OpenSSL key generation examples here](https://www.openssl.org/docs/man1.1.1/man1/openssl-genpkey.html).
 
+   > **Note** The minimum key size for an `Authserver` is 2048
+
 2. Create a secret resource by using the key generated earlier in this procedure:
 
    ```shell

--- a/app-sso/reference/api/authserver.hbs.md
+++ b/app-sso/reference/api/authserver.hbs.md
@@ -67,12 +67,12 @@ spec:
       expiry: "12h"  # optional, default expiry is 12 hours
   tokenSignature: # required
     signAndVerifyKeyRef:
-      name: ""
+      name: "" # Must be a secret that contains an RSA private key with a minimum length of 2048 bits
     extraVerifyKeyRefs:
-      - name: ""
+      - name: "" # Must be a secret that contains an RSA private key with a minimum length of 2048 bits
   storage: # optional
     redis: # required if 'storage' is defined
-      serviceRef: # reference to a provisioned service within the same namespace as this AuthServer. Currently supports Secret reference only.
+      serviceRef: # reference to a provisioned service within the same namespace as this AuthServer. Currently, supports Secret reference only.
         apiVersion: "v1"
         kind: "Secret"
         name: ""


### PR DESCRIPTION
- the minimum is 2048

[#185338123]

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

Please cherry-pick back to including `TAP 1.3` (`1.3`, `1.4`, `1.5`, `1.6`), and include it in the latest (`1.7`)