### PR TITLE
App Scanning installed in profiles

### DIFF
--- a/about-package-profiles.hbs.md
+++ b/about-package-profiles.hbs.md
@@ -736,13 +736,13 @@ For a diagram showing the packages contained in each profile, see
    <td></td>
   </tr>
   <tr>
-   <th scope="row">SCST - Scan 2.0 (beta)</th>
-   <td></td>
-   <td></td>
-   <td></td>
-   <td></td>
+   <th scope="row">SCST - Scan 2.0</th>
+   <td>&check;</td>
    <td></td>
    <td>&check;</td>
+   <td></td>
+   <td></td>
+   <td></td>
   </tr>
   <tr>
    <th scope="row">SCST - Sign (deprecated)</th>

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -167,7 +167,8 @@ The following issues, listed by component and area, are resolved in this release
 - This release fixes the issue with expired certificates where you must restart the metadata-store pods when the internal database certificate is rotated by cert-manager.
 You will no longer see this issue with the default internal database, but the solution does not cover the case of an external database.
 
-- Artifact Metadata Repository now properly sets the `hasNextPage` to `false` when there is no more items to be retrieved during a paginated query. This fixes the issue
+- Artifact Metadata Repository now properly sets the `hasNextPage` to `false` when there are
+no more items to be retrieved during a paginated query. This fixes the issue
 where the last page always returns an empty list.
 
 ---

--- a/scst-scan/install-app-scanning.hbs.md
+++ b/scst-scan/install-app-scanning.hbs.md
@@ -1,14 +1,14 @@
 # Install Supply Chain Security Tools - Scan 2.0 in a cluster
 
-The topic tells you how to install Supply Chain Security Tools (SCST) - Scan 2.0.
+By default, SCST - Scan 2.0 is installed in the [build and full profiles](../about-package-profiles.hbs.md#installation-profiles-in-tanzu-application-platform-v-varsurl_version). This document will guide you on how to install Supply Chain Security Tools (SCST) - Scan 2.0 if are installing out-of-band of a profile.
 
 ## <a id="scst-app-scanning-prereqs"></a> Prerequisites
 
 SCST - Scan 2.0 requires the following prerequisites:
 
 - Complete all prerequisites to install Tanzu Application Platform. For more information, see [Prerequisites](../prerequisites.hbs.md).
-- Install the [Tekton component](../tekton/install-tekton.hbs.md). Tekton is already installed if you installed Tanzu Application Platform by using a profile based installation in both the Full and Build Profiles.
-- Enable AMR and AMR Observer, because downstream Tanzu Application Platform services, such as Tanzu Developer Portal and Tanzu CLI, depend on scan results stored in SCST - Store to display correctly. For more information, see [Artifact Metadata Repository Observer for Supply Chain Security Tools - Store](../scst-store/amr/install-amr-observer.hbs.md).
+- Install the [Tekton component](../tekton/install-tekton.hbs.md).
+- If you wish to store results, AMR and AMR Observer. Downstream Tanzu Application Platform services, such as Tanzu Developer Portal and Tanzu CLI, depend on scan results stored in SCST - Store to display correctly. For more information, see [Artifact Metadata Repository Observer for Supply Chain Security Tools - Store](../scst-store/amr/install-amr-observer.hbs.md).
 
 >**Note** If you are installing SCST - Scan 2.0 in a cluster with restricted Kubernetes Pod Security Standards, you must update configurations for the Tekton Pipelines package. See [Troubleshooting](./app-scanning-troubleshooting.hbs.md#scanning-in-a-cluster-with-restricted-kubernetes-pod-security-standards).
 

--- a/scst-scan/integrate-app-scanning.hbs.md
+++ b/scst-scan/integrate-app-scanning.hbs.md
@@ -9,8 +9,10 @@ Scanning` supply chain uses SCST - Scan 1.0 but you can switch to using SCST - S
 
 SCST - Scan 2.0 includes two integrations for container image scanners:
 
-- Anchore Grype
-- Aqua Trivy
+| Container Image Scanner | Documentation | Cluster Image Template Name |  Status |
+| --- | --- | --- | --- |
+| Aqua Trivy | [Link](https://aquasecurity.github.io/trivy) | image-vulnerability-scan-trivy | Recommended out-of-box scanner for Scan 2.0 |
+| Anchore Grype | [Link](https://github.com/anchore/grype) | image-vulnerability-scan-grype | Alternative to Trivy that is used in Scan 1.0 |
 
 VMware recommends using Aqua Trivy scanner with Tanzu Application Platform for
 container image scanning.  Anchore Grype is included as an open source
@@ -19,22 +21,11 @@ in SCST - Scan 1.0.  Additionally, you can build an integration for additional
 scanners by following the [Bring Your Own Scanner
 guide](./bring-your-own-scanner.hbs.md).
 
-| Container Image Scanner | Documentation | Template Name |  Status |
-| --- | --- | --- | --- |
-| Aqua Trivy | [Link](https://aquasecurity.github.io/trivy) | image-vulnerability-scan-trivy | Recommended out-of-box scanner for Scan 2.0 |
-| Anchore Grype | [Link](https://github.com/anchore/grype) | image-vulnerability-scan-grype | Alternative to Trivy that is used in Scan 1.0 |
+## <a id="enable-supply-chain"></a> Enable with OOTB supply chain
 
-## <a id="prerequisites"></a> Prerequisites
+To enable Scan 2.0 with an OOTB supply chain using the Trivy scanner:
 
-Before you can integrate SCST - Scan 2.0 with the out of the box supply chain:
-
-- Install the Scan 2.0 component as this component is not included in any of the installation profiles. See [Install Supply Chain Security Tools - Scan 2.0 in a cluster](./install-app-scanning.hbs.md).
-
-## <a id="integration-supply-chain"></a> Integrate with OOTB supply chain
-
-To integrate Scan 2.0 with an OOTB supply chain using the Trivy scanner:
-
-1. After completing the prerequisites, update your `tap-values.yaml` file to specify the Trivy ClusterImageTemplate. For example:
+1.  Update your `tap-values.yaml` file to specify the Trivy ClusterImageTemplate. For example:
 
     ```yaml
     ootb_supply_chain_testing_scanning:
@@ -62,9 +53,5 @@ To integrate Scan 2.0 with an OOTB supply chain using the Trivy scanner:
     ```
 
     Where `TAP-VERSION` is the version of Tanzu Application Platform installed.
-
-1. Enable AMR and AMR Observer. 
-
-    Downstream Tanzu Application Platform services, such as Tanzu Developer Portal and Tanzu CLI, depend on scan results stored in SCST - Store to display correctly. For more information, see [Artifact Metadata Repository Observer for Supply Chain Security Tools - Store](../scst-store/amr/install-amr-observer.hbs.md).
-
+    
 1. Verify the scan capability is working as expected by creating a workload. See [Verify](./verify-app-scanning-supply-chain.hbs.md).

--- a/scst-scan/overview.hbs.md
+++ b/scst-scan/overview.hbs.md
@@ -60,7 +60,7 @@ Other general guidance:
 
 If you require policy to block a workload in a supply chain based on detected vulnerabilities, use Scan 1.0.
 If you wish to create a scan integration for a scan tool that does not exist, use Scan 2.0 as the [process is greatly simplified](./bring-your-own-scanner.hbs.md).
-If you opt in to using Supply Chains (Cartographer V2), use Scan 2.0 as only Scan 2.0 is supported with Supply Chains.
+If you opt in to using the new [Supply Chains component](../supply-chain/about.hbs.md), use Scan 2.0 as only Scan 2.0 is supported with Supply Chains.
 
 ## <a id="scst-scan-note"></a>A Note on Vulnerability Scanners
 


### PR DESCRIPTION
Call out that App Scanning is now installed as part of the install profiles and does not require manual installation.  

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

Just main

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
