### PR TITLE
ESBACK-512: validated community plugins

### DIFF
--- a/tap-gui/configurator/validated-community-plugins/about.hbs.md
+++ b/tap-gui/configurator/validated-community-plugins/about.hbs.md
@@ -1,0 +1,13 @@
+# Overview of Tanzu Developer Portal Validated Community plug-ins
+
+Tanzu Developer Portal has the following validated community plug-ins available:
+
+- [GitHub Actions](github-actions.hbs.md)
+- [Grafana](grafana.hbs.md)
+- [Homepage](home-page.hbs.md)
+- [Jira](jira.hbs.md)
+- [Prometheus](prometheus.hbs.md)
+- [Snyk](snyk.hbs.md)
+- [SonarQube](sonarqube.hbs.md)
+- [Stack Overflow](stack-overflow.hbs.md)
+- [TechInsights](techinsights.hbs.md)

--- a/tap-gui/configurator/validated-community-plugins/github-actions.hbs.md
+++ b/tap-gui/configurator/validated-community-plugins/github-actions.hbs.md
@@ -1,0 +1,41 @@
+# GitHub Actions in Tanzu Developer Portal
+
+This topic tells you about the GitHub Actions validated frontend plugin.
+
+The GitHub Actions frontend plug-in visualizes your GitHub Actions integrations.
+To learn more about the GitHub Actions plug-ins visit the [GitHub Actions Backstage documentation](https://github.com/backstage/backstage/tree/master/plugins/github-actions).
+
+## <a id="add-plugin"></a> Adding the GitHub Actions Plug-in to a Custom Tanzu Developer Portal
+
+### <a id="buildtime-config"></a> Buildtime Configuration
+
+To add the GitHub Actions plug-in to your custom Tanzu Developer portal, add the frontend plugin to your `tdp-config.yaml` file:
+
+```yaml
+app:
+  plugins:
+    ...
+    - name: '@vmware-tanzu/tdp-plugin-github-actions'
+      version: '^0.0.2'
+    ...
+```
+
+In this example, we use version `^0.0.2` as it is the latest version at the time of writing.
+
+### <a id="runtime-config"></a> Runtime Configuration
+
+To configure the GitHub Actions plug-in, update the `app_config` section of your `tap-values.yaml` file to include a gitHub integration like the following example:
+
+```yaml
+tap_gui:
+  # ... existing configuration
+  app_config:
+    # ... existing configuration
+    integrations:
+      github:
+        - host: 'GITHUB-HOST.com'
+          apiBaseUrl: 'https://api.GITHUB-HOST.com'
+```
+Where:
+
+* `GITHUB-HOST` is the domain of your github.

--- a/tap-gui/configurator/validated-community-plugins/grafana.hbs.md
+++ b/tap-gui/configurator/validated-community-plugins/grafana.hbs.md
@@ -1,0 +1,66 @@
+# Grafana in Tanzu Developer Portal
+
+This topic tells you about the Grafana validated frontend plugin.
+
+The Grafana frontend plug-in visualises Grafana information in a Component's overview tab.
+To learn more about the Grafana plug-ins visit the [Grafana Plug-in documentation](https://github.com/K-Phoen/backstage-plugin-grafana).
+
+## <a id="add-plugin"></a> Adding the Grafana Plug-in to a Custom Tanzu Developer Portal
+
+### <a id="buildtime-config"></a> Buildtime Configuration
+
+To add the Grafana plug-in to your custom Tanzu Developer portal, add the frontend plugin to your `tdp-config.yaml` file:
+
+```yaml
+app:
+  plugins:
+    ...
+    - name: '@vmware-tanzu/tdp-plugin-backstage-grafana'
+      version: '^0.0.2'
+    ...
+```
+
+In this example, we use version `^0.0.2` as it is the latest version at the time of writing.
+
+### <a id="runtime-config"></a> Runtime Configuration
+
+To configure the Github Actions plug-in, update the `app_config` section of your `tap-values.yaml` file to include a `proxy` entry and `grafana` configiration like the following example:
+
+```yaml
+tap_gui:
+  # ... existing configuration
+  app_config:
+    # ... existing configuration
+    proxy:
+      # ... existing configuration
+      '/grafana/api':
+        # May be a public or an internal DNS
+        target: https://test.grafana.net/
+        headers:
+          Authorization: 'Bearer ${GRAFANA_TOKEN}'
+
+    grafana:
+      # Publicly accessible domain
+      domain: https://test.grafana.net/
+      # Is unified alerting enabled in Grafana?
+      # See: https://grafana.com/blog/2021/06/14/the-new-unified-alerting-system-for-grafana-everything-you-need-to-know/
+      # Optional. Default: false
+      unifiedAlerting: true
+
+```
+Where:
+
+* `GRAFANA_TOKEN` is a valid token for your Grafana instance.
+
+Add the annotations entry for Grafana to the catalog entity to display the grafana alerts and dashboard lists on the component overview tab.
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana-example
+  description: An example for Grafana integration.
+  annotations:
+    grafana/dashboard-selector: 'general'
+    grafana/alert-label-selector: 'type=http-requests'
+```

--- a/tap-gui/configurator/validated-community-plugins/homepage.hbs.md
+++ b/tap-gui/configurator/validated-community-plugins/homepage.hbs.md
@@ -1,0 +1,57 @@
+# Homepage in Tanzu Developer Portal
+
+This topic tells you about the Homepage validated frontend plugin.
+
+The Homepage frontend plug-in makes it possible to create a custom home page for your Tanzu Developer Portal to conveniently surface important information.
+To learn more about the Homepage plug-ins visit the [Homepage Backstage documentation](https://github.com/backstage/backstage/tree/master/plugins/home).
+
+## <a id="add-plugin"></a> Adding the Homepage Plug-in to a Custom Tanzu Developer Portal
+
+### <a id="buildtime-config"></a> Buildtime Configuration
+
+To add the Homepage plug-in to your custom Tanzu Developer portal, add the frontend plugin to your `tdp-config.yaml` file:
+
+```yaml
+app:
+  plugins:
+    ...
+    - name: '@vmware-tanzu/tdp-plugin-home'
+      version: '^0.0.2'
+    ...
+```
+
+In this example, we use version `^0.0.2` as it is the latest version at the time of writing.
+
+### <a id="runtime-config"></a> Runtime Configuration
+
+To customize your Homepage, update the `app_config` section of your `tap-values.yaml` file like the following example:
+
+```yaml
+tap_gui:
+  # ... existing configuration
+  app_config:
+    # ... existing configuration
+    customize:
+      # ... existing configuration
+      features:
+        # ... existing configuration
+        home:
+          # Activate or deactivate the plugin? Default: true
+          enabled: true
+          # Show or hide the sidebar entry. Default: true
+          showInSidebar: true
+          # base64 encoded SVG image.
+          logo: 'BASE64-ENCODED-LOGO-STRING'
+          welcomeMessage: string
+          quickLinks:
+            url: string
+            label: string
+            # base64 encoded SVG image.
+            icon: 'BASE64-ENCODED-ICON-STRING'
+
+```
+
+Where:
+
+* all of the values are optional
+* `BASE64-ENCODED-LOGO-STRING` and 'BASE64-ENCODED-ICON-STRING' are base64 encoded svgs

--- a/tap-gui/configurator/validated-community-plugins/jira.hbs.md
+++ b/tap-gui/configurator/validated-community-plugins/jira.hbs.md
@@ -1,0 +1,63 @@
+# Jira in Tanzu Developer Portal
+
+This topic tells you about the Jira validated frontend plugin.
+
+The Jira frontend plug-in visualizes your JIRA activity stream in a Component's overview tab.
+To learn more about the Jira plug-ins visit the [Jira Plug-in documentation](https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-jira).
+
+## <a id="add-plugin"></a> Adding the Jira Plug-in to a Custom Tanzu Developer Portal
+
+### <a id="buildtime-config"></a> Buildtime Configuration
+
+To add the Jira plug-in to your custom Tanzu Developer portal, add the frontend plugin to your `tdp-config.yaml` file:
+
+```yaml
+app:
+  plugins:
+    ...
+    - name: '@vmware-tanzu/tdp-plugin-backstage-jira'
+      version: '^0.0.2'
+    ...
+```
+
+In this example, we use version `^0.0.2` as it is the latest version at the time of writing.
+
+### <a id="runtime-config"></a> Runtime Configuration
+
+To configure the Jira plug-in, update the `app_config` section of your `tap-values.yaml` file to include a proxy entry like the following example:
+
+```yaml
+tap_gui:
+  # ... existing configuration
+  app_config:
+    # ... existing configuration
+    proxy:
+      # ... existing configuration
+      '/jira/api':
+        target: JIRA-URL
+        headers:
+          Authorization:
+            $env: JIRA-TOKEN
+          Accept: 'application/json'
+          Content-Type: 'application/json'
+          X-Atlassian-Token: 'no-check'
+          # This is a workaround since Jira APIs reject browser origin requests. Any dummy string without whitespace works.
+          User-Agent: 'AnyRandomString'
+```
+Where:
+
+* `JIRA-URL` is the url for your Jira instance.
+* `JIRA-TOKEN` is a valid token for your Jira instance.
+
+Add the `annotations` entry for Jira to the catalog entity to display the jira project results on the component overview tab.
+
+##### Catalog
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: jira-overview-card
+  annotations:
+    jira/project-key: YOUR_PROJECT_KEY
+```

--- a/tap-gui/configurator/validated-community-plugins/prometheus.hbs.md
+++ b/tap-gui/configurator/validated-community-plugins/prometheus.hbs.md
@@ -1,0 +1,51 @@
+# Prometheus in Tanzu Developer Portal
+
+This topic tells you about the Prometheus validated frontend plugin.
+
+The Prometheus frontend plug-in displays Prometheus information in your Tanzu Developer Portal. 
+To learn more about the Snyk plug-ins visit the [Prometheus Plug-in documentation](https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-prometheus).
+
+## <a id="add-plugin"></a> Adding the Prometheus Plug-in to a Custom Tanzu Developer Portal
+
+### <a id="buildtime-config"></a> Buildtime Configuration
+
+To add the Prometheus plug-in to your custom Tanzu Developer portal, add the frontend plugin to your `tdp-config.yaml` file:
+
+```yaml
+app:
+  plugins:
+    ...
+    - name: '@vmware-tanzu/tdp-plugin-prometheus'
+      version: '^0.0.2'
+    ...
+```
+
+In this example, we use version `^0.0.2` as it is the latest version at the time of writing.
+
+### <a id="runtime-config"></a> Runtime Configuration
+
+To configure the Prometheus plug-in, update the `app_config` section of your `tap-values.yaml` file to include a `proxy` entry and `prometheus` configiration like the following example:
+
+```yaml
+tap_gui:
+  # ... existing configuration
+  app_config:
+    # ... existing configuration
+    proxy:
+      # ... existing configuration
+      '/prometheus/api':
+        # url to the api and path of your hosted prometheus instance
+        target: http://localhost:9090/api/v1/
+        changeOrigin: true
+        secure: false
+        headers:
+          Authorization: AUTH-TOKEN
+
+    # Defaults to /prometheus/api and can be omitted if proxy is configured for that url
+    prometheus:
+      proxyPath: /prometheus/api
+      uiUrl: http://localhost:9090
+```
+Where:
+
+* `PROMETHEUS-AUTH-TOKEN` is a valid token for your secure prometheus instance.

--- a/tap-gui/configurator/validated-community-plugins/snyk.hbs.md
+++ b/tap-gui/configurator/validated-community-plugins/snyk.hbs.md
@@ -1,0 +1,27 @@
+# Snyk in Tanzu Developer Portal
+
+This topic tells you about the Snyk validated frontend plugin.
+
+The Snyk frontend plug-in displays security vulnerabilities from [snyk.io](https://snyk.io/). The plug-in shows an overview of the vulnerabilities found by Snyk on the Overview tab of an entity, and adds a tab to the entity view showing all details related to the scan.
+To learn more about the Snyk plug-ins visit the [Snyk Backstage documentation](https://github.com/snyk-tech-services/backstage-plugin-snyk).
+
+## <a id="add-plugin"></a> Adding the Snyk Plug-in to a Custom Tanzu Developer Portal
+
+### <a id="buildtime-config"></a> Buildtime Configuration
+
+To add the Snyk plug-in to your custom Tanzu Developer portal, add the frontend plugin to your `tdp-config.yaml` file:
+
+```yaml
+app:
+  plugins:
+    ...
+    - name: '@vmware-tanzu/tdp-plugin-snyk'
+      version: '^0.0.2'
+    ...
+```
+
+In this example, we use version `^0.0.2` as it is the latest version at the time of writing.
+
+### <a id="runtime-config"></a> Runtime Configuration
+
+There is no runtime configuration required for the Synk frontend plug-in.

--- a/tap-gui/configurator/validated-community-plugins/sonarqube.hbs.md
+++ b/tap-gui/configurator/validated-community-plugins/sonarqube.hbs.md
@@ -1,0 +1,62 @@
+# SonarQube in Tanzu Developer Portal
+
+This topic tells you about the SonarQube validated frontend and backend plugins.
+
+The SonarQube frontend plug-in displays static analysis code quality statistics.
+To learn more about the SonarQube plug-ins visit the [SonarQube Backstage documentation](https://github.com/backstage/backstage/blob/master/plugins/sonarqube).
+
+## <a id="add-plugin"></a> Adding the SonarQube Plug-ins to a Custom Tanzu Developer Portal
+
+### <a id="buildtime-config"></a> Buildtime Configuration
+
+To add the SonarQube plug-ins to your custom Tanzu Developer portal, add the frontend and backend plugins to your `tdp-config.yaml` file:
+
+  ```yaml
+  app:
+    plugins:
+      ...
+      - name: '@vmware-tanzu/tdp-plugin-backstage-sonarqube'
+        version: '^0.0.2'
+      ...
+  backend:
+    plugins:
+      ...
+      - name: '@vmware-tanzu/tdp-plugin-backstage-sonarqube-backend'
+        version: '^0.0.3'
+      ...
+  ```
+
+In this example, we use versions `^0.0.2` and `^0.0.3` as they are the latest versions at the time of writing.
+
+### <a id="runtime-config"></a> Runtime Configuration
+
+To connect your Stack Overflow plug-in to a running instance, update the `app_config` section of your `tap-values.yaml` file like the following example:
+
+```yaml
+tap_gui:
+  # ... existing configuration
+  app_config:
+    # ... existing configuration
+    sonarqube:
+      baseUrl: 'SONARQUBE-URL'
+      apiKey: 'SONARQUBE-API-KEY'
+
+```
+Where:
+
+* `SONARQUBE-URL` is the url of your SonarQube instance.
+* `SONARQUBE-API-KEY` is a valid api key for connecting to the SonarQube instance.
+
+
+Add the `annotations` entry for sonarqube to the catalog entity to display the sonarqube project results on the component overview tab.
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage
+  annotations:
+    sonarqube.org/project-key: YOUR_INSTANCE_NAME/YOUR_PROJECT_KEY
+```
+
+More detailed explanation for Sonarqube configuration is available [here](https://github.com/backstage/backstage/blob/master/plugins/sonarqube-backend/README.md).

--- a/tap-gui/configurator/validated-community-plugins/stackoverflow.hbs.md
+++ b/tap-gui/configurator/validated-community-plugins/stackoverflow.hbs.md
@@ -1,0 +1,36 @@
+# Stack Overflow in Tanzu Developer Portal
+
+This topic tells you about the Stack Overflow validated frontend plugin.
+
+The Stack Overflow frontend plug-in provides Stack Overflow functionality in your Tanzu Developer Portal.
+To learn more about the Stack Overflow plug-ins visit the [Stack Overflow Backstage documentation](https://github.com/backstage/backstage/tree/master/plugins/stack-overflow).
+
+## <a id="add-plugin"></a> Adding the Stack Overflow Plug-in to a Custom Tanzu Developer Portal
+
+### <a id="buildtime-config"></a> Buildtime Configuration
+
+To add the Stackoverflow plug-in to your custom Tanzu Developer portal, add the frontend plugin to your `tdp-config.yaml` file:
+
+  ```yaml
+  app:
+    plugins:
+      ...
+      - name: '@vmware-tanzu/tdp-plugin-stack-overflow'
+        version: '^0.0.2'
+      ...
+  ```
+
+In this example, we use version `^0.0.2` as it is the latest version at the time of writing.
+
+### <a id="runtime-config"></a> Runtime Configuration
+
+To configure your Stack Overflow plug-in, update the `app_config` section of your `tap-values.yaml` file like the following example:
+
+```yaml
+tap_gui:
+  # ... existing configuration
+  app_config:
+    # ... existing configuration
+    stackoverflow:
+      baseUrl: https://api.stackexchange.com/2.2 # alternative: your internal stack overflow instance
+```

--- a/tap-gui/configurator/validated-community-plugins/techinsights.hbs.md
+++ b/tap-gui/configurator/validated-community-plugins/techinsights.hbs.md
@@ -1,0 +1,34 @@
+# TechInsights in Tanzu Developer Portal
+
+This topic tells you about the TechInsights validated frontend and backend plugins.
+
+The TechInsights frontend plug-in visualizes entity checks defined by the backend plug-in. 
+The TechInsights backend plug-in performs entity checks and provides an API for the fronend plug-in.
+To learn more about the TechInsights plug-ins visit the [TechInsights Backstage documentation](https://github.com/backstage/backstage/tree/master/plugins/tech-insights).
+
+## <a id="add-plugin"></a> Adding the TechInsights Plug-in to a Custom Tanzu Developer Portal
+
+### <a id="buildtime-config"></a> Buildtime Configuration
+
+To add the TechInsights plug-ins to your custom Tanzu Developer portal, add the frontend and backend plugins to your `tdp-config.yaml` file:
+
+  ```yaml
+  app:
+    plugins:
+      ...
+      - name: '@vmware-tanzu/tdp-plugin-techinsights'
+        version: '^0.0.2'
+      ...
+  backend:
+    plugins:
+      ...
+      - name: '@vmware-tanzu/tdp-plugin-techinsights-backend'
+        version: '^0.0.2'
+      ...
+  ```
+
+In this example, we use version `^0.0.2` as it is the latest version at the time of writing.
+
+### <a id="runtime-config"></a> Runtime Configuration
+
+There is no runtime configuration required for the TechInsights plug-ins.

--- a/tap-gui/plugins/about.hbs.md
+++ b/tap-gui/plugins/about.hbs.md
@@ -37,15 +37,15 @@ with Tanzu Developer Portal.
 
 Tanzu Developer Portal currently supports the following validated plug-ins:
 
-- GitHub Actions
-- Grafana
-- Home Page
-- Jira
-- Prometheus
-- Snyk
-- SonarQube
-- Stack Overflow
-- TechInsights
+- [GitHub Actions](../configurator/validated-community-plugins/github-actions.hbs.md)
+- [Grafana](../configurator/validated-community-plugins/grafana.hbs.md)
+- [Homepage](../configurator/validated-community-plugins/home-page.hbs.md)
+- [Jira](../configurator/validated-community-plugins/jira.hbs.md)
+- [Prometheus](../configurator/validated-community-plugins/prometheus.hbs.md)
+- [Snyk](../configurator/validated-community-plugins/snyk.hbs.md)
+- [SonarQube](../configurator/validated-community-plugins/sonarqube.hbs.md)
+- [Stack Overflow](../configurator/validated-community-plugins/stack-overflow.hbs.md)
+- [TechInsights](../configurator/validated-community-plugins/techinsights.hbs.md)
 
 ## <a id='ext-plug-ins'></a> External plug-ins
 

--- a/toc.hbs.md
+++ b/toc.hbs.md
@@ -656,6 +656,7 @@
          - [Build your customized Tanzu Developer Portal](tap-gui/configurator/building.hbs.md)
          - [Configure the Configurator with a private registry](tap-gui/configurator/private-registries.hbs.md)
          - [Run your customized Tanzu Developer Portal](tap-gui/configurator/running.hbs.md)
+         - [Validated Community Plugins](tap-gui/configurator/validated-community-plugins/about.hbs.md)
          - [Troubleshoot Tanzu Developer Portal Configurator](tap-gui/configurator/troubleshooting.hbs.md)
       - [Tanzu Developer Portal plug-ins](tap-gui/plugins/about.hbs.md)
          - [Tanzu Developer Portal plug-ins overview](tap-gui/plugins/about.hbs.md)


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
1.7

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches

Notes:
* for plugin docs I linked to a lot of github pages. I wasn't sure if we prefer source code docs or npmjs pages, or something else.
* plugin version will change with future releases. It is important for customers to know which plugin version corresponds to which tap release. In the examples I provided the latest version for the 1.7 release, and noted that this is the latest version at  the time of writing. This will be improved with [ESBACK-628](https://jira.eng.vmware.com/browse/ESBACK-628)
* I've introduced some duplication for the list of validated plugins. I think it makes sense to have the list on the plugins page, but also in the configurator section since the validated plugins are only relevant when building a custom tdp.
