### PR TITLE
Add a pointer to Tap Sandbox from Vscode/IntelliJ about sections

### DIFF
--- a/intellij-extension/about.hbs.md
+++ b/intellij-extension/about.hbs.md
@@ -43,6 +43,12 @@ This extension gives the following features:
   For more information about a typical monorepo setup, see
   [Working with microservices in a monorepo](using-the-extension.hbs.md#mono-repo).
 
+- **Connect to a Sandbox Cluster:**
+
+  You can connect to a TAP Sandbox instance from your Tanzu Developer tools IDE extensions to 
+  try TAP and see its benefits. Please refer [these instructions](https://tanzu.academy/guides/developer-sandbox) 
+  to spin up TAP Sandbox and connect to it from your IDE.
+
 {{> 'partials/ide-extensions/no-ootb-basic-variation' }}
 
 ## <a id="next-steps"></a> Next steps

--- a/vscode-extension/about.hbs.md
+++ b/vscode-extension/about.hbs.md
@@ -39,4 +39,10 @@ The extension has the following features:
   This enables developers to connect to a pre-configured development container that includes all
   Tanzu tools and IDE extensions required for development on Tanzu pre-installed.
 
+- **Connect to a Sandbox Cluster:**
+
+  You can connect to a TAP Sandbox instance from your Tanzu Developer tools IDE extensions to 
+  try TAP and see its benefits. Please refer [these instructions](https://tanzu.academy/guides/developer-sandbox) 
+  to spin up TAP Sandbox and connect to it from your IDE.
+
 {{> 'partials/ide-extensions/no-ootb-basic-variation' }}


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

Probably just Tap 1.7 and later? 

However... this is really not specific to a version of TAP. 

The sandbox environment will most likely be kept up to date so it is always on a 'recent' version of TAP, which means that going back in time and adding a note like this into older versions of the docs makes little sense (you won't get an old version of TAP on the sandbox... and in the future once 1.8 is released you then won't even get a 1.7 version of sandbox anymore soon thereafter.
