### PR TITLE
Crossplane v1.14 in TAP 1.8

### DIFF
--- a/crossplane/reference/version-matrix.hbs.md
+++ b/crossplane/reference/version-matrix.hbs.md
@@ -36,5 +36,21 @@ used in UXP, provider-helm, and provider-kubernetes.
         <td>0.15.0</td>
         <td>0.8.0</td>
     </tr>
+    <tr>
+        <td>1.7.0</td>
+        <td>0.3.0</td>
+        <td>1.13.2-up.1</td>
+        <td>1.13.2-up.1</td>
+        <td>0.15.0</td>
+        <td>0.9.0</td>
+    </tr>
+    <tr>
+        <td>1.8.0</td>
+        <td>0.4.0</td>
+        <td>1.14.1-up.1</td>
+        <td>1.14.1-up.1</td>
+        <td>0.15.0</td>
+        <td>0.9.0</td>
+    </tr>
   </tbody>
 </table>

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -36,6 +36,10 @@ This release includes the following changes, listed by component and area.
 #### <a id='1-8-0-COMPONENT-NAME'></a> v1.8.0 Features: COMPONENT-NAME
  
 - Feature description.
+
+#### <a id='1-8-0-COMPONENT-NAME'></a> v1.8.0 Features: Crossplane
+
+- Updates Universal Crossplane to v1.14.1-up.1. For more information, see the [Upbound blog](https://blog.crossplane.io/crossplane-v1-14/).
  
 ---
  


### PR DESCRIPTION
## About

Updates docs for new crossplane version.

Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

The addition of the 1.7.0 row to the matrix in crossplane/reference/version-matrix.hbs.md should also be back ported to TAP 1.7. The 1.8.0 row and the update to the release notes should only exist on `main` for TAP 1.8.