### PR TITLE
docs: 1.7 upgrade docs for store

### DIFF
--- a/scst-scan/troubleshoot-scan.hbs.md
+++ b/scst-scan/troubleshoot-scan.hbs.md
@@ -379,8 +379,9 @@ A connection error while attempting to connect to the
 local cluster URL causes this error. If this is a multicluster deployment, set the
 `grype.metadataStore.url` property in your Build profile `values.yaml`. You must
 set the ingress domain of SCST - Store which is deployed in the View cluster.
-For information about this configuration, see [Install Build
-profile](../scst-store/multicluster-setup.hbs.md#install-build-profile).
+For information about this configuration, see [Multicluster Setup — How to
+configure Grype in the Build profile values
+file](../scst-store/multicluster-setup.hbs.md#grype-mds-config).
 
 ### Sourcescan error with SCST - Store endpoint without a prefix
 

--- a/scst-store/cluster-specific-scanner-configurations.hbs.md
+++ b/scst-store/cluster-specific-scanner-configurations.hbs.md
@@ -24,7 +24,9 @@ ingress connection to the store is not needed.
 The default values automatically configure the connection between a supported
 scanner, such as Grype, and SCST - Store. Scanners use `app-tls-cert` by default
 from SCST-Store. You do not need to make changes to the `grype` section of the
-`tap-values.yaml` provided in the full profile installation. See [Install Tanzu Application Platform package and profiles](../install-online/profile.hbs.md#install-profile).
+`tap-values.yaml` provided in the full profile installation. See [Install Tanzu
+Application Platform package and
+profiles](../install-online/profile.hbs.md#install-profile).
 
 To view the default values, see [Install Supply Chain Security Tools - Scan](../scst-scan/install-scst-scan.hbs.md#-configure-properties).
 
@@ -36,4 +38,5 @@ view cluster. Scanners must use `ingress-cert` to communicate with SCST-Store.
 To view a sample Build profile YAML file, see [Build
 profile](../multicluster/reference/tap-values-build-sample.hbs.md). For
 information about how Build profile uses the configuration, see [Multicluster
-setup](multicluster-setup.hbs.md#install-build-profile).
+setup — How to configure Grype in the Build profile values
+file](multicluster-setup.hbs.md#grype-mds-config).

--- a/scst-store/multicluster-setup.hbs.md
+++ b/scst-store/multicluster-setup.hbs.md
@@ -58,7 +58,7 @@ data:
 EOF
 ```
 
-### <a id='copy-amr'></a>Copy AMR CloudEvent Handler CA certificate data from the View cluster
+### <a id='copy-ceh-ca'></a>Copy AMR CloudEvent Handler CA certificate data from the View cluster
 
 With your kubectl targeted at the View cluster, you can get AMR CloudEvent Handler's TLS
 CA certificate's data.
@@ -82,7 +82,7 @@ MDS_AUTH_TOKEN=$(kubectl get secrets metadata-store-read-write-client -n metadat
 You use
 this environment variable in the next step.
 
-## <a id='copy-cloudevent'></a>Copy AMR CloudEvent Handler edit token from the View cluster
+### <a id='copy-ceh-token'></a>Copy AMR CloudEvent Handler edit token from the View cluster
 
 Copy the AMR CloudEvent Handler token into an environment variable: 
 
@@ -139,7 +139,7 @@ certificate and authentication token.
 The Build cluster now has a Metadata Store CA certificate named  `store-ca-cert` and a Metadata Store authentication
 token named `store-auth-token` in the namespace `metadata-store-secrets`.
 
-### <a id='apply-edit'></a>Apply the CloudEvent Handler CA certificate data and edit token to the Build and Run clusters
+### <a id='apply-ceh-ca-token'></a>Apply the CloudEvent Handler CA certificate data and edit token to the Build and Run clusters
 
 Now we will apply the CloudEvent Handler CA certificate and edit token to the Build and Run clusters. These values need to be accessible during the Build and Run profile deployments.
 
@@ -178,7 +178,7 @@ certificate and edit token.
 After all the steps are done, both the Build and Run clusters each have a CloudEvent Handler CA certificate and edit
 token named `amr-observer-edit-token` in the namespaces `metadata-store-secrets` and `amr-observer-system`. Now you are ready to deploy the Build and Run profiles.
 
-## <a id='install-build-profile'></a>Install the Build and Run profiles
+## <a id='install-build-run-profiles'></a>Install the Build and Run profiles
 
 If you came to this topic from [Install multicluster Tanzu Application
 Platform profiles](../multicluster/installing-multicluster.hbs.md) after
@@ -186,7 +186,7 @@ installing the View profile, return to that topic to [install the Build
 profile](../multicluster/installing-multicluster.hbs.md#install-build)
 and [install the Run profile](../multicluster/installing-multicluster.hbs.md#install-run).
 
-### <a id='use-config'></a>How the Build profile uses the configuration
+## <a id='grype-mds-config'></a>How to configure Grype in the Build profile values file
 
 The Build profile `values.yaml` uses the secrets you created to configure
 the Grype scanner which talks to SCST - Store. After performing a vulnerabilities

--- a/scst-store/upgrading.hbs.md
+++ b/scst-store/upgrading.hbs.md
@@ -1,7 +1,7 @@
 # Upgrading Supply Chain Security Tools - Store
 
-This topic describes how you can troubleshoot upgrading issues in Supply Chain
-Security Tools (SCST) - Store.
+This topic describes how to upgrade Supply Chain Security Tools (SCST) - Store as
+well as how to troubleshoot upgrade issues.
 
 ## <a id="upgrading-1-7"></a>Upgrading to 1.7
 

--- a/scst-store/upgrading.hbs.md
+++ b/scst-store/upgrading.hbs.md
@@ -1,8 +1,71 @@
-# Troubleshoot upgrading Supply Chain Security Tools - Store
+# Upgrading Supply Chain Security Tools - Store
 
-This topic describes how you can troubleshoot upgrading issues Supply Chain Security Tools (SCST) - Store.
+This topic describes how you can troubleshoot upgrading issues in Supply Chain
+Security Tools (SCST) - Store.
 
-## <a id="deploy-does-not-exist"></a> Database deployment does not exist
+## <a id="upgrading-1-7"></a>Upgrading to 1.7
+
+In TAP 1.7, we introduce the Artifact Metadata Repository (AMR) into SCST - Store.
+AMR components will be installed by default after the upgrade.
+
+How AMR needs to be configured depends on how TAP was deployed.
+
+* TAP is installed in a single cluster (Full profile) deployment
+* TAP is installed in a multicluster deployment
+
+###<a id="full-profile-upgrade"></a> Single cluster (Full profile) upgrade
+
+In a Full profile, AMR does not need any additional user configuration. See
+[AMR architecture](amr/architecture.hbs.md) and
+[deployment details](deployment-details.hbs.md) for more information.
+
+### <a id="multicluster-upgrade"></a> Multicluster upgrade
+
+In a multicluster deployment, AMR components are installed on the View, Build and
+Run clusters. The AMR Observer is installed on the Build and Run clusters, and
+needs to be configured to talk to the AMR CloudEvent Handler installed on the View
+cluster.
+
+Read [SCST - Store multicluster setup](multicluster-setup.hbs.md) for the new
+configuration in detail. The doc includes instructions for configuring both the
+AMR (new) and the Metadata Store (existing). The new configurations for 1.7 are:
+
+1. [Copy AMR CloudEvent Handler CA certificate data from the View
+   cluster](multicluster-setup.hbs.md#copy-ceh-ca)
+1. [Copy AMR CloudEvent Handler edit token from the View
+   cluster](multicluster-setup.hbs.md#copy-ceh-token)
+1. [Apply the CloudEvent Handler CA certificate data and edit token to the Build
+   and Run clusters](multicluster-setup.hbs.md#apply-ceh-ca-token)
+
+
+## <a id="troubleshoot"></a>Troubleshoot upgrading
+
+### <a id="observer-cannot-talk-to-ceh"></a> AMR Observer cannot talk to AMR CloudEvent Handler
+
+To see the AMR Observer pod, use this command.
+
+```console
+kubectl get pods -n amr-observer-system
+```
+
+To view AMR Observer logs, use this command.
+
+```console
+kubectl logs OBSERVER-POD-NAME -n amr-observer-system
+```
+
+Where:
+
+* `OBSERVER-POD-NAME` is the name of the AMR observer pod
+
+If you encounter errors relating to the authentication token, check that you have
+configured the AMR Observer correctly. It may be missing the edit token for the AMR
+CloudEvent Handler. See [SCST - Store multicluster setup](multicluster-setup.hbs.md)
+for more information on how to configure the edit token, as well as the CA cert and
+endpoint.
+
+
+### <a id="deploy-does-not-exist"></a> Database deployment does not exist
 
 To prevent issues with the metadata store database, such as the ones described in
 this topic, the database deployment is `StatefulSet` in
@@ -14,7 +77,7 @@ If you have scripts searching for a `metadata-store-db` deployment, edit the scr
 instead search for `StatefulSet`.
 
 
-## <a id="invalid-checkpoint-record"></a> Invalid checkpoint record
+### <a id="invalid-checkpoint-record"></a> Invalid checkpoint record
 
 When using Tanzu to upgrade to a new version of the store, there is occasionally data
 corruption. Here is an example of how this shows up in the log:
@@ -39,7 +102,7 @@ The log shows a database pod in a failure loop. For steps to fix the issue so th
 upgrade can proceed, see the [SysOpsPro documentation](https://sysopspro.com/fix-postgresql-error-panic-could-not-locate-a-valid-checkpoint-record/).
 
 
-## <a id="upgraded-pod-hanging"></a> Upgraded pod hanging
+### <a id="upgraded-pod-hanging"></a> Upgraded pod hanging
 
 Because the default access mode in the PVC is `ReadWriteOnce`, if you are deploying in an
 environment with multiple nodes then each pod might be on a different node.

--- a/toc.hbs.md
+++ b/toc.hbs.md
@@ -688,7 +688,7 @@
           - [Log configuration and usage](scst-store/logs.hbs.md)
           - [Connecting to the Postgres Database](scst-store/connect-to-database.hbs.md)
           - [Troubleshoot Supply Chain Security Tools - Store](scst-store/troubleshooting.hbs.md)
-          - [Troubleshoot upgrading](scst-store/upgrading.hbs.md)
+          - [Upgrading](scst-store/upgrading.hbs.md)
           - [Failover, redundancy, and backups](scst-store/failover.hbs.md)
           - [Custom certificate configuration](scst-store/custom-cert.hbs.md)
           - [TLS configuration](scst-store/tls-configuration.hbs.md)

--- a/upgrading.hbs.md
+++ b/upgrading.hbs.md
@@ -67,6 +67,15 @@ The following sections describe how to upgrade in different scenarios.
 
 The following changes affect the upgrade procedures:
 
+- **Artifact Metadata Repository introduced**
+
+    In Tanzu Application Platform v1.7.0, the [Artifact Metadata
+    Repository](scst-store/amr/overview.hbs.md) component is introduced into the
+    Supply Chain Security Tools (SCST) - Store package. In a multicluster
+    deployment, this component requires additional configuration during upgrade.
+    See [SCST - Store upgrade to 1.7
+    instructions](scst-store/upgrading.hbs.md#upgrading-1-7).
+
 - **Keyless support deactivated by default**
 
     In Tanzu Application Platform v1.5.0, keyless support is deactivated by default. For more information, see [Install Supply Chain Security Tools - Policy Controller](scst-policy/install-scst-policy.hbs.md).
@@ -166,8 +175,11 @@ To reduce the likelihood of temporary failures, follow these steps to upgrade yo
 
 ### <a id="comp-specific-instruct"></a> Upgrade instructions for component-specific installation
 
-For information about upgrading Tanzu Developer Portal, see [Upgrade Tanzu Developer Portal](tap-gui/upgrades.html).
-For information about upgrading Supply Chain Security Tools - Scan, see [Upgrade Supply Chain Security Tools - Scan](scst-scan/upgrading.md).
+Some components have instructions for upgrading.
+
+* Tanzu Developer Portal, see [Upgrade Tanzu Developer Portal](tap-gui/upgrades.html).
+* Supply Chain Security Tools - Scan, see [Upgrade Supply Chain Security Tools - Scan](scst-scan/upgrading.md).
+* Supply Chain Security Tools - Store, see [Upgrading Supply Chain Security Tools - Store](scst-store/upgrading.hbs.md).
 
 ## <a id="verify"></a> Verify the upgrade
 


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

This is for 1.7.

The existing docs for upgrading SCST - Store only have instructions for troubleshooting. With 1.7, we introduce the AMR component. In a full profile, the AMR does not need any user configuration. However, in a multicluster TAP, the user does need to do some configuration.

In a previous PR, we had already updated the SCST - Store multicluster docs page. In this MR, we refer to those instructions by expanding the Upgrading doc and linking to the multicluster doc. After that, we also add a link to the TAP upgrading doc.
