### PR TITLE
Update grype installation information

### DIFF
--- a/about-package-profiles.hbs.md
+++ b/about-package-profiles.hbs.md
@@ -597,12 +597,12 @@ For a diagram showing the packages contained in each profile, see
     </tr>
     <tr>
       <th scope="row">Grype Scanner for SCST - Scan</th>
-      <td>&check;</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
       <td></td>
       <td>&check;</td>
-      <td></td>
-      <td></td>
-      <td></td>
     </tr>
     <tr>
       <th scope="row">Local Source Proxy</th>

--- a/getting-started/add-test-and-security.hbs.md
+++ b/getting-started/add-test-and-security.hbs.md
@@ -169,7 +169,7 @@ the workload must be updated to point at your Tekton pipeline.
 
 ### <a id="prereqs-install-OOTB-test-scan"></a>Prerequisites
 
-- Both the Scan Controller and the default Grype scanner must be installed for scanning. Refer to the verify installation steps later in the topic.
+- Both the Scan Controller and the Grype scanner must be installed for scanning. Refer to the verify installation steps later in the topic.
 
   > **Note** When leveraging both Tanzu Build Service and Grype in your Tanzu Application Platform supply chain, you can receive enhanced scanning coverage for the languages and frameworks with check marks in the column "Extended Scanning Coverage using Anchore Grype" on the [Language and Framework Support Table](../about-package-profiles.hbs.md#language-support).
 
@@ -178,16 +178,24 @@ To install OOTB Supply Chain with Testing and Scanning:
 >**Note** The OOTB Supply Chain with Testing and Scanning capability has been changed to opt-in and is skipped by default starting in Tanzu Application Platform 1.6. See [Scan Types](../scst-scan/scan-types.hbs.md).
 
 1. Supply Chain Security Tools (SCST) - Scan is installed as part of the Tanzu Application Platform profiles.
-Verify that both Scan Controller and Grype Scanner are installed by running:
-
+    Verify that Scan Controller is installed by running:
     ```console
     tanzu package installed get scanning -n tap-install
-    tanzu package installed get grype -n tap-install
     ```
 
-    If the packages are not already installed, follow the steps in [Supply Chain Security Tools - Scan](../scst-scan/install-scst-scan.md) to install the required scanning components.
+    If the package is not already installed, follow the steps in [Supply Chain Security Tools - Scan](../scst-scan/install-scst-scan.hbs.md) to install the required scanning components.
 
-    During installation of the Grype Scanner, sample ScanTemplates are installed into the `default` namespace. If the workload is deployed into another namespace, these sample ScanTemplates must also be present in the other namespace. One way to accomplish this is to install Grype Scanner again and provide the namespace in the values file.
+
+1. Supply Chain Security Tools (SCST) - Grype Scanner is installed through Namespace Provisioner.
+
+    Verify that Grype Scanner is present on your workload namespace:
+    ```console
+    tanzu package installed get grype-scanner-YOUR-DEV-NAMESPACE -n tap-install
+    ```
+
+    To install Grype Scanner to multiple namespaces, VMware recommends using a namespace provisioner. See [Namespace Provisioner](../namespace-provisioner/about.hbs.md)
+
+    ScanTemplates are installed into the respective namespaces created by Namespace Provisioner. Grype scanner must be present in the namespace the workload is deployed to for scanning.
 
     A ScanPolicy is required and must be in the required namespace. A sample ScanPolicy is provided as follows to block a supply chain when CVEs with critical, high, and unknown ratings are found using `notAllowedSeverities := ["Critical","High","UnknownSeverity"]`. You can also configure the supply chain to use your own custom policies and apply exceptions when you want to ignore certain CVEs. See [Out of the Box Supply Chain with Testing and Scanning](../scc/ootb-supply-chain-testing-scanning.hbs.md#updates-to-developer-namespace). To apply the sample ScanPolicy, you can either add the namespace flag to the kubectl command or add the namespace text box to the template by running:
 

--- a/scc/ootb-supply-chain-testing-scanning.hbs.md
+++ b/scc/ootb-supply-chain-testing-scanning.hbs.md
@@ -208,7 +208,7 @@ live in the same namespace as the workload with the names matching the following
 - source scanning (`blob-source-scan-template`)
 - image scanning (`private-image-scan-template`)
 
-If you have not already installed the Grype ScanTemplates in the namespace that you are writing the workload to, you can use the Namespace Provisioner to install them. See [Manage a List of developer namespaces](../namespace-provisioner/provision-developer-ns.hbs.md#manage-a-list-of-developer-namespaces).
+You can install the Grype ScanTemplates, in the namespace that you are writing the workload to, with Namespace Provisioner. See [Manage a List of developer namespaces](../namespace-provisioner/provision-developer-ns.hbs.md#manage-a-list-of-developer-namespaces).
 
 1. Label the namespace that you are writing the workload to with the default *namespace_selector* `apps.tanzu.vmware.com/tap-ns=""`.
 
@@ -218,10 +218,8 @@ If you have not already installed the Grype ScanTemplates in the namespace that 
 
 >**Note** Although you can customize the templates, if you are following the Getting Started
 >guide, VMware recommends that you follow what is provided in the installation of
->`grype.scanning.apps.tanzu.vmware.com`. This is created in the same namespace as configured by
->using `grype.namespace` in either Tanzu Application Platform profiles or individual component
->installation as in the earlier example. For more information, see
->[About Source and Image Scans](../scst-scan/explanation.md#about-src-and-image-scans).
+>`grype.scanning.apps.tanzu.vmware.com`. For more information, see
+>[About Source and Image Scans](../scst-scan/explanation.hbs.md#about-src-and-image-scans).
 
 #### <a id="storing-scan-results"></a>Enable storing scan results
 


### PR DESCRIPTION
TAP 1.8.x, grype is no longer installed through tap-values/profiles. 
Grype is now installed from Namespace Provisioner unless explicitly specified that the namespace does not have grype.


# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
