### PR TITLE
Add disclaimer, cb cli docs, and cb image reference

### DIFF
--- a/scst-scan/ivs-carbon-black.hbs.md
+++ b/scst-scan/ivs-carbon-black.hbs.md
@@ -2,15 +2,18 @@
 
 To configure an ImageVulnerabilityScan for Carbon Black, use the following ImageVulnerabilityScan and secret configuration:
 
-This topic gives you an example of how to configure an ImageVulnerabilityScan (IVS) for Grype.
+This topic gives you an example of how to configure an ImageVulnerabilityScan (IVS) for Carbon Black.
 
 ## <a id="example"></a> Example ImageVulnerabilityScan
 
 This section contains a sample IVS that uses Carbon Black to scan a targeted image and push the results to the specified registry location.
 For information about the IVS specification, see [Configuration Options](ivs-create-your-own.hbs.md#img-vuln-config-options).
 
-- Configure Carbon Black CLI with CarbonBlack `cbctl-creds` secret and credentials by using the `~/.cbctl/cbctl.yaml` config file. See the [Carbon Black](https://developer.carbonblack.com/reference/carbon-black-cloud/container/latest/image-scanning-cli#configuration) documentation.
-- Set the tekton-pipelines feature-flags configmap `enable-api-fields` to `alpha`. This enables the user to use the `stdoutConfig` which is needed to output the scan report as a file.
+### <a id="cbc-config"></a> Prepare the Carbon Black Scanner configuration
+
+1. Obtain a Carbon Black API Token from Carbon Black Cloud.
+
+2. Create a Carbon Black secret YAML file and insert the Carbon Black API configuration key. Obtain all values from your CBC console.
 
 ```yaml
 apiVersion: v1
@@ -23,7 +26,29 @@ stringData:
     cb_api_key: CB-API-KEY
     org_key: ORG-KEY
     saas_url: SAAS-URL
----
+```
+
+Where:
+
+- `CB-API-ID` is the API ID obtained from VMware Carbon Black Cloud (CBC).
+- `CB-API-KEY` is the API Key obtained from CBC.
+- `ORG-KEY` is the Org Key for your CBC organization.
+- `SAAS-URL` is the CBC Backend URL.
+
+
+3. Apply the Carbon Black secret YAML file by running:
+
+    ```console
+    kubectl apply -f YAML-FILE
+    ```
+
+    Where `YAML-FILE` is the name of the Carbon Black secret YAML file you created.
+
+### <a id="configure-carbon-black-ivs"></a> Configure IVS for Carbon Blac
+
+- Set the tekton-pipelines feature-flags configmap `enable-api-fields` to `alpha`. This enables the user to use the `stdoutConfig` which is needed to output the scan report as a file.
+
+```yaml
 apiVersion: app-scanning.apps.tanzu.vmware.com/v1alpha1
 kind: ImageVulnerabilityScan
 metadata:
@@ -64,12 +89,8 @@ spec:
 
 Where:
 
-- `CB-API-ID` is the API ID obtained from VMware Carbon Black Cloud (CBC).
-- `CB-API-KEY` is the API Key obtained from CBC.
-- `ORG-KEY` is the Org Key for your CBC organization.
-- `SAAS-URL` is the CBC Backend URL.
 - `CARBON-BLACK-SCANNER-IMAGE` is the Carbon Black scanner image. For example, `cbartifactory/cbctl:latest`. or information about publicly available Grype images, see DockerHub. For information about publicly available Carbon Black images, see [DockerHub](https://hub.docker.com/r/cbartifactory/cbctl). For more information about using the Carbon Black Scanner CLI, see the [Carbon Black documentation](https://developer.carbonblack.com/reference/carbon-black-cloud/container/latest/image-scanning-cli/).
-
+- Configure Carbon Black CLI with CarbonBlack `cbctl-creds` secret and credentials by using the `~/.cbctl/cbctl.yaml` config file. See the [Carbon Black](https://developer.carbonblack.com/reference/carbon-black-cloud/container/latest/image-scanning-cli#configuration) documentation.
 
 **Note** The Carbon Black `cbctl-creds` secret is mounted as a workspace binding and the credentials are inserted into a `cbctl.yaml` config file that the Carbon Black CLI uses.
 

--- a/scst-scan/ivs-carbon-black.hbs.md
+++ b/scst-scan/ivs-carbon-black.hbs.md
@@ -1,8 +1,6 @@
 # Configure a ImageVulnerabilityScan for Carbon Black
 
-To configure an ImageVulnerabilityScan for Carbon Black, use the following ImageVulnerabilityScan and secret configuration:
-
-This topic gives you an example of how to configure an ImageVulnerabilityScan (IVS) for Carbon Black.
+This topic gives you an example of how to configure a Secret and ImageVulnerabilityScan (IVS) for Carbon Black.
 
 ## <a id="example"></a> Example ImageVulnerabilityScan
 
@@ -11,9 +9,8 @@ For information about the IVS specification, see [Configuration Options](ivs-cre
 
 ### <a id="cbc-config"></a> Prepare the Carbon Black Scanner configuration
 
-1. Obtain a Carbon Black API Token from Carbon Black Cloud.
+This section contains a sample Secret containing the Carbon Black credentials inside the `~/.cbctl/cbctl.yaml` config file which are used to authenticate your Carbon Black Account and can be found in the Carbon Black console. See [here](https://developer.carbonblack.com/reference/carbon-black-cloud/container/latest/image-scanning-cli#configuration) for more details. You will only need to apply this once to your developer namespace.
 
-2. Create a Carbon Black secret YAML file and insert the Carbon Black API configuration key. Obtain all values from your CBC console.
 
 ```yaml
 apiVersion: v1
@@ -30,21 +27,12 @@ stringData:
 
 Where:
 
-- `CB-API-ID` is the API ID obtained from VMware Carbon Black Cloud (CBC).
-- `CB-API-KEY` is the API Key obtained from CBC.
-- `ORG-KEY` is the Org Key for your CBC organization.
-- `SAAS-URL` is the CBC Backend URL.
+- `CB-API-ID` is the API ID obtained from Carbon Black Cloud.
+- `CB-API-KEY` is the API Key obtained from Carbon Black.
+- `ORG-KEY` is the Org Key for your Carbon Black organization.
+- `SAAS-URL` is the Carbon Black Backend URL.
 
-
-3. Apply the Carbon Black secret YAML file by running:
-
-    ```console
-    kubectl apply -f YAML-FILE
-    ```
-
-    Where `YAML-FILE` is the name of the Carbon Black secret YAML file you created.
-
-### <a id="configure-carbon-black-ivs"></a> Configure IVS for Carbon Blac
+### <a id="configure-carbon-black-ivs"></a> Configure IVS for Carbon Black
 
 - Set the tekton-pipelines feature-flags configmap `enable-api-fields` to `alpha`. This enables the user to use the `stdoutConfig` which is needed to output the scan report as a file.
 
@@ -89,12 +77,11 @@ spec:
 
 Where:
 
-- `CARBON-BLACK-SCANNER-IMAGE` is the Carbon Black scanner image. For example, `cbartifactory/cbctl:latest`. or information about publicly available Grype images, see DockerHub. For information about publicly available Carbon Black images, see [DockerHub](https://hub.docker.com/r/cbartifactory/cbctl). For more information about using the Carbon Black Scanner CLI, see the [Carbon Black documentation](https://developer.carbonblack.com/reference/carbon-black-cloud/container/latest/image-scanning-cli/).
-- Configure Carbon Black CLI with CarbonBlack `cbctl-creds` secret and credentials by using the `~/.cbctl/cbctl.yaml` config file. See the [Carbon Black](https://developer.carbonblack.com/reference/carbon-black-cloud/container/latest/image-scanning-cli#configuration) documentation.
+- `CARBON-BLACK-SCANNER-IMAGE` is the Carbon Black scanner image. For example, `cbartifactory/cbctl:latest`. For information about publicly available Carbon Black images, see [DockerHub](https://hub.docker.com/r/cbartifactory/cbctl). For more information about using the Carbon Black Scanner CLI, see the [Carbon Black documentation](https://developer.carbonblack.com/reference/carbon-black-cloud/container/latest/image-scanning-cli/).
 
-**Note** The Carbon Black `cbctl-creds` secret is mounted as a workspace binding and the credentials are inserted into a `cbctl.yaml` config file that the Carbon Black CLI uses.
+**Note**: The Carbon Black `cbctl-creds` secret is mounted as a workspace binding and the credentials are inserted into a `cbctl.yaml` config file that the Carbon Black CLI uses.
 
-**Note** `stdoutConfig.path` is specified to take the output stream of the step to a given file where it can be published to the registry. See [tekton docs](https://github.com/tektoncd/community/blob/main/teps/0011-redirecting-step-output-streams.md) for more details.
+**Note**: `stdoutConfig.path` is specified to take the output stream of the step to a given file where it can be published to the registry. See [tekton docs](https://github.com/tektoncd/community/blob/main/teps/0011-redirecting-step-output-streams.md) for more details.
 
 ### <a id="disclaimer"></a> Disclaimer
 For the publicly available Carbon Black scanner CLI image, CLI commands and parameters used are accurate at the time of documentation.

--- a/scst-scan/ivs-carbon-black.hbs.md
+++ b/scst-scan/ivs-carbon-black.hbs.md
@@ -2,6 +2,13 @@
 
 To configure an ImageVulnerabilityScan for Carbon Black, use the following ImageVulnerabilityScan and secret configuration:
 
+This topic gives you an example of how to configure an ImageVulnerabilityScan (IVS) for Grype.
+
+## <a id="example"></a> Example ImageVulnerabilityScan
+
+This section contains a sample IVS that uses Carbon Black to scan a targeted image and push the results to the specified registry location.
+For information about the IVS specification, see [Configuration Options](ivs-create-your-own.hbs.md#img-vuln-config-options).
+
 - Configure Carbon Black CLI with CarbonBlack `cbctl-creds` secret and credentials by using the `~/.cbctl/cbctl.yaml` config file. See the [Carbon Black](https://developer.carbonblack.com/reference/carbon-black-cloud/container/latest/image-scanning-cli#configuration) documentation.
 - Set the tekton-pipelines feature-flags configmap `enable-api-fields` to `alpha`. This enables the user to use the `stdoutConfig` which is needed to output the scan report as a file.
 
@@ -61,8 +68,12 @@ Where:
 - `CB-API-KEY` is the API Key obtained from CBC.
 - `ORG-KEY` is the Org Key for your CBC organization.
 - `SAAS-URL` is the CBC Backend URL.
-- `CARBON-BLACK-SCANNER-IMAGE` is the Carbon Black scanner image.
+- `CARBON-BLACK-SCANNER-IMAGE` is the Carbon Black scanner image. For example, `cbartifactory/cbctl:latest`. or information about publicly available Grype images, see DockerHub. For information about publicly available Carbon Black images, see [DockerHub](https://hub.docker.com/r/cbartifactory/cbctl). For more information about using the Carbon Black Scanner CLI, see the [Carbon Black documentation](https://developer.carbonblack.com/reference/carbon-black-cloud/container/latest/image-scanning-cli/).
+
 
 **Note** The Carbon Black `cbctl-creds` secret is mounted as a workspace binding and the credentials are inserted into a `cbctl.yaml` config file that the Carbon Black CLI uses.
 
 **Note** `stdoutConfig.path` is specified to take the output stream of the step to a given file where it can be published to the registry. See [tekton docs](https://github.com/tektoncd/community/blob/main/teps/0011-redirecting-step-output-streams.md) for more details.
+
+### <a id="disclaimer"></a> Disclaimer
+For the publicly available Carbon Black scanner CLI image, CLI commands and parameters used are accurate at the time of documentation.


### PR DESCRIPTION
Summary:
* Add disclaimer for carbon black cli usage
* inline steps for carbon black configuration similar to scan 1.0

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
1.6

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
