### PR TITLE
Change namespace to accept to all namespaces

### DIFF
--- a/install-aws/resources.hbs.md
+++ b/install-aws/resources.hbs.md
@@ -387,8 +387,8 @@ cat << EOF > workload-trust-policy.json
             },
             "Action": "sts:AssumeRoleWithWebIdentity",
             "Condition": {
-                "StringEquals": {
-                    "${OIDCPROVIDER}:sub": "system:serviceaccount:default:default",
+                "StringLike": {
+                    "${OIDCPROVIDER}:sub": "system:serviceaccount:*:default",
                     "${OIDCPROVIDER}:aud": "sts.amazonaws.com"
                 }
             }


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.7/tap/install-aws-resources.html
- Change the workload trust policy from "system:serviceaccount:default:default" to "system:serviceaccount:*:default"
- Change to StringEquals to StringLike
- With the above 2 allow all namespaces with default SA to access ECR.
This is becoming a 100% reproducible complaints coming from our customers when working with EKS.

Discussed internally in a slack thread.

https://vmware.slack.com/archives/C02D60T1ZDJ/p1702955025697119
