### PR TITLE
Link to new procedure for blue-green with Flagger

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -7,6 +7,14 @@ v{{ vars.url_version }}.
 
 **Release Date**: 12 December 2023
 
+### <a id='1-7-2-new-features'></a> v1.7.2 New features by component and area
+
+This release includes the following changes, listed by component and area.
+
+#### <a id='1-7-2-scc'></a> v1.7.2 Features: Supply Chain Choreographer
+
+- Documents procedure for implementing blue-green deployments with Flagger for Carvel Package Supply Chains. See [Use blue-green deployment with Flagger for Supply Chain Choreographer (beta)](scc/blue-green-with-flagger.hbs.md).
+
 ### <a id='1-7-2-security-fixes'></a> v1.7.2 Security fixes
 
 This release has the following security fixes, listed by component and area.

--- a/toc.hbs.md
+++ b/toc.hbs.md
@@ -518,6 +518,7 @@
               - [Use Gitops delivery with Argo CD (beta)](scc/delivery-with-argo.hbs.md)
               - [Use Blue-green deployment with Contour and PackageInstall (beta)](scc/blue-green-with-packageinstall.hbs.md)
               - [Use Canary deployment with Contour and Carvel Packages](scc/canary-deployment.hbs.md)
+              - [Use Blue-green deployments with Flagger](scc/blue-green-with-flagger.hbs.md)
           - [Use an existing image in Your Supply Chain](scc/pre-built-image.hbs.md)
           - [Authenticate Git](scc/git-auth.hbs.md)
           - [Use Azure DevOps as a Git provider](scc/azure.hbs.md)


### PR DESCRIPTION
I updated the release notes for 1.7.2 with a "new feature", but actually this procedure has been in the docs since 1.7, just not linked. So let me know if I should be updating the 1.7.0 release notes instead.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

1.8/main.
