### PR TITLE
[TANZUSC-5861] Remove invalid Contour configuration for Azure LoadBalancers

### DIFF
--- a/install-azure/profile.hbs.md
+++ b/install-azure/profile.hbs.md
@@ -298,20 +298,6 @@ Where:
 - `EXTERNAL-REGISTRY-FOR-LOCAL-SOURCE-SECRET-NAMESPACE` is the namespace in which
   `EXTERNAL-REGISTRY-FOR-LOCAL-SOURCE-SECRET` is available.
 
-For Azure, the default settings create a classic LoadBalancer.
-To use the Network LoadBalancer instead of the classic LoadBalancer for ingress, add the
-following to your `tap-values.yaml`:
-
-```yaml
-contour:
-  infrastructure_provider: azure
-  envoy:
-    service:
-      azure:
-        LBType: nlb
-```
-
-
 > **Important** Installing Grype by using `tap-values.yaml` as follows is
 > deprecated in v1.6 and will be removed in v1.8:
 >


### PR DESCRIPTION
The type of Azure LoadBalancers are defined at the time of cluster creation. The configuration here seems to be AWS specific but was copied over in error. There are currently no Azure specific settings in Contour.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
* All of `1.8`
* All of `1.7`
* All of `1.6`
* All of `1.5`