### PR TITLE
Modifies the backstage versions transform to remove slashes

### DIFF
--- a/tap-gui/update-backstage-versions.sh
+++ b/tap-gui/update-backstage-versions.sh
@@ -39,7 +39,7 @@ function main {
 
 function transformBackstageVersionsIntoDict {
 	# shellcheck disable=SC2016
-	"$yqCommand" '{version: .releaseVersion, packages: (reduce .packages[] as $item ({}; . + {($item.name | sub("^@"; "")): $item.version}))}'
+	"$yqCommand" '{version: .releaseVersion, packages: (reduce .packages[] as $item ({}; . + {($item.name | sub("^@"; "") | sub("\/"; "-")): $item.version}))}'
 }
 
 function downloadBackstageVersion {


### PR DESCRIPTION
Slashes apparently can't be used in the template_variables. This updated script is able to produce the same variables that are currently in the template_variables file. I re-ran the script and got no diff in that file when compared to the hand modified variables that had the slashes removed.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
None