### PR TITLE
Add version matrix for servicebinding on tap 1.8

### DIFF
--- a/service-bindings/version-matrix.hbs.md
+++ b/service-bindings/version-matrix.hbs.md
@@ -1,0 +1,30 @@
+# Version matrix for Service Binding
+
+This topic provides a matrix of versions between Tanzu Application Platform, the service binding package
+(`servicebinding.tanzu.vmware.com`), and the [service binding runtime](https://github.com/servicebinding/runtime/), which is the community reference implementation of [Service Binding](https://servicebinding.io/).
+
+> **Note** Tanzu Application Platform patch releases are only added to the table when there
+> is a change to one or more of the other versions in the table. Otherwise, the corresponding
+> versions remain the same for each Tanzu Application Platform patch release.
+
+<table>
+  <thead>
+    <tr>
+        <th>Tanzu Application Platform</th>
+        <th>Service Binding package</th>
+        <th>Service Binding runtime</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+        <td>1.7.1</td>
+        <td>0.10.2</td>
+        <td>0.6.0</td>
+    </tr>
+    <tr>
+        <td>1.8.0</td>
+        <td>0.11.0</td>
+        <td>0.7.0</td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

No, this is only for tap 1.8
