### PR TITLE
[VSEE-1179] Remove trivy display report step because it is not needed

### DIFF
--- a/scst-scan/clusterimagetemplates.hbs.md
+++ b/scst-scan/clusterimagetemplates.hbs.md
@@ -158,28 +158,6 @@ This section describes how to create a ClusterImageTemplate using an ImageVulner
             - --scanners=vuln
             - --format=cyclonedx
             - --output=scan.cdx.json
-          - name: trivy-display-report
-            image: my.registry.com/aquasec/trivy:0.41.0     # input the location of your trivy scanner image
-            env:
-            - name: TRIVY_DB_REPOSITORY
-              value: #@ data.values.params.trivy_db_repository
-            - name: TRIVY_JAVA_DB_REPOSITORY
-              value: #@ data.values.params.trivy_java_db_repository
-            - name: TRIVY_CACHE_DIR
-              value: /workspace/trivy-cache
-            - name: XDG_CACHE_HOME
-              value: /workspace/.cache
-            - name: TMPDIR
-              value: /workspace
-            args:
-            - image
-            - $(params.image)
-            - --skip-db-update
-            - --skip-java-db-update
-            - --exit-code=0
-            - --scanners=vuln
-            - --severity=HIGH
-            - --no-progress
     ```
 
     Where:


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
N/A
It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
