### PR TITLE
remove deprecated appliveview-sample convention

### DIFF
--- a/app-live-view/configuring-apps/convention-server.hbs.md
+++ b/app-live-view/configuring-apps/convention-server.hbs.md
@@ -115,7 +115,6 @@ status:
         conventions.carto.run/applied-conventions: |-
           spring-boot-convention/auto-configure-actuators-check
           spring-boot-convention/app-live-view-appflavour-check
-          appliveview-sample/app-live-view-appflavour-check
           appliveview-sample/app-live-view-connector-steeltoe
           appliveview-sample/app-live-view-appflavours-steeltoe
         developer.conventions/target-containers: workload

--- a/spring-boot-conventions/enabling-app-live-view.hbs.md
+++ b/spring-boot-conventions/enabling-app-live-view.hbs.md
@@ -116,7 +116,6 @@ status:
           spring-boot-convention/app-live-view-appflavour-check
           spring-boot-convention/app-live-view-connector-boot
           spring-boot-convention/app-live-view-appflavours-boot
-          appliveview-sample/app-live-view-appflavour-check
         developer.conventions/target-containers: workload
       labels:
         app.kubernetes.io/component: run
@@ -240,7 +239,6 @@ status:
           spring-boot-convention/app-live-view-appflavours-boot
           spring-boot-convention/app-live-view-connector-scg
           spring-boot-convention/app-live-view-appflavours-scg
-          appliveview-sample/app-live-view-appflavour-check
         developer.conventions/target-containers: workload
       labels:
         app.kubernetes.io/component: run


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
This is targeted for only TAP 1.8 release

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
