### PR TITLE
Use a simple unauthenticated example to start the walkthrough

### DIFF
--- a/scst-store/api-walkthrough.hbs.md
+++ b/scst-store/api-walkthrough.hbs.md
@@ -6,22 +6,42 @@ This topic includes an example API call that you can use with Supply Chain Secur
 
 The following procedure explains how to use CURL to POST an image report.
 
-1. In your terminal, switch to the kubectl context or kubeconfig to target the TAP _View_ cluster.
+1. In the terminal, switch to the kubectl context or kubeconfig to target the TAP _View_ cluster.
 
-2. Retrieve the `metadata-store-read-write-client` access token.
-    See [Retrieve access tokens](retrieve-access-tokens.hbs.md). Run:
-
-    ```console
-    export METADATA_STORE_ACCESS_TOKEN=$(kubectl get secrets metadata-store-read-write-client -n metadata-store -o jsonpath="{.data.token}" | base64 -d)
-    ```
-
-3. Retrieve the CA Certificate and store it locally. Run:
+2. Retrieve the CA certificate and store it locally. Run:
 
     ```console
     kubectl get secret ingress-cert -n metadata-store -o json | jq -r '.data."ca.crt"' | base64 -d > /tmp/ca.crt
     ```
 
-4. Run the Curl POST command. This assumes that you have deployed TAP with ingress enabled. We discuss in a [different section](#without-ingress) what to do if ingress is not enabled.
+3. Use Curl to make a request to the health endpoint as an example. This assumes that you have deployed TAP with ingress enabled. We discuss in a [different section](#without-ingress) what to do if ingress is not enabled.
+
+   ```console
+   curl -i https://metadata-store.<ingress-domain>/api/health \
+       --cacert /tmp/ca.crt
+   ```
+
+   For example:
+
+   ```console
+   $ curl -i https://metadata-store.example.com/api/health \
+      --cacert /tmp/ca.crt
+   
+   HTTP/2 200
+   content-length: 0
+   date: Tue, 23 Jan 2024 22:50:57 GMT
+   x-envoy-upstream-service-time: 0
+   server: envoy
+   ```
+
+4. Next we'll try an _authenticated_ endpoint. Authenticated endpoints require an access token. Retrieve the `metadata-store-read-write-client` access token.
+    (See [Retrieve access tokens](retrieve-access-tokens.hbs.md) for more details). Run:
+
+    ```console
+    export METADATA_STORE_ACCESS_TOKEN=$(kubectl get secrets metadata-store-read-write-client -n metadata-store -o jsonpath="{.data.token}" | base64 -d)
+    ```
+
+5. We'll use the `api/imageReport` endpoint as an example. Use Curl to create a POST request: 
 
     ```console
     curl https://metadata-store.<ingress-domain>/api/imageReport \
@@ -32,7 +52,7 @@ The following procedure explains how to use CURL to POST an image report.
         --data "@<ABSOLUTE PATH TO THE POST BODY>"
     ```
 
-5. Replace \<ABSOLUTE PATH TO THE POST BODY\> with the absolute filepath of the API JSON for an image report.
+    Replace \<ABSOLUTE PATH TO THE POST BODY\> with the absolute filepath of the API JSON for an image report.
 
 6. The following is a sample POST body of a image report API JSON:
 


### PR DESCRIPTION
The existing example uses an authenticated example which requires an access token. We should start with an unauthenticated endpoint to ease the reader.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

Merge into 1.7, 1.6, 1.5, and 1.4.