### PR TITLE
Note requirements for fluxcd kubeconfig

### DIFF
--- a/scc/delivery-with-flux.hbs.md
+++ b/scc/delivery-with-flux.hbs.md
@@ -165,6 +165,8 @@ Configure Flux CD on the Build cluster to deploy your `Packages`, `PackageInstal
        --from-file=value.yaml=<path-to-run-cluster-kubeconfig>
    ```
 
+   > **Note** The KubeConfig should be self-contained and not rely on binaries, environment, or credential files from the kustomize-controller Pod. KubeConfigs with cmd-path in them likely won’t work without a custom, per-provider installation of kustomize-controller.
+
 2. Configure your Build cluster to clone the GitOps repository. On the Build cluster, create the following Flux CD `GitRepository`:
 
    ```yaml


### PR DESCRIPTION
- https://jira.eng.vmware.com/browse/TANZUSC-5892: users ran into issues when trying to use a kubeconfig that referenced the gcloud or aws CLIs

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
main