### PR TITLE
Remove TAP version from the release notes deprecated API

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -3681,7 +3681,7 @@ Deprecated features remain on this list until they are retired from Tanzu Applic
 ### <a id="1-7-sc-deprecations"></a> Source Controller deprecations
 
 - The Source Controller `ImageRepository` API is deprecated and is marked for
-  removal in Tanzu Application Platform v1.9. Use the `OCIRepository` API instead.
+  removal in Tanzu Application Platform. Use the `OCIRepository` API instead.
   The Flux Source Controller installation includes the `OCIRepository` API.
   For more information about the `OCIRepository` API, see the
   [Flux documentation](https://fluxcd.io/flux/components/source/ocirepositories/).


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

- 1.7.5
- 1.6.9

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
