### PR TITLE
Remove net-istio config options

### DIFF
--- a/cloud-native-runtimes/how-to-guides/app-operators/resource_management.hbs.md
+++ b/cloud-native-runtimes/how-to-guides/app-operators/resource_management.hbs.md
@@ -30,8 +30,6 @@ To configure the memory and CPU allocation for the deployments in the `knative-s
 - `net-certmanager-webhook`
 - `net-contour-controller`
 - `webhook`
-- `net-istio-controller`
-- `net-istio-webhook`
 
 ### <a id='resource-mgmt-example'></a> Example: updating the activator deployment
 


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
* 1-7-0
* 1-7-1
* 1-7-2
* 1-7-3

---
The package no longer bundles net-istio. Cleaned out references to configuration options specific to net-istio. Additionally these specific values will always cause a deploy to fail.