### PR TITLE
Update release-notes.hbs.md

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -343,6 +343,12 @@ to ensure that they are correctly created.
 - Clicking the red square Stop button in the Visual Studio top toolbar can cause a workload to fail.
   For more information, see [Troubleshooting](vs-extension/troubleshooting.hbs.md#stop-button).
 
+#### <a id='1-7-1-tap-tsm-integrations-ki'></a> v1.7.1 Known issues: TAP TSM integrations
+
+- Clicking the red square Stop button in the Visual Studio top toolbar can cause a workload to fail.
+  [TAP integration with TSM](integrations/tsm-tap-integration.hbs.md) does not work out of of the box on Vsphere with Tanzu TKr 1.26.
+  One may apply the label advised by [Vsphere with Tanzu 1.26 release notes](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-releases/services/rn/vmware-tanzu-kubernetes-releases-release-notes/index.html#TKr%201.26.5%20for%20vSphere%208.x-What's%20New) as a workaround, but that would be provide more than the
+  mininum necessary privlige to the resources in developer namespaces.
 ---
 
 ### <a id='1-7-1-components'></a> v1.7.1 Component versions


### PR DESCRIPTION
adding TSM + TAP integrations limitation with a workaround on 1.7.1 release notes

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
