### PR TITLE
Removed unused metadata store description

### DIFF
--- a/multicluster/reference/tap-values-build-sample.hbs.md
+++ b/multicluster/reference/tap-values-build-sample.hbs.md
@@ -91,7 +91,6 @@ Images are written to `SERVER-NAME/REPO-NAME/workload-name`. Examples:
     - Docker Hub has the form `repository: "my-dockerhub-user"`.
     - Google Cloud Registry has the form `repository: "my-project/supply-chain"`.
 - `SSH-SECRET-KEY` is the SSH secret key in the developer namespace for the supply chain to fetch source code from and push configuration to. See [Git authentication](../../scc/git-auth.hbs.md) for more information.
-- `METADATA-STORE-URL-ON-VIEW-CLUSTER` is the URL of the Supply Chain Security Tools (SCST) - Store deployed on the View cluster. For example, `https://metadata-store.example.com`. For information about `caSecret` and `store-auth-token`, see [Set up multicluster Supply Chain Security Tools (SCST) - Store](../../scst-store/multicluster-setup.hbs.md).
 - `MY-DEV-NAMESPACE` is the name of the developer namespace. SCST - Scan deploys the `ScanTemplates` there. This allows the scanning feature to run in this namespace.
 - `TARGET-REGISTRY-CREDENTIALS-SECRET` is the name of the Secret that contains the
 credentials to pull an image from the registry for scanning.


### PR DESCRIPTION
In the build profile sample, there's a bullet point that describes `METADATA-STORE-URL-ON-VIEW-CLUSTER`. However, this variable no longer appears in the yaml example. So this bullet is no longer needed.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

This applies to main and 1.8.