### PR TITLE
Add deprecated warning for APIx package

### DIFF
--- a/api-validation-scoring/about.hbs.md
+++ b/api-validation-scoring/about.hbs.md
@@ -1,7 +1,7 @@
 # Overview of API Validation and Scoring
 
 > **Caution** The APIx package used for API scoring and validation is deprecated.
-> It will be removed in TAP 1.8.
+> It will be removed in Tanzu Application Platform 1.8.
 
 API Validation and Scoring focuses on scanning and validating an OpenAPI specification. 
 The API specification is generated from the [API Auto Registration](../api-auto-registration/about.hbs.md). 

--- a/api-validation-scoring/about.hbs.md
+++ b/api-validation-scoring/about.hbs.md
@@ -1,5 +1,8 @@
 # Overview of API Validation and Scoring
 
+> **Caution** The APIx package used for API scoring and validation is deprecated.
+> It will be removed in TAP 1.8.
+
 API Validation and Scoring focuses on scanning and validating an OpenAPI specification. 
 The API specification is generated from the [API Auto Registration](../api-auto-registration/about.hbs.md). 
 After an API is registered, the API specification goes through static scan analysis and is validated. 

--- a/api-validation-scoring/about.hbs.md
+++ b/api-validation-scoring/about.hbs.md
@@ -1,7 +1,7 @@
 # Overview of API Validation and Scoring
 
 > **Caution** The APIx package used for API scoring and validation is deprecated.
-> It will be removed in Tanzu Application Platform 1.8.
+> It will be removed in the next Tanzu Application Platform release.
 
 API Validation and Scoring focuses on scanning and validating an OpenAPI specification. 
 The API specification is generated from the [API Auto Registration](../api-auto-registration/about.hbs.md). 

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -1927,6 +1927,10 @@ The following table lists the supported component versions for this Tanzu Applic
 The following features, listed by component, are deprecated.
 Deprecated features remain on this list until they are retired from Tanzu Application Platform.
 
+### <a id='1-7-api-deprecations'></a> API Scoring and Validation deprecations
+
+- The `apix` package is deprecated and will be removed in the next Tanzu Application Platform 1.8 release.
+
 ### <a id='1-7-cnrs-deprecations'></a> Cloud Native Runtimes deprecations
 
 - **`default_tls_secret` config option**: After changes in this release, this config option is moved

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -1929,7 +1929,7 @@ Deprecated features remain on this list until they are retired from Tanzu Applic
 
 ### <a id='1-7-api-deprecations'></a> API Scoring and Validation deprecations
 
-- The `apix` package is deprecated and will be removed in the next Tanzu Application Platform 1.8 release.
+- The `apix` package is deprecated and will be removed in the next Tanzu Application Platform release.
 
 ### <a id='1-7-cnrs-deprecations'></a> Cloud Native Runtimes deprecations
 


### PR DESCRIPTION
This change is only for 1.7. I will be making a different MR for 1.8 to completely remove the package and its docs.

cc/ @csterwa @royclarkson