### PR TITLE
Allows k8s-reader cluster role to fetch CRDs for TAP Gui

### DIFF
--- a/tap-gui/cluster-view-setup.hbs.md
+++ b/tap-gui/cluster-view-setup.hbs.md
@@ -151,6 +151,9 @@ To set up a Service Account to view resources on a cluster:
       resources:
       - resourceinspectiongrants
       verbs: ['get', 'watch', 'list', 'create']
+    - apiGroups: ['apiextensions.k8s.io']
+      resources: ['customresourcedefinitions']
+      verbs: ['get', 'watch', 'list']
     ```
 
     This YAML content creates `Namespace`, `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding`.


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

1.7.0+