### PR TITLE
Remove policy controller exclusion

### DIFF
--- a/install-aws/profile.hbs.md
+++ b/install-aws/profile.hbs.md
@@ -231,9 +231,6 @@ ceip_policy_disclosed: true
 
 profile: full # Can take iterate, build, run, view.
 
-excluded_packages:
-- policy.apps.tanzu.vmware.com
-
 supply_chain: basic # Can take testing, testing_scanning.
 
 ootb_supply_chain_basic: # Based on supply_chain set above, can be changed to ootb_supply_chain_testing, ootb_supply_chain_testing_scanning.

--- a/install-openshift/profile.hbs.md
+++ b/install-openshift/profile.hbs.md
@@ -259,9 +259,6 @@ ceip_policy_disclosed: FALSE-OR-TRUE-VALUE # Installation fails if this is not s
 
 profile: full # Can take iterate, build, run, view.
 
-excluded_packages:
-- policy.apps.tanzu.vmware.com
-
 supply_chain: basic # Can take testing, testing_scanning.
 
 ootb_supply_chain_basic: # Based on supply_chain set above, can be changed to ootb_supply_chain_testing, ootb_supply_chain_testing_scanning.


### PR DESCRIPTION
This exclusion is no longer needed, and was fixed in 1.3.2.  It was missed in removing it from openshift and aws.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

1.4, 1.5, 1.6, 1.7.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
