### PR TITLE
Add CarbonBlack pod security known issue

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -1605,6 +1605,16 @@ This release has the following known issues, listed by component and area.
   This is due to caching behavior in the system which is not accounted for during configuration updates.
   For a workaround, see [Troubleshoot Bitnami Services](bitnami-services/how-to-guides/troubleshooting.hbs.md#private-reg).
 
+#### <a id='1-7-0-cbc-scanner-ki'></a> v1.7.0 Known issues: Carbon Black Scanner for SCST - Scan
+
+- Carbon Black Scanner templates will raise a PodSecurity violation error in clusters that use the
+  restricted Pod Security Standard. As a temporary workaround, you can do the following:
+
+  - Copy the template (e.g `carbonblack-private-image-scan-template`) with a different name.
+  - Set `securityContext.runAsNonRoot: true` in the new template
+  - Apply the new template to your cluster
+  - Update the `tap-values.yaml` file to use the new template in your workloads.
+
 #### <a id='1-7-0-convention-ki'></a> v1.7.0 Known issues: Cartographer Conventions
 
 - While processing workloads with large SBOMs, the Cartographer Convention controller manager pod can

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -1611,7 +1611,17 @@ This release has the following known issues, listed by component and area.
   restricted Pod Security Standard. As a temporary workaround, you can do the following:
 
   - Copy the template (e.g `carbonblack-private-image-scan-template`) with a different name.
-  - Set `securityContext.runAsNonRoot: true` in the new template
+  - Set the following `securityContext` in the new template:
+    ```
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      privileged: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+    ```
   - Apply the new template to your cluster
   - Update the `tap-values.yaml` file to use the new template in your workloads.
 


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

This change applies to TAP 1.7.0 and 1.7.1.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
