### PR TITLE
Attempt to fix formatting for local engine server note

### DIFF
--- a/application-accelerator/creating-accelerators/using-local-engine-server.hbs.md
+++ b/application-accelerator/creating-accelerators/using-local-engine-server.hbs.md
@@ -23,12 +23,14 @@ The ZIP file contains the local engine server and a Java runtime for running the
 >
 >In the Finder on your Mac, locate the directory where you extracted the downloaded ZIP file and expand the "acc-engine" directory.
 >
->  We need to "control-open" the following files:
->  - control-click `acc-engine/app/bin/ytt` and then click Open. This will run it in a terminal that you can close.
->  - control-click `acc-engine/app/bin/java` and then click Open. This will run it in a terminal that you can close.
+>We need to "control-open" the following files:
 >
-> The above app files are saved as exceptions to your security settings.
-> You can now run them without getting a verification message.
+>    - control-click `acc-engine/app/bin/ytt` and then click Open. This will run it in a terminal that you can close.
+>
+>    - control-click `acc-engine/app/bin/java` and then click Open. This will run it in a terminal that you can close.
+>
+>The above app files are saved as exceptions to your security settings.
+>You can now run them without getting a verification message.
 
 Open a terminal window and change directory to `acc-engine` located inside the directory where you extracted the ZIP file.
 


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

This is for TAP 1.8

The note section should look like this:

>**Note** For macOS users we need to do the following steps in order to open an app from an unidentified developer:
>(We are working on having these artifacts signed using an Apple developer account to avoid these extra steps)
>
>In the Finder on your Mac, locate the directory where you extracted the downloaded ZIP file and expand the "acc-engine" directory.
>
>We need to "control-open" the following files:
>
>    - control-click `acc-engine/app/bin/ytt` and then click Open. This will run it in a terminal that you can close.
>
>    - control-click `acc-engine/app/bin/java` and then click Open. This will run it in a terminal that you can close.
>
>The above app files are saved as exceptions to your security settings.
>You can now run them without getting a verification message.


It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
