### PR TITLE
feat: [AMR-552] Update the CLI "Query vulnerabilities, images, and packages" section

### DIFF
--- a/cli-plugins/insight/query-data.hbs.md
+++ b/cli-plugins/insight/query-data.hbs.md
@@ -10,7 +10,6 @@ files.
 The following are use cases supported by the CLI:
 
 - What packages and CVEs exist in a particular image? (`image`)
-- What packages and CVEs exist in my source code? (`source`)
 - What dependencies are affected by a specific CVE? (`vulnerabilities`)
 
 ## <a id='query-insight'></a> Query using the Tanzu Insight CLI plug-in
@@ -28,6 +27,85 @@ Use `tanzu insight -h` or for more information see [Tanzu Insight Details](cli-d
 
 ## <a id='example1'></a>Example #1: What packages and CVEs does a specific image contain?
 
+### Determining an image's digest
+
+To query an image scan for vulnerabilities, you need the image's digest, which you can get from the image scan resource.
+
+#### When using Supply Chain Tools - Scan 2.0
+
+When using Supply Chain Tools - Scan 2.0, the image digest can be found by looking inside the corresponding
+image vulnerability scan custom resource.
+
+To get a list of image vulnerability scans, run:
+
+```console
+kubectl get imagevulnerabilityscan -n WORKLOAD-NAMESPACE
+```
+
+For example:
+
+```console
+$ kubectl get imagevulnerabilityscan -n my-apps
+NAME                                  SUCCEEDED   REASON
+tanzu-java-web-app-grype-scan-jb76m   True        Succeeded
+```
+ 
+The name of the image vulnerability scan will start with the name of the workload.
+
+To describe the image vulnerability scan, run:
+
+```console
+kubectl describe imagevulnerabilityscan IMAGE-VULNERABILITY-SCAN-NAME -n WORKLOAD-NAMESPACE
+```
+
+For example:
+
+```console
+kubectl describe imagevulnerabilityscan tanzu-java-web-app-grype-scan-jb76m -n my-apps
+```
+
+In the resource, look for the `Spec.Image` field. The value points to the image that was scanned, including its digest.
+
+For example:
+
+```yaml
+Spec:
+  Image: fake.oci-registry.io/dev-cluster/supply-chain-apps/tanzu-java-web-app-my-apps@sha256:a24a8d8eb724b6816f244925cc6625a84c15f6ced6a19335121343424be693cd
+```
+
+In this example, the image's digest is: `sha256:a24a8d8eb724b6816f244925cc6625a84c15f6ced6a19335121343424be693cd`
+
+
+#### Using Supply Chain Tools - Scan Pre-2.0
+
+When using Supply Chain Tools - Scan Pre-2.0, the image digest can be found by looking inside the corresponding image scan custom resource.
+
+Run:
+
+```console
+kubectl get imagescan WORKLOAD-NAME -n WORKLOAD-NAMESPACE
+```
+
+For example:
+
+```console
+kubectl get imagescan tanzu-java-web-app -n my-apps
+```
+
+In the resource, look for the `Spec.Registry.Image` field. The value points to the image that was scanned, including its digest.
+
+For example:
+
+```yaml
+Spec:
+  Registry:
+    Image: fake.oci-registry.io/dev-cluster/supply-chain-apps/tanzu-java-web-app-my-apps@sha256:e8c648533c4c7440ee9a93142ac7480205e0f7669e4f86771cede8bfaacdc2cf
+```
+
+In this example, the image's digest is: `sha256:e8c648533c4c7440ee9a93142ac7480205e0f7669e4f86771cede8bfaacdc2cf`
+
+### Image querying with image digest
+
 Run:
 
 ```console
@@ -41,10 +119,10 @@ Where:
 For example:
 
 ```console
-$ tanzu insight image get --digest sha256:407d7099d6ce7e3632b6d00682a43028d75d3b088600797a833607bd629d1ed5
-Registry:	docker.io
-Image Name:	checkr/flagr:1.1.12
-Digest:    	sha256:407d7099d6ce7e3632b6d00682a43028d75d3b088600797a833607bd629d1ed5
+$ tanzu insight image get --digest sha256:sha256:e8c648533c4c7440ee9a93142ac7480205e0f7669e4f86771cede8bfaacdc2cf
+Registry:	fake.oci-registry.com
+Image Name:	dev-cluster/supply-chain-apps/tanzu-java-web-app-my-apps
+Digest:    	sha256:sha256:e8c648533c4c7440ee9a93142ac7480205e0f7669e4f86771cede8bfaacdc2cf
 Packages:
 	1. alpine-baselayout@3.1.2-r0
 	2. alpine-keys@2.1-r2
@@ -58,101 +136,7 @@ Packages:
 ...
 ```
 
-## <a id='example2'></a>Example #2: What packages and CVEs does my source code contain?
-
-### Determining source code org, repo, and commit SHA
-
-To query a source scan for vulnerabilities, you need a Git org and Git repository, or the commit SHA.  Find these by examining the source scan resource.
-
-Run:
-
-```console
-kubectl describe sourcescan WORKLOAD-NAME -n WORKLOAD-NAMESPACE
-```
-
-For example:
-
-```console
-kubectl describe sourcescan tanzu-java-web-app -n my-apps
-```
-
-In the resource look for the `Spec.Blob` field. Within, there's `Revision` and `URL`.
-
-For example:
-
-```yaml
-Spec:
-  Blob:
-    Revision:     master/c7e4c27ba43250a4b7c46f030355c108aa73cc39
-    URL:          http://source-controller.flux-system.svc.cluster.local./gitrepository/my-apps/tanzu-java-web-app-gitops/c7e4c27ba43250a4b7c46f030355c108aa73cc39.tar.gz
-```
-
-In the earlier example, the URL is parsed and split into the org and repo. Revision is parsed as the commit SHA.
-
-- Org is parsed as `gitrepository`
-- Repo is parsed as `my-apps/tanzu-java-web-app-gitops/c7e4c27ba43250a4b7c46f030355c108aa73cc39.tar.gz`
-- Commit SHA is parsed as `master/c7e4c27ba43250a4b7c46f030355c108aa73cc39`
-
-Use this information to perform your search.
-
-### Source code query with repo and org
-
-Run:
-
-```console
-tanzu insight source get --repo REPO --org ORG
-```
-
-Where:
-
-- `REPO` specifies the repository. For example, java-web-app, my-apps/java-web-app/c7ls8bakd87sakjda8d7.tar.gz
-- `ORG` is the source code's organization. For example, gitrepository, gitrepositiory-kj32kal8
-
-For example:
-
-```console
-$ tanzu insight source get --repo my-apps/java-web-app/c7ls8bakd87sakjda8d7.tar.gz --org gitrepository
-ID:       	1
-Repository:  my-apps/java-web-app/c7ls8bakd87sakjda8d7.tar.gz
-Commit:  c7e4c27ba43250a4b7c46f030355c108aa73cc39
-Organization:	gitrepository
-Packages:
-		1. go.uber.org/atomic@v1.7.0
-		CVEs:
-			1. CVE-2022-42322 (Low)
-		2. golang.org/x/crypto@v0.0.0-20220518034528-6f7dac969898
-		3. github.com/valyala/bytebufferpool@v1.0.0
-```
-
-### Source code query with commit SHA
-
-Run:
-
-```console
-tanzu insight source get --commit COMMIT
-```
-
-Where:
-
-- `COMMIT` specifies the commit. For example, d7e4c27ba43250a4b7c46f030355c108aa73cc39, main/d7e4c27ba43250a4b7c46f030355c108aa73cc39
-
-For example:
-
-```console
-$ tanzu insight source get --commit b66668e
-ID:       	2
-Repository:  kpack
-Commit:  b66668e
-Organization:	pivotal
-Packages:
-		1. cloud.google.com/go/kms@v1.0.0
-		2. github.com/BurntSushi/toml@v3.1.1
-		CVEs:
-			1. CVE-2021-30999 (Low)
-		3. github.com/Microsoft/go-winio@v0.5.2
-```
-
-## <a id='example3'></a>Example #3: What dependencies are affected by a specific CVE?
+## <a id='example2'></a>Example #2: What dependencies are affected by a specific CVE?
 
 Run:
 


### PR DESCRIPTION
Updating this document on the updated way to fetch an image digest using tanzu cli. Also removing information about fetching source scan results, as it is not yet supported as part of the OOTB experience.

(cherry picked from commit 26e4f7b5aded3f158dbcde0c8f33b8078323e35d)

### Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

* TAP 1.5.6