### PR TITLE
release notes: breaking change: TAP defaults to Deployment for Contour's Envoy now, causes downtime

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -252,6 +252,26 @@ This release includes the following changes, listed by component and area.
 
 - Minikube support has been removed.
 
+
+#### <a id="1-7-0-contour-br"></a> v1.7.0 Breaking changes: Contour
+
+Change:
+- TAP now defaults to installing Contour as a Deployment instead of a DaemonSet
+
+Implications:
+- When upgrading to TAP 1.7.0, the Envoy pods will be deleted and recreated. This means there will be downtime for all workloads exposed publicly (including all Web Workloads, TAP GUI, and any Server workloads exposed manually via an HTTPProxy).
+
+Mitigation:
+- Prior to upgrading, update your tap-values file to add `contour.envoy.workload.type` and set it to `DaemonSet`
+  Example yaml snippet for tap-values:
+  
+  ```
+  contour:
+    envoy:
+      workload:
+        type: DaemonSet
+  ```
+
 #### <a id="1-7-0-alv-br"></a> v1.7.0 Breaking changes: Application Live View
 
 - The `appliveview_connector.backend.sslDisabled` key has been removed and is replaced by

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -256,7 +256,7 @@ This release includes the following changes, listed by component and area.
 #### <a id="1-7-0-contour-br"></a> v1.7.0 Breaking changes: Contour
 
 Change:
-- TAP now defaults to installing Contour as a Deployment instead of a DaemonSet. It will default to 2 replicas.
+- TAP now defaults to installing Contour as a Deployment instead of a DaemonSet. It will default to 2 replicas. **This will cause downtime when upgrading**.
 
 Implication 1:
 - When upgrading to TAP 1.7.0, the Envoy pods will be deleted and recreated. This means there will be downtime for all workloads exposed publicly (including all Web Workloads, TAP GUI, and any Server workloads exposed manually via an HTTPProxy).

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -262,7 +262,7 @@ Implication 1:
 - When upgrading to TAP 1.7.0, the Envoy pods will be deleted and recreated. This means there will be downtime for all workloads exposed publicly (including all Web Workloads, TAP GUI, and any Server workloads exposed manually via an HTTPProxy).
 
 Mitigation 1:
-- Prior to upgrading, update your tap-values file to add `contour.envoy.workload.type` and set it to `DaemonSet`
+- If you wish to remain using a DaemonSet, prior to upgrading, update your tap-values file to add `contour.envoy.workload.type` and set it to `DaemonSet`
   Example yaml snippet for tap-values:
   
   ```

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -256,12 +256,12 @@ This release includes the following changes, listed by component and area.
 #### <a id="1-7-0-contour-br"></a> v1.7.0 Breaking changes: Contour
 
 Change:
-- TAP now defaults to installing Contour as a Deployment instead of a DaemonSet
+- TAP now defaults to installing Contour as a Deployment instead of a DaemonSet. It will default to 2 replicas.
 
-Implications:
+Implication 1:
 - When upgrading to TAP 1.7.0, the Envoy pods will be deleted and recreated. This means there will be downtime for all workloads exposed publicly (including all Web Workloads, TAP GUI, and any Server workloads exposed manually via an HTTPProxy).
 
-Mitigation:
+Mitigation 1:
 - Prior to upgrading, update your tap-values file to add `contour.envoy.workload.type` and set it to `DaemonSet`
   Example yaml snippet for tap-values:
   
@@ -270,6 +270,21 @@ Mitigation:
     envoy:
       workload:
         type: DaemonSet
+  ```
+
+Implication 2:
+- When running Envoy as a Deployment, the pods include anti-affinity rules so that they are not installed on the same node. With a default of 2, this means your cluster needs a minimum of 2 nodes for a successful install.
+
+Mitigation 2:
+- If you are running a single node cluster, prior to upgrading, update your tap-values file to add `contour.envoy.workload.replicas` and set it to `1`
+  Example yaml snippet for tap-values:
+  
+  ```
+  contour:
+    envoy:
+      workload:
+	    type: Deployment
+        replicas: 2
   ```
 
 #### <a id="1-7-0-alv-br"></a> v1.7.0 Breaking changes: Application Live View


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
