### PR TITLE
VSEE-1287 | added a note to specifically call out TKGs 1.26+ as restricted cluster

### DIFF
--- a/scst-scan/install-app-scanning.hbs.md
+++ b/scst-scan/install-app-scanning.hbs.md
@@ -40,7 +40,7 @@ tekton_pipelines:
     disable_affinity_assistant: "true"
 ```
 
-Having affinity assistance `enabled` specifically on clusters with restricted pod context like TKGs 1.26+ where Pod Scurity Admission Pod Security Standards is set to be restricted by default, can cause a deadlock where affinity pod cannot be scheduled and will prevent scanning go ahead.
+Having the Affinity Assistant feature `enabled` on clusters where the Kubernetes Pod Security Admission is enforcing Pod Security Standards to be restricted by default (like TKGs 1.26+), can cause a deadlock where the affinity pod cannot be scheduled and it will prevent scanning go ahead.
 
 ## <a id="install-scst-app-scanning"></a> Install
 

--- a/scst-scan/install-app-scanning.hbs.md
+++ b/scst-scan/install-app-scanning.hbs.md
@@ -40,6 +40,8 @@ tekton_pipelines:
     disable_affinity_assistant: "true"
 ```
 
+Having affinity assistance `enabled` specifically on clusters with restricted pod context like TKGs 1.26+ where Pod Scurity Admission Pod Security Standards is set to be restricted by default, can cause a deadlock where affinity pod cannot be scheduled and will prevent scanning go ahead.
+
 ## <a id="install-scst-app-scanning"></a> Install
 
 To install SCST - Scan 2.0:


### PR DESCRIPTION
where affinity assistance should be specifically be disabled.

please cherry pick to `main`.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
