### PR TITLE
Update troubleshoot to provide solution for delete-kubernetes-auth.sh

### DIFF
--- a/troubleshooting-tap/troubleshooting-gitops.hbs.md
+++ b/troubleshooting-tap/troubleshooting-gitops.hbs.md
@@ -125,3 +125,12 @@ Events:
             ...
             version: "v1" # v1 or v2
     ```
+- **Problem 3:** Incorrect command to disable vault auth
+
+    ```console
+    ./tanzu-sync/vault/scripts/setup/delete-kubernetes-auth.sh
+    Error deleting auth/tap-gitops-vault/config: Error making API request.
+    Namespace: admin/URL: DELETE https://vault-cluster-public-vault-5593a539.8ae01486.z1.hashicorp.cloud:8200/v1/auth/tap-gitops-vault/configCode: 405. Errors:
+    * 1 error occurred:	* unsupported operation
+    ```
+    **Solution :** Update command `vault delete auth/$CLUSTER_NAME/config` to `vault auth disable $CLUSTER_NAME` in file `./tanzu-sync/vault/scripts/setup/delete-kubernetes-auth.sh`.


### PR DESCRIPTION
Update troubleshoot to provide solution for delete-kubernetes-auth.sh for 1.6.5

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
NA
It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
