### PR TITLE
Introduce docs for git-writer component

### DIFF
--- a/supply-chain/catalog/git-writer.hbs.md
+++ b/supply-chain/catalog/git-writer.hbs.md
@@ -1,0 +1,57 @@
+# GIT Writer Component
+
+## Description
+
+The GIT Writer component writes carvel package configuration to a git repository. This enables a supply chain to deliver built packages to a GitOps repository. This component has 2 variants: 
+ - `git-writer` - make commits directly to a branch
+ - `git-writer-pr` - makes commits to a new branch and open a pull request.
+
+
+## API
+
+_Component Input_: `package`
+
+_Configuration_: `spec.GitOps` configuration is used configure the GIT writer component.
+
+_Component Output_: `gitops`
+
+_Secrets_: Ensure an appropriate secret is added to the service account to allow for git authentication.
+
+### Configuring the `git-writer` component:
+```
+spec:
+    gitOps:
+    url:      # https URL of the git repository
+    branch:   # branch to commit to
+    subPath:  # subpath within repository to write to
+```
+
+### Configuring the `git-writer-pr` component:
+```
+spec:
+    gitOps:
+    url:          # https URL of the git repository
+    baseBranch:   # branch to base the merge request off
+    subPath:      # subpath within repository to write to
+```
+
+
+## Dependencies
+
+* Supply Chain
+* Supply Chain Catalog
+* Tekton
+* Carvel Package Component
+
+## Input Description
+
+The GIT Writer Component takes a `package` input from some earlier component in the supply chain and writes it to a GIT commit. This can be done either as a direct commit to a branch using `git-writer`, or as a pull request using `git-writer-pr`.
+
+The component is agnostic of the packaging format and commits all files in the package input.
+
+## Output Description
+
+The GIT Writer Component produces a `gitops` output which contains the following details of the commit/PR:
+
+- `url` URL to the pull request (`git-writer-pr`), or the repository URL (`git-writer`)
+- `digest` SHA of the git commit.

--- a/toc.hbs.md
+++ b/toc.hbs.md
@@ -747,6 +747,7 @@
       - [Tanzu Catalog of Supply Chain Components](supply-chain/catalog/about.hbs.md)
           - [Idioms](supply-chain/catalog/idioms.hbs.md)
           - [Source Component](supply-chain/catalog/source.hbs.md)
+          - [Git Writer Component](supply-chain/catalog/git-writer.hbs.md)
       - [API Reference](supply-chain/api/about.hbs.md)
           - [Component API](supply-chain/api/component.hbs.md)
           - [SupplyChain API](supply-chain/api/supplychain.hbs.md)


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
None

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
