### PR TITLE
Add instructions on using the `env` label when configuring AMR observer to support DORA

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -137,7 +137,7 @@ This release includes the following changes, listed by component and area.
 
 - Adds support for ingesting SBOMs in CycloneDX v1.5 format.
 - Better error messaging for ingestion errors.
-- Added configuration in [instructions for configuring AMR observer](docs-tap/scst-store/amr/configuration.hbs.md)
+- Added configuration in [instructions for configuring AMR observer](scst-store/amr/configuration.hbs.md)
   for how to enable DORA metrics functionality. Users who configured the label `environment` should now rename it
   to `env`.
 

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -137,6 +137,9 @@ This release includes the following changes, listed by component and area.
 
 - Adds support for ingesting SBOMs in CycloneDX v1.5 format.
 - Better error messaging for ingestion errors.
+- Added configuration in [instructions for configuring AMR observer](docs-tap/scst-store/amr/configuration.hbs.md)
+  for how to enable DORA metrics functionality. Users who configured the label `environment` should now rename it
+  to `env`.
 
 ---
 

--- a/scst-store/amr/configuration.hbs.md
+++ b/scst-store/amr/configuration.hbs.md
@@ -18,7 +18,7 @@ amr:
   observer:
     location: |
       labels:
-      - key: environment
+      - key: env
         value: prod
     resync_period: "10h"
     ca_cert_data: |
@@ -40,6 +40,7 @@ amr:
       image_vulnerability_scans: 1
 ```
 
+
 Where `DOMAIN` is the domain you want to target.
 
 Configuration options:
@@ -49,6 +50,7 @@ Configuration options:
   - Location is the multiline string configuration for the location content.
   - The YAML string can contain a single field:
     - `labels`: Consists of an array for key and value pairing. Useful for adding searchable and identifiable metadata.
+      - Having a label named `env` is important for enabling [DORA functionality](../../tap-gui/plugins/dora.hbs.md).
 
 - `amr.observer.resync_period`
   - Default: "10h"


### PR DESCRIPTION
I changed a label that was `environment` to `env`. This is important because the DORA feature is looking for `env`.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

This applies to main, 1.8, and 1.7.