### PR TITLE
Update profile.hbs.md updating the versions supported for TAP 1.8

### DIFF
--- a/install-openshift/profile.hbs.md
+++ b/install-openshift/profile.hbs.md
@@ -321,9 +321,9 @@ service's External IP address.
     * Harbor has the form `kp_default_repository: "my-harbor.io/my-project/build-service"`.
     * Docker Hub has the form `kp_default_repository: "my-dockerhub-user/build-service"` or `kp_default_repository: "index.docker.io/my-user/build-service"`.
     * Google Cloud Registry has the form `kp_default_repository: "gcr.io/my-project/build-service"`.
-- `K8S-VERSION` is the Kubernetes version used by your OpenShift cluster. It must be in the form of `1.26.x`, where `x` stands for the patch version. Examples:
-    - Red Hat OpenShift Container Platform v4.13 uses the Kubernetes version `1.26.3`.
+- `K8S-VERSION` is the Kubernetes version used by your OpenShift cluster. It must be in the form of `1.27.x`, where `x` stands for the patch version. Examples:
     - Red Hat OpenShift Container Platform v4.14 uses the Kubernetes version `1.27.6`.
+    - Red Hat OpenShift Container Platform v4.15 uses the Kubernetes version `1.28.5`.
 - `SERVER-NAME` is the host name of the registry server. Examples:
     * Harbor has the form `server: "my-harbor.io"`.
     * Docker Hub has the form `server: "index.docker.io"`.


### PR DESCRIPTION
Update profile.hbs.md updating the versions supported

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)? no. Specific to 1.8

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
