### PR TITLE
Document ports and protocols for LSP.

### DIFF
--- a/local-source-proxy/prereqs.hbs.md
+++ b/local-source-proxy/prereqs.hbs.md
@@ -11,6 +11,10 @@ You need the following prerequisites before you can install Local Source Proxy (
 - Either IaaS-specific trust for Kubernetes service accounts to access the registry, or a secret with
   sufficient privileges to push and pull artifacts from that repository.
 
+- If you are installing Local Source Proxy on a Kubernetes cluster managed by a cloud provider
+  (e.g. EKS, AKS, GKE), ensure that TCP port 5002 is open between control plane nodes and your worker
+  nodes.
+
 The rest of this topic tells you how to obtain these prerequisites.
 
 Using Tanzu CLI

--- a/local-source-proxy/troubleshoot.hbs.md
+++ b/local-source-proxy/troubleshoot.hbs.md
@@ -246,3 +246,25 @@ Tanzu CLI and the apps plug-in are out of date.
    ```console
    tanzu plugin upgrade apps
    ```
+
+## <a id="timeout"></a> Error: i/o timeout
+
+### Symptom
+
+When running either `tanzu apps lsp health` or `tanzu apps workload apply`,
+the CLI returns an error message with the message below after hanging for
+a few minutes:
+
+```console
+connect: i/o timeout
+```
+
+### Cause
+
+TCP port 5002 is not open between your control plane nodes and your
+worker nodes.
+
+### Solution
+
+1. Open the port.
+2. Re-run the failing command.


### PR DESCRIPTION
## Summary

This pull request documents ports and protocols required to run Local Source Proxy.

Specifically, it documents requiring tcp/5002 to be open between the control plane and worker nodes.

## Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

All releases that include LSP.
