### PR TITLE
AppSSO: Service Ops can specify Configuration URI for OIDC provider config discovery

### DIFF
--- a/app-sso/reference/api/authserver.hbs.md
+++ b/app-sso/reference/api/authserver.hbs.md
@@ -162,7 +162,12 @@ spec:
                # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
                # must not start with 'client' or 'unknown'
       openID:
-        issuerURI: ""
+        configurationURI: "" # optional. If not specified, must define alternate fields: issuerURI and/or (authorizationUri, tokenUri, and jwksUri). This field must be suffixed with '/.well-known/openid-configuration'
+        issuerURI: "" # DEPRECATED, optional, use 'openid.configurationURI' instead. This field may not be set if 'configurationURI' is specified.
+        authorizationUri: "" # optional. Must be specified if 'configurationURI' and 'issuerURI' are not set.
+        tokenUri: "" # optional.  Must be specified if 'configurationURI' and 'issuerURI' are not set.
+        jwksUri: "" # optional.  Must be specified if 'configurationURI' and 'issuerURI' are not set.
+        userinfoUri: "" # optional
         displayName: "" # optional, must be between 2 and 32 characters in length
         clientID: ""
         clientSecretRef:
@@ -445,15 +450,11 @@ spec:
               - message.write
     - name: okta
       openID:
-        issuerURI: https://dev-xxxxxx.okta.com
+        configurationURI: https://dev-xxxxxx.okta.com/.well-known/openid-configuration
         displayName: "Okta"
         clientID: xxxxxxxxxxxxx
         clientSecretRef:
           name: okta-client-secret
-        authorizationUri: https://dev-xxxxxx.okta.com/oauth2/v1/authorize
-        tokenUri: https://dev-xxxxxx.okta.com/oauth2/v1/token
-        jwksUri: https://dev-xxxxxx.okta.com/oauth2/v1/keys
-        userinfoUri: https://dev-xxxxxx.okta.com/oauth2/v1/userinfo
         scopes:
           - openid
         roles:


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)? TAP 1.8 only.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
