### PR TITLE
Update psql Composition in STK docs

### DIFF
--- a/services-toolkit/how-to-guides/dynamic-provisioning-rds.hbs.md
+++ b/services-toolkit/how-to-guides/dynamic-provisioning-rds.hbs.md
@@ -207,7 +207,7 @@ To create the composition:
                 key: password
                 namespace: crossplane-system
               engine: postgres
-              engineVersion: "13.7"
+              engineVersion: "13.8"                   # <---- Refer to https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html for latest
               name: postgres
               username: masteruser
               publiclyAccessible: true                # <---- DANGER


### PR DESCRIPTION
## About

Update version in PSQL Composition in STK how-to guide for AWS RDS dynamic provisioning.

Which other branches do you want a technical writer to cherry-pick this PR to (if any)? TAP 1.5, 1.6, 1.7 and 1.8
