### PR TITLE
Fix source scan secret

### DIFF
--- a/scst-scan/scan-types.hbs.md
+++ b/scst-scan/scan-types.hbs.md
@@ -36,31 +36,41 @@ To add source scanning to the default out-of-the-box test and scan supply chain:
 1. Create a `secret.yml` file with a `Secret` that contains your ytt overlay. For example:
 
    ```yaml
-   #@ load("@ytt:overlay", "overlay")
-   #@overlay/match by=overlay.subset({"metadata":{"name":"source-test-scan-to-url"}, "kind": "ClusterSupplyChain"})
-   ---
-   spec:
-     resources:
-       #@overlay/match by=overlay.index(2)
-       #@overlay/insert before=True
-          - name: source-scanner
-            params:
-            - default: scan-policy
-              name: scanning_source_policy
-            - default: blob-source-scan-template
-              name: scanning_source_template
-            sources:
-            - name: source
-              resource: source-tester
-            templateRef:
-              kind: ClusterSourceTemplate
-              name: source-scanner-template
-          #@overlay/match by="name"
-          - name: image-provider
-            sources:
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: ootb-supply-chain-testing-scanning-add-source-scanner
+    namespace: tap-install
+    annotations:
+      kapp.k14s.io/change-group: "tap-overlays"
+  type: Opaque
+  stringData:
+    ootb-supply-chain-testing-scanning-add-source-scanner.yaml: |
+      #@ load("@ytt:overlay", "overlay")
+      #@overlay/match by=overlay.subset({"metadata":{"name":"source-test-scan-to-url"}, "kind": "ClusterSupplyChain"})
+      ---
+      spec:
+      resources:
+        #@overlay/match by=overlay.index(2)
+        #@overlay/insert before=True
+            - name: source-scanner
+              params:
+              - default: scan-policy
+                name: scanning_source_policy
+              - default: blob-source-scan-template
+                name: scanning_source_template
+              sources:
+              - name: source
+                resource: source-tester
+              templateRef:
+                kind: ClusterSourceTemplate
+                name: source-scanner-template
             #@overlay/match by="name"
-            - name: source
-              resource: source-scanner
+            - name: image-provider
+              sources:
+              #@overlay/match by="name"
+              - name: source
+                resource: source-scanner
    ```
 
    For information about ytt overlays, see the

--- a/scst-scan/scan-types.hbs.md
+++ b/scst-scan/scan-types.hbs.md
@@ -50,27 +50,27 @@ To add source scanning to the default out-of-the-box test and scan supply chain:
       #@overlay/match by=overlay.subset({"metadata":{"name":"source-test-scan-to-url"}, "kind": "ClusterSupplyChain"})
       ---
       spec:
-      resources:
-        #@overlay/match by=overlay.index(2)
-        #@overlay/insert before=True
-            - name: source-scanner
-              params:
-              - default: scan-policy
-                name: scanning_source_policy
-              - default: blob-source-scan-template
-                name: scanning_source_template
-              sources:
-              - name: source
-                resource: source-tester
-              templateRef:
-                kind: ClusterSourceTemplate
-                name: source-scanner-template
-            #@overlay/match by="name"
-            - name: image-provider
-              sources:
+        resources:
+          #@overlay/match by=overlay.index(2)
+          #@overlay/insert before=True
+              - name: source-scanner
+                params:
+                - default: scan-policy
+                  name: scanning_source_policy
+                - default: blob-source-scan-template
+                  name: scanning_source_template
+                sources:
+                - name: source
+                  resource: source-tester
+                templateRef:
+                  kind: ClusterSourceTemplate
+                  name: source-scanner-template
               #@overlay/match by="name"
-              - name: source
-                resource: source-scanner
+              - name: image-provider
+                sources:
+                #@overlay/match by="name"
+                - name: source
+                  resource: source-scanner
    ```
 
    For information about ytt overlays, see the


### PR DESCRIPTION
A previous commit accidentally removed the secret header, which makes it more difficult for a user to apply this workaround.  Adding this back in.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

Please cherry pick this to 1.6 and 1.7.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
