### PR TITLE
Updating example for pinniped tls passthrough httpproxy

### DIFF
--- a/authn-authz/pinniped-install-guide.hbs.md
+++ b/authn-authz/pinniped-install-guide.hbs.md
@@ -137,8 +137,8 @@ spec:
     fqdn: "DNS-NAME"
     tls:
       passthrough: true
-  routes:
-  - services:
+  tcpproxy:
+    services:
     - name: pinniped-supervisor
       port: 8443
 ```
@@ -369,8 +369,8 @@ spec:
     fqdn: "DNS-NAME"
     tls:
       passthrough: true
-  routes:
-  - services:
+  tcpproxy:
+    services:
     - name: pinniped-supervisor
       port: 8443
 ```


### PR DESCRIPTION
(First PR! Apologies if I missed something.) 

The example httpproxy provided when using `tls.passthrough = true` does not follow contour's official documentation. We had to change this in our environment in order to connect to pinniped. Cross referenced this against another environment and they had made the same change (outside of TAP). 

https://projectcontour.io/docs/1.25/config/tls-termination/#tls-session-passthrough

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
This was tested against TAP 1.7.2, but likely needs to go to all 1.7.x 

---
It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
