### PR TITLE
The example will create a classic loadbalancer and not network loadbalancer

### DIFF
--- a/contour/how-to-guides/configuring-contour-with-loadbalancer-tls-termination.hbs.md
+++ b/contour/how-to-guides/configuring-contour-with-loadbalancer-tls-termination.hbs.md
@@ -26,7 +26,7 @@ The following are required before proceeding with the configuration:
 
 ## <a id="create-tls"></a> Create a TLS certificate in ACM
 
-Create a public TLS certificate for DOMAIN using AWS Certificate Manager (ACM).  
+Create a public TLS certificate for `*.DOMAIN` using AWS Certificate Manager (ACM).  
 See [AWS documentation](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) for more details.
 
 >**Important** Record the `ARN` of the created certificate, which is required in the following steps.

--- a/contour/how-to-guides/configuring-contour-with-loadbalancer-tls-termination.hbs.md
+++ b/contour/how-to-guides/configuring-contour-with-loadbalancer-tls-termination.hbs.md
@@ -1,4 +1,4 @@
-# Configure Contour to support TLS termination at an AWS Elastic Load Balancing
+# Configure Contour to support TLS termination at an AWS Elastic Load Balancer
 
 This topic tells you how to configure Contour to accept traffic from an AWS 
 Network LoadBalancer (NLB) that terminates TLS traffic.

--- a/contour/how-to-guides/configuring-contour-with-loadbalancer-tls-termination.hbs.md
+++ b/contour/how-to-guides/configuring-contour-with-loadbalancer-tls-termination.hbs.md
@@ -1,7 +1,6 @@
 # Configure Contour to support TLS termination against AWS Elastic Load Balancing
 
-This topic tells you how to configure Contour to accept traffic from an AWS 
-Network LoadBalancer (NLB) that terminates TLS traffic.
+This topic tells you how to configure Contour to accept traffic from AWS LoadBalancer that terminates TLS traffic.
 
 For more information, see the [AWS Knowledge Center documentation](https://repost.aws/knowledge-center/terminate-https-traffic-eks-acm).
 

--- a/contour/how-to-guides/configuring-contour-with-loadbalancer-tls-termination.hbs.md
+++ b/contour/how-to-guides/configuring-contour-with-loadbalancer-tls-termination.hbs.md
@@ -84,6 +84,7 @@ Follow these steps to configure your Tanzu Application Platform:
      domain_template: "\{{.Name}}-\{{.Namespace}}.\{{.Domain}}"
 
     contour:
+      infrastructure_provider: aws
      envoy:
        service:
          aws:

--- a/contour/how-to-guides/configuring-contour-with-loadbalancer-tls-termination.hbs.md
+++ b/contour/how-to-guides/configuring-contour-with-loadbalancer-tls-termination.hbs.md
@@ -1,4 +1,4 @@
-# Configure Contour to support TLS termination at an AWS Elastic Load Balancer
+# Configure Contour to support TLS termination against AWS Elastic Load Balancing
 
 This topic tells you how to configure Contour to accept traffic from an AWS 
 Network LoadBalancer (NLB) that terminates TLS traffic.

--- a/contour/how-to-guides/configuring-contour-with-loadbalancer-tls-termination.hbs.md
+++ b/contour/how-to-guides/configuring-contour-with-loadbalancer-tls-termination.hbs.md
@@ -1,4 +1,4 @@
-# Configure Contour to support TLS termination at an AWS Network LoadBalancer
+# Configure Contour to support TLS termination at an AWS Elastic Load Balancing
 
 This topic tells you how to configure Contour to accept traffic from an AWS 
 Network LoadBalancer (NLB) that terminates TLS traffic.
@@ -91,6 +91,8 @@ Follow these steps to configure your Tanzu Application Platform:
     contour:
      envoy:
        service:
+         aws:
+           LBType: nlb
          annotations:
            service.beta.kubernetes.io/aws-load-balancer-ssl-cert: ARN
            service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
@@ -101,7 +103,9 @@ Follow these steps to configure your Tanzu Application Platform:
      - name: overlay-contour-envoy
     ```
 
-    Where `ARN` is the ARN recored in [Create a TLS certificate in ACM](#create-tls).
+   Where `ARN` is the ARN recored in [Create a TLS certificate in ACM](#create-tls).
+
+   >**Note** If plan to use Classic LoadBalancer remove `contour.envoy.service.aws.LBType: aws`
 
 1. Update your Tanzu Application Platform installation:
 

--- a/contour/how-to-guides/configuring-contour-with-loadbalancer-tls-termination.hbs.md
+++ b/contour/how-to-guides/configuring-contour-with-loadbalancer-tls-termination.hbs.md
@@ -23,15 +23,11 @@ The following are required before proceeding with the configuration:
 - The Contour package installed on the cluster, either as part of Tanzu Application Platform or from the standalone component installation. For more information, see [Install Contour](install.hbs.md).
 - Access to AWS Certificate Manager.
 - A domain registered in Route53 or elsewhere. This topic refers to this domain as `DOMAIN`.
-- A certificate for `*.DOMAIN`.
 
 ## <a id="create-tls"></a> Create a TLS certificate in ACM
 
-Use AWS Certificate Manager (ACM) to import your certificate. 
-
-![Image of ACM import certificate interface.](./images/aws-acm-import-certificate.png)
-
-This process is streamlined when Route 53 manages `DOMAIN`.
+Create a public TLS certificate for DOMAIN using AWS Certificate Manager (ACM).  
+See [AWS documentation](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) for more details.
 
 >**Important** Record the `ARN` of the created certificate, which is required in the following steps.
 


### PR DESCRIPTION
- The generic term is `Elastic Load Balancing`
- The create TLS certificate procedure is suggesting only the "import certificate" option which inaccurate, disallowing the "request certificate" procedure. Fixing to a more generic pointer
- By default it will create Classic Load Balancer
- Need to explicitly point to NLB (recommeded) 
