### PR TITLE
Add release notes to mention docker fields and related sub-fields are deprecated/removed in TAP 1.7

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -398,6 +398,7 @@ Deprecated features remain on this list until they are retired from Tanzu Applic
 
 - The profile based installation of Grype to a developer namespace and related fields in the values file, such as `grype.namespace` and
   `grype.targetImagePullSecret`, were deprecated in Tanzu Application Platform v1.6.0 and are marked for removal in v1.8.0. Before removal, you can opt-in to use the profile based installation of Grype to a single namespace by setting `grype.namespace` in the `tap-values.yaml` configuration file.
+- The `docker` field and related sub-fields used in Supply Chain Security Tools - Scan are deprecated and have been removed in Tanzu Application Platform v1.7.0.
 
 ---
 

--- a/scst-scan/troubleshoot-scan.hbs.md
+++ b/scst-scan/troubleshoot-scan.hbs.md
@@ -429,8 +429,8 @@ For information about `shared.ca_cert_data`, see [View possible configuration se
 ### <a id="unable-pull-scanner-images"></a> Unable to pull scan controller and scanner images from a specified registry
 
 The `docker` field and related sub-fields by SCST - Scan Controller, Grype
-Scanner, or Snyk Scanner are deprecated in Tanzu Application Platform v1.4.0.
-Previously these text boxes might be used to populate the `registry-credentials`
+Scanner, or Snyk Scanner are deprecated in Tanzu Application Platform v1.4.0 and removed in Tanzu Application Platform v1.7.0.
+Previously these fields might be used to populate the `registry-credentials`
 secret. You might encounter the following error during installation:
 
 ```console


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
