### PR TITLE
Document git PR output type

### DIFF
--- a/supply-chain/reference/catalog/output-types.hbs.md
+++ b/supply-chain/reference/catalog/output-types.hbs.md
@@ -18,9 +18,15 @@ structure. Use this as a guide to consuming or emitting types from your own cust
 ...detail about the content found at the url...
 
 ## Conventions
-## Git
-## Gitops
-This is being replaced in 1.8
+
+## Git PR
+
+Output for a Git pull request.
+
+* Name: git-pr
+* URL: url of the pull request
+* Digest: sha digest of the pull request commit
+
 ## Image
 
 ## OCI YAML Files


### PR DESCRIPTION

Updates the output type to match what is now output by Git Writer 0.1.3

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

None.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
