### PR TITLE
[Draft] VSEE-1235 | documented the cases where upgrade fails

### DIFF
--- a/install-aws/profile.hbs.md
+++ b/install-aws/profile.hbs.md
@@ -279,10 +279,6 @@ metadata_store:
 namespace_provisioner:
   aws_iam_role_arn: "arn:aws:iam::${AWS_ACCOUNT_ID}:role/tap-workload"
 
-scanning:
-  metadataStore:
-    url: "" # Configuration is moved, so set this string to empty.
-
 tap_telemetry:
   customer_entitlement_account_number: "CUSTOMER-ENTITLEMENT-ACCOUNT-NUMBER" # (Optional) Identify data for creating Tanzu Application Platform usage reports.
 EOF

--- a/install-azure/profile.hbs.md
+++ b/install-azure/profile.hbs.md
@@ -274,10 +274,6 @@ metadata_store:
   app_service_type: ClusterIP
   ns_for_export_app_cert: ${YOUR_NAMESPACE}
 
-scanning:
-  metadataStore:
-    url: "" # Configuration is moved, so set this string to empty.
-
 accelerator:
   server:
     service_type: "ClusterIP"

--- a/install-gitops/upgrading.hbs.md
+++ b/install-gitops/upgrading.hbs.md
@@ -17,6 +17,7 @@ Before you upgrade your Tanzu Application Platform:
 - For information about Tanzu Developer Portal considerations, see
   [Tanzu Developer Portal Considerations](../tap-gui/upgrades.hbs.md#considerations).
 - Verify all packages are reconciled by running `kubectl get packageinstall --namespace tap-install`.
+- The previously deprecated field `scanning.metadataStore.url` is now completely removed from values provided for the installation/upgrading of Tanzu Application Platform v1.7. Make sure that this field is not present in the `tap-non-sensitive-values.yaml` file during the upgrade.
 
 ## <a id="relocate-images"></a> Relocate Tanzu Application Platform images to a registry
 

--- a/install-offline/profile.hbs.md
+++ b/install-offline/profile.hbs.md
@@ -237,9 +237,6 @@ buildservice:
     namespace: "KP-DEFAULT-REPO-SECRET-NAMESPACE"
   exclude_dependencies: true
 supply_chain: basic
-scanning:
-  metadataStore:
-    url: ""
 contour:
   infrastructure_provider: aws
   envoy:

--- a/install-online/profile.hbs.md
+++ b/install-online/profile.hbs.md
@@ -338,11 +338,6 @@ metadata_store:
   ns_for_export_app_cert: "MY-DEV-NAMESPACE" # Verify this namespace is available within your cluster before initiating the Tanzu Application Platform installation.
   app_service_type: ClusterIP # Defaults to LoadBalancer. If shared.ingress_domain is set earlier, this must be set to ClusterIP.
 
-scanning:
-  metadataStore:
-  # In a single cluster, the connection between the scanning pod and the metadata store happens inside the cluster and does not pass through ingress. This is automatically configured, you do not need to provide an ingress connection to the store.
-    url: "" # Configuration is moved, so set this string to empty.
-
 policy:
   tuf_enabled: false # By default, TUF initialization and keyless verification are deactivated.
 tap_telemetry:

--- a/install-openshift/profile.hbs.md
+++ b/install-openshift/profile.hbs.md
@@ -304,10 +304,6 @@ tap_gui:
 metadata_store:
   ns_for_export_app_cert: "MY-DEV-NAMESPACE"
   app_service_type: ClusterIP # Defaults to LoadBalancer. If shared.ingress_domain is set earlier, this must be set to ClusterIP.
-
-scanning:
-  metadataStore:
-    url: "" # Configuration is moved, so set this string to empty.
 ```
 
 > **Important** Installing Grype by using `tap-values.yaml` as follows is

--- a/multicluster/reference/tap-values-build-sample.hbs.md
+++ b/multicluster/reference/tap-values-build-sample.hbs.md
@@ -43,9 +43,6 @@ ootb_supply_chain_testing_scanning: # Optional if the corresponding shared keys 
     repository: "REPO-NAME"
   gitops:
     ssh_secret: "SSH-SECRET-KEY" # (Optional) Defaults to "".
-scanning:
-  metadataStore:
-    url: "" # Configuration is moved, so set this string to empty.
 tap_telemetry:
   customer_entitlement_account_number: "CUSTOMER-ENTITLEMENT-ACCOUNT-NUMBER" # (Optional) Identify data for creating Tanzu Application Platform usage reports.
 

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -238,6 +238,9 @@ This release includes the following changes, listed by component and area.
   upgrading `app-scanning.apps.tanzu.vmware.com` to v0.2.0.
   See [Troubleshooting](./scst-scan/app-scanning-troubleshooting.hbs.md#upgrading-scan-0.2.0).
 
+- The previously deprecated field `scanning.metadataStore.url` is now completely removed and 
+  its presence can cause the reconcillation failure. See [Troubleshooting](./scst-scan/troubleshoot-scan.hbs.md#reconcillation-failure-during-upgrade)
+
 #### <a id='1-7-0-cli-re-br'></a> v1.7.0 Breaking changes: Tanzu CLI command reference documenation
 
 - The Tanzu CLI plug-in command reference documentation has moved from the Tanzu Application Platform

--- a/scst-scan/troubleshoot-scan.hbs.md
+++ b/scst-scan/troubleshoot-scan.hbs.md
@@ -473,3 +473,32 @@ Pods
 ```
 
 One restart in scanner pods is expected with successful scans. To support Tanzu Service Mesh (TSM) integration, jobs were replaced with TaskRuns. This restart is an artifact of how Tekton cleans up sidecar containers by patching the container specifications.
+
+### <a id="reconcillation-failure-during-upgrade"></a> Reconcillation of SCST - Scan is failing when upgrading to v1.7+
+
+When upgrading the SCST - Scan from a previous version to v1.7+, one may see a reconcillation failure like:
+
+```
+NAME                                PACKAGE-NAME                                         PACKAGE-VERSION                STATUS
+  scanning                            scanning.apps.tanzu.vmware.com                       1.7.0-build.36081392+c072d305  Reconcile failed
+```
+
+If getting the package using the command `tanzu package installed get scanning -n tap-install` one may find the error like:
+
+```
+STATUS:                  Reconcile failed
+CONDITIONS:              - type: ReconcileFailed
+  status: "True"
+  reason: ""
+  message: Error (see .status.usefulErrorMessage for details)
+USEFUL-ERROR-MESSAGE:    ytt: Error: Overlaying data values (in following order: additional data values):
+One or more data values were invalid
+====================================Given data value is not declared in schema
+values.yaml:
+    |
+  2 |   url: ""
+    |    = found: url
+    = expected: a map item with the key named "exports" (from .ytt/data.yaml:52)
+```
+
+This is because the previously deprecated field of `scanning.metadataStore.url` is now completely removed. If this field is present in `tap-values.yaml` provided for the upgrade then the reconcillation will fail. Remove the field from the values file and run the upgrade command again to resolve this problem.

--- a/troubleshooting-tap/troubleshoot-install-tap.hbs.md
+++ b/troubleshooting-tap/troubleshoot-install-tap.hbs.md
@@ -311,3 +311,21 @@ To deploy successfully, the `servicebinding.tanzu.vmware.com` package requires C
 
 Upgrade to Cluster Essentials v{{ vars.url_version }}. For more information about the upgrade procedures, see the
 [Cluster Essentials documentation](https://{{ vars.staging_toggle }}.vmware.com/en/Cluster-Essentials-for-VMware-Tanzu/{{ vars.url_version }}/cluster-essentials/deploy.html#upgrade).
+
+## <a id='reconcillation-failure-scan-2'></a> Reconcillation fails when Supply Chain Security Tools - Scan 2.0 present and upgrading
+
+When Supply Chain Security Tools - Scan 2.0 (app-scanning.apps.tanzu.vmware.com) is deployed to a cluster and upgrading from TAP 1.6 to TAP 1.7, one may encounter a reconcillation error like:
+
+```
+Expected to find at least one version, but did not (details: all=1 ->
+      after-prereleases-filter=1 -> after-kapp-controller-version-check=1 -> after-constraints-filter=0)
+```
+
+**Explanation**
+
+upgrade instructions overwrites the previous TAP 1.6 repo with the 1.7 version which leads to reconcillation error above.
+
+**Solution**
+
+1. Upgrade app-scanning.apps.tanzu.vmware.com to version 0.2.1 if possible
+1. Otherwise, adding a new package repository with TAP 1.6 will make the error disappear.

--- a/upgrading.hbs.md
+++ b/upgrading.hbs.md
@@ -23,6 +23,7 @@ Before you upgrade Tanzu Application Platform:
   [Update the new package repository](#add-new-package-repo), upgrade to Cluster Essentials
   v{{ vars.url_version }}. For more information about the upgrade procedures, see the
   [Cluster Essentials documentation](https://{{ vars.staging_toggle }}.vmware.com/en/Cluster-Essentials-for-VMware-Tanzu/{{ vars.url_version }}/cluster-essentials/deploy.html#upgrade).
+- The previously deprecated field `scanning.metadataStore.url` is now completely removed from the `tap-values.yaml` file. Make sure that this field is not present in the `tap-values.yaml` file used for the upgrade.
 - Note that this upgrade will update all workloads and pods that are using service bindings. This is done automatically after upgrading to 1.7 and requires no user action.
 - All pods with service bindings are recreated concurrently at the time of the upgrade. You must have sufficient Kubernetes resources in your clusters to support the pod rollout.
 


### PR DESCRIPTION
* because the removed field `scanning.metadataStore.url` is provided in tap-values
* app-scanning is deployed to the cluster

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
