### PR TITLE
[Read for merge] Add note to say storage class should not have per-node limit

### DIFF
--- a/scst-scan/install-app-scanning.hbs.md
+++ b/scst-scan/install-app-scanning.hbs.md
@@ -23,7 +23,7 @@ When you install SCST - Scan 2.0, you can configure the following optional prope
 | workspace.storageSize  | 100Mi | string | Size of the PersistentVolume that the Tekton pipelineruns uses. |
 | workspace.storageClass  | "" | string | Name of the storage class to use while creating the PersistentVolume claims used by tekton pipelineruns. **Note**: should be configured with a storage class that does not have a per-node limit. |
 
-**Note**: If storage classes do not have a node limit but use the node storage (e.g. hostpath), the nodes must have large enough disks. For example, every scan can at most have a 2Gi volume on a hostpath or storage class. "2Gi * number of AMR images / number of nodes" would indicate how much storage this cluster would need.
+**Note**: If the StorageClass you select does not have a node limit but uses the node storage (e.g. hostpath), the nodes must have large enough disks. For example, if a scan creates a 2Gi volume on a hostpath type storage class, `2Gi * number of AMR images` would indicate how much storage this cluster needs overall. `2Gi * number of AMR images / number of nodes` would indicate how much storage each node would need.
 
 ## <a id="install-scst-app-scanning"></a> Install
 

--- a/scst-scan/install-app-scanning.hbs.md
+++ b/scst-scan/install-app-scanning.hbs.md
@@ -20,8 +20,8 @@ When you install SCST - Scan 2.0, you can configure the following optional prope
 | docker.import | true | Boolean | Import `docker.pullSecret` from another namespace (requires secretgen-controller). Set to false if the secret is already present. |
 | docker.pullSecret | registries-credentials | string | Name of a Docker pull secret in the deployment namespace to pull the scanner images |
 | scans.maxConcurrentScans | 10 | integer | The maximum number of scans that the scan controller schedules to run concurrently |
-| workspace.storageSize  | 100Mi | string | Size of the PersistentVolume that the Tekton pipelineruns uses |
-| workspace.storageClass  | "" | string | Name of the storage class to use while creating the PersistentVolume claims used by tekton pipelineruns |
+| workspace.storageSize  | 100Mi | string | Size of the PersistentVolume that the Tekton pipelineruns uses. |
+| workspace.storageClass  | "" | string | Name of the storage class to use while creating the PersistentVolume claims used by tekton pipelineruns. **Note**: should be configured with a storage class that does not have a per-node limit. |
 
 ## <a id="install-scst-app-scanning"></a> Install
 

--- a/scst-scan/install-app-scanning.hbs.md
+++ b/scst-scan/install-app-scanning.hbs.md
@@ -23,6 +23,8 @@ When you install SCST - Scan 2.0, you can configure the following optional prope
 | workspace.storageSize  | 100Mi | string | Size of the PersistentVolume that the Tekton pipelineruns uses. |
 | workspace.storageClass  | "" | string | Name of the storage class to use while creating the PersistentVolume claims used by tekton pipelineruns. **Note**: should be configured with a storage class that does not have a per-node limit. |
 
+**Note**: If storage classes do not have a node limit but use the node storage (e.g. hostpath), the nodes must have large enough disks. For example, every scan can at most have a 2Gi volume on a hostpath or storage class. "2Gi * number of AMR images / number of nodes" would indicate how much storage this cluster would need.
+
 ## <a id="install-scst-app-scanning"></a> Install
 
 To install SCST - Scan 2.0:


### PR DESCRIPTION
This PR is missing the correction of the workspace.storageSize default value being 2Gi instead of 100mi which is in this [PR](https://github.com/pivotal/docs-tap/pull/3011/files) 

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
