### PR TITLE
fixes typo replacing tanzu cmd with kubectl

### DIFF
--- a/tap-gui/configurator/building.hbs.md
+++ b/tap-gui/configurator/building.hbs.md
@@ -204,7 +204,7 @@ Use an existing supply chain
   2. Submit the workload definition file by running:
 
       ```console
-      tanzu apps workload create -f tdp-workload.yaml
+      kubectl apply -f tdp-workload.yaml
       ```
 
      The supply chain does not need to go beyond the image-provider stage. After an image is built,


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
1.7 onwards

