### PR TITLE
Update release-notes.hbs.md to remove V8

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -136,7 +136,7 @@ This release has the following known issues, listed by component and area.
 #### <a id='1-6-8-tap-ki'></a> v1.6.8 Known issues: Tanzu Application Platform
 
 - This Tanzu Application Platform release is not supported with Tanzu Kubernetes releases (TKR) v1.26 on
-  vSphere with Tanzu v8.
+  vSphere with Tanzu.
 
 #### <a id='1-6-8-amr-obs-ce-hndlr-ki'></a> v1.6.8 Known issues: Artifact Metadata Repository Observer and CloudEvent Handler
 


### PR DESCRIPTION
Update release-notes.hbs.md to remove V8 as this applies to Vsphere with Tanzu V8 and V7.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)? required only for 1.6.x docs.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
