### PR TITLE
Remove explicit instructions to install AMR using values

### DIFF
--- a/scst-store/amr/configuration.hbs.md
+++ b/scst-store/amr/configuration.hbs.md
@@ -10,11 +10,8 @@ You can obtain the Tanzu Application Platform values schema by running:
 tanzu package available get amr-observer.apps.tanzu.vmware.com/${VERSION} --values-schema --namespace tap-install
 ```
 
-Values are under the `amr` root key, not under the `metadata_store` root key. 
-
->**Note** If you deployed AMR Observer as [standalone](./install-amr-observer.hbs.md#a-idstandalone-installa-installing-artifact-metadata-repository-observer-standalone), not through a Tanzu Application Platform package, the values file for a standalone package installation does not have the Tanzu Application Platform value root keys of `amr.observer` or `amr.deploy_observer`.
-
-The following is an example template of the AMR Observer Tanzu Application Platform values:
+This is an example AMR Observer configuration which is under the `amr` key in
+TAP's values file.
 
 ```yaml
 amr:
@@ -115,6 +112,7 @@ Configuration options:
   - `.autoconfigure`
     - Default: `true`
     - Delegate creation of authentication token secret to the artifact metadata repository. By default it is set to true.
+
 ## <a id='amr-cloudevent-handler'></a> AMR CloudEvent Handler
 
 - `amr.cloudevent_handler.auth.kubernetes_service_accounts`

--- a/scst-store/amr/install-amr-cloudevent-handler.hbs.md
+++ b/scst-store/amr/install-amr-cloudevent-handler.hbs.md
@@ -18,25 +18,5 @@ Where `VIEW-CLUSTER-NAME` is the name of the view profile cluster you want to us
 
 ## Install
 
-On the view profile cluster or full profile cluster, the Metadata Store installation must be updated to have Artifact Metadata Repository deployed. 
-When the Artifact Metadata Repository is deployed, Artifact Metadata Repository CloudEvent Handler is deployed alongside it. 
-
-To do so, additional Tanzu Application Platform values are required:
-
-```yaml
-metadata_store:
-    amr:
-        deploy: true
-```
-
-## Uninstall
-
-Artifact Metadata Repository CloudEvent Handler is deployed alongside Artifact Metadata Repository. Therefore, to undeploy Artifact Metadata Repository CloudEvent Handler, the Tanzu Application Platform values are updated with:
-
-```yaml
-metadata_store:
-    amr:
-        deploy: false
-```
-
->**Note** When Artifact Metadata Repository Observer is deployed on the same cluster with the full Tanzu Application Platform profile, Artifact Metadata Repository Observer is undeployed when Artifact Metadata Repository is undeployed.
+The AMR CloudEvent Handler is installed by default in TAP's Full and View
+profiles.

--- a/scst-store/amr/install-amr-observer.hbs.md
+++ b/scst-store/amr/install-amr-observer.hbs.md
@@ -4,15 +4,7 @@ This topic tells you how to install Artifact Metadata Repository (AMR) Observer 
 
 ## <a id='prerecs'></a> Prerequisites
 
-You must deploy AMR and AMR CloudEvent Handler if you are using the Full profile. To do so, additional Tanzu Application Platform values are required.
-
-```yaml
-metadata_store:
-    amr:
-        deploy: true
-```
-
-Alternatively, AMR and AMR CloudEvent Handler must be deployed and accessible by the cluster where AMR Observer is deployed.
+The AMR Observer is deployed by default on TAP's Full, Build and Run profiles.
 
 ## <a id='switch-context'></a> Switching Context
 
@@ -30,18 +22,10 @@ tanzu package installed update tap --values-file tap-values.yaml -n tap-install
 
 Where `OBSERVER-CLUSTER-NAME` is the name of the cluster you want to use.
 
-## <a id='install'></a> Install
+## <a id='install'></a> Configuring AMR Observer in a multicluster deployment
 
-To deploy AMR Observer on a Full, Build, or Run Tanzu Application Platform profile, update the Tanzu Application Platform values:
-
-```yaml
-amr: 
-  deploy_observer: true
-```
-
->**Note** If deployed on a full profile Tanzu Application Platform cluster and `metadata-store.amr.deploy` is `false`, this overrides `amr.deploy_observer` to `false`.
-
-When AMR Observer is installed on a different cluster from AMR and AMR CloudEvent Handler, the following values are required:
+When AMR Observer is installed on a different cluster from the AMR CloudEvent
+Handler, the following values are required:
 
 - `amr.observer.cloudevent_handler.endpoint` is required for the Observer to send to the AMR CloudEvent Handler.
 - `amr.observer.cloudevent_handler.ca_cert_data` or `shared.ca_cert_data` are required for AMR CloudEvent Handlers that use Custom CA certificates to generate the associated TLS certificate for the ingress endpoint.
@@ -73,7 +57,8 @@ See [Configuration - AMR Observer](./configuration.hbs.md#amr-observer).
     amr-observer.apps.tanzu.vmware.com  0.1.0-alpha.8  2023-06-08 16:17:22 -0400 EDT
   ```
 
-1. Get the values-schema to create the values file:
+1. Look at the package values-schema to create the values file. For more
+   information, see [Configuration](./configuration.hbs.md#Configuration).
   
   ```console
   $ tanzu package available get amr-observer.apps.tanzu.vmware.com/0.1.0-alpha.8 --values-schema --namespace tap-install
@@ -86,13 +71,4 @@ See [Configuration - AMR Observer](./configuration.hbs.md#amr-observer).
     resync_period                                  string   resync_period determines the minimum frequency at which watched resources are reconciled. A lower period will correct entropy more quickly, but reduce responsiveness to change if there are many watched resources. Change this value only if you know what you are doing. Defaults to 10 hours if unset.
   ```
 
-1. A sample `values-file.yaml` for installing AMR Observer standalone on a cluster where AMR CloudEvent Handler is present.
-
-  ```yaml
-  cloudevent_handler:
-    endpoint: http://amr-cloudevent-handler.metadata-store.svc.cluster.local
-  ```
-
-The values file for a standalone package installation does not have the Tanzu Application Platform value root key of `amr.observer` or `amr.deploy_observer`.
-
-For more information, see [Configuration](./configuration.hbs.md#Configuration).
+1. Install the package using `tanzu package install`.

--- a/scst-store/deployment-details.hbs.md
+++ b/scst-store/deployment-details.hbs.md
@@ -39,54 +39,23 @@ VMware recommends the following connection methods for Tanzu Application Platfor
 
 For a production environment, VMware recommends installing SCST - Store with ingress enabled.
 
-#### <a id='amr'></a>Deploying AMR
-
-By default, AMR is not deployed with SCST - Store. There is an `amr` section inside `metadata_store`. To deploy AMR, you must set the `deploy` property under `amr` to `true`.
-
-```yaml
-metadata_store:
-  amr:
-    deploy: true
-```
-
->**Note** The `deploy` property expects a Boolean value of `true` or `false`, not a string value.
-
 #### <a id='appserv-type'></a>App service type
 
-This configuration is available in the following places:
-
-- `metadata_store` configures the app service type of the metadata store.
-- `amr` in the `metadata_store` section configures the app service type.
-
-Supported values include: 
-
-- `LoadBalancer`
-- `ClusterIP`
-- `NodePort`. The
-`app_service_type` is set to `LoadBalancer` by default. If your environment does
-not support `LoadBalancer`, configure the
-`app_service_type` property to use `ClusterIP` in your deployment YAML:
-
-For metadata-store:
+The Metadata Store's app service type is configuring inside the `metadata_store`
+property of the values file.
 
 ```yaml
 metadata_store:
   app_service_type: "ClusterIP"
 ```
 
-For AMR:
+Supported values include: 
 
-```yaml
-metadata_store:
-  amr:
-    deploy: true
-    app_service_type: "ClusterIP"
-```
+- `LoadBalancer`
+- `ClusterIP`
+- `NodePort`
 
-If you set the `ingress_enabled` to `"true"`, VMware recommends setting
-the `app_service_type` property to `"ClusterIP"`. 
-
->**Note** The `app_service_type` is set to `ClusterIP` by default when you enable shared ingress.
+The `app_service_type` is set to `ClusterIP` by default.
 
 #### <a id='ingress'></a>Ingress support
 
@@ -128,25 +97,16 @@ See [Use external postgres database](use-external-database.hbs.md).
 #### <a id='cust-data-pass'></a>Custom database password
 
 By default, a database password is generated upon deployment. To configure a
-custom password, use the `db_password` property in the deployment YAML. 
-The `db_password` property is available under `metadata_store` and under `amr` in `metadata_store`.
+custom password, use the `metadata_store.db_password` property in the values
+file
 
 >**Important** There is a known issue related to changing database passwords [Persistent Volume Retains Data](../release-notes.md#store-persistent-volume-retains-data).
 
-To configure a custom database password for the store:
+To configure a custom database password for the AMR:
 
 ```yaml
 metadata_store:
   db_password: "PASSWORD"
-```
-
-To configure a custom database password for AMR:
-
-```yaml
-metadata_store:
-  amr:
-    deploy: true
-    db_password: "PASSWORD"
 ```
 
 Where `PASSWORD` is the same password used for both deployments.


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

This change is for 1.7.

Back in 1.6 we had instructions for enabling AMR explicitly using a values file. Now that AMR is on by default I want to update the docs to reflect that.
