### PR TITLE
Update ClusterImageTemplate docs

### DIFF
--- a/scst-scan/clusterimagetemplates.hbs.md
+++ b/scst-scan/clusterimagetemplates.hbs.md
@@ -173,7 +173,7 @@ ClusterImageTemplate Notes:
             publisher: #@ data.values.params.image_scanning_service_account_publisher
           steps:
           - name: trivy-generate-report
-            image: TRIVY-SCANNER-IMAGE # input the location of your Trivy scanner image
+            image: TRIVY-SCANNER-IMAGE
             env:
             - name: TRIVY_DB_REPOSITORY
               value: #@ data.values.params.trivy_db_repository
@@ -201,8 +201,8 @@ ClusterImageTemplate Notes:
 
 2. Edit the following in your `custom-ivs-template.yaml` file:
   - `.metadata.name` is the name of your ClusterImageTemplate. Ensure that it does not conflict with the names of packaged templates. See [Author your supply chains](../scc/authoring-supply-chains.hbs.md#providing-your-own-templates).
-  - `REGISTRY-SERVER` is the registry server.
-  - `REGISTRY-REPOSITORY` is the registry repository.
+  - `REGISTRY-SERVER` is the registry server which is used for the scan results location.
+  - `REGISTRY-REPOSITORY` is the registry repository which is used for the scan results location.
   - `TRIVY-SCANNER-IMAGE` is the location of your Trivy scanner CLI image
   - `.metadata.annotations.'app-scanning.apps.tanzu.vmware.com/scanner-name'` is the scanner image name reported in the Tanzu Developer Portal, formerly Tanzu Application Platform GUI.
 

--- a/scst-scan/clusterimagetemplates.hbs.md
+++ b/scst-scan/clusterimagetemplates.hbs.md
@@ -8,7 +8,7 @@ The following prerequisite is required to author a ClusterImageTemplate for Supp
 
 - You create your own ImageVulnerabilityScan or configured one of the samples provided in [Configure your custom ImageVulnerabilityScan](./ivs-custom-samples.hbs.md).
 - See ClusterImageTemplate [docs](https://cartographer.sh/docs/v0.3.0/reference/template/#clusterimagetemplate) for more details.
-- Understand `ytt` templating. See carvel `ytt` [docs](https://carvel.dev/ytt/) for documentation and playground samples.
+- Understand `ytt` templating. See Carvel `ytt` [docs](https://carvel.dev/ytt/) for documentation and playground samples.
 
 ## <a id='create-clusterimagetemplate'></a> Create a ClusterImageTemplate
 
@@ -174,7 +174,6 @@ ClusterImageTemplate Notes:
             - vuln
             - $(params.image)
     ```
-
 
 >**Note** `apps.tanzu.vmware.com/correlationid` contains the metadata of the mapping to the source of the scanned resource.
 

--- a/scst-scan/clusterimagetemplates.hbs.md
+++ b/scst-scan/clusterimagetemplates.hbs.md
@@ -142,7 +142,7 @@ Notes:
             publisher: #@ data.values.params.image_scanning_service_account_publisher
           steps:
           - name: trivy
-            image: TRIVY-SCANNER-IMAGE # input the location of your trivy scanner image
+            image: TRIVY-SCANNER-IMAGE # input the location of your Trivy scanner image
             env:
             - name: TRIVY_DB_REPOSITORY
               value: #@ data.values.params.trivy_db_repository

--- a/scst-scan/ivs-trivy.hbs.md
+++ b/scst-scan/ivs-trivy.hbs.md
@@ -27,13 +27,12 @@ spec:
     command: ["trivy"]
     args:
     - image
-    - --format
-    - cyclonedx
-    - --output
-    - $(params.scan-results-path)/scan.cdx.json
-    - --scanners
-    - vuln
     - $(params.image)
+    - --exit-code=0
+    - --no-progress
+    - --scanners=vuln
+    - --format=cyclonedx
+    - --output=$(params.scan-results-path)/scan.cdx.json
 ```
 
 Where:


### PR DESCRIPTION
Differences between catalog repo [ClusterImageTemplate Trivy](https://gitlab.eng.vmware.com/supply-chain-choreographer/catalog/-/blob/main/src/ootb-templates/bundle/config/image-vulnerability-scan-trivy.yaml) and this ClusterImageTemplate Trivy sample in the Scan 2.0 docs:
* There is `registry.server` and `registry.repository` here but not in the catalog ClusterImageTemplate Trivy because it appears that in the ootb-templates there is ytt happening to populate the registry.server and registry.repository fields but we need to make sure they are populated here if a user wants to create their own ClusterImageTemplate sample.
* The `label_exclusions` in [catalog](https://gitlab.eng.vmware.com/supply-chain-choreographer/catalog/-/blob/main/src/ootb-templates/bundle/config/image-vulnerability-scan-trivy.yaml#L53) are not included in this sample because in 1.7 they defined these values in this [values.yaml ](https://gitlab.eng.vmware.com/supply-chain-choreographer/catalog/-/blob/main/src/ootb-templates/bundle/values.yaml#L7). However if we copied this, we'd get an error trying to fetch this field `label_propagation_exclusions` because it doesn't exist at the time of applying this yaml. 


# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
