### PR TITLE
Update app scanning supply chain docs with reviews/suggestions

### DIFF
--- a/scst-scan/tanzu-supply-chain/create-supply-chain-with-app-scanning.hbs.md
+++ b/scst-scan/tanzu-supply-chain/create-supply-chain-with-app-scanning.hbs.md
@@ -8,17 +8,22 @@ solution for Supply Chains Choreographer for Tanzu.
 This section describes what dependencies are needed to create and run a Tanzu Supply Chain Workload.
 
 * Installed Packages:
-  * Supplychain:
+  * Tanzu Supply Chain:
+
     * Supply Chain (supply-chain.apps.tanzu.vmware.com)
     * Supply Chain Catalog (supply-chain-catalog.apps.tanzu.vmware.com)
     * Managed Resource Controller (managed-resource-controller.apps.tanzu.vmware.com)
-    * [Tekton](../../tekton/install-tekton.hbs.md)
-  * Components:
+  * Supply Chain Components:
+
     * [Source](../../supply-chain/reference/catalog/about.hbs.md#source-git-provider)
     * [Buildpack](../../supply-chain/reference/catalog/about.hbs.md#buildpack-build)
     * [Trivy Scanning](../../supply-chain/reference/catalog/about.hbs.md#trivy-image-scan)
   * Scanning:
+
     * [SCST - Scan 2.0](../install-app-scanning.hbs.md)
+
+  * Tekton:
+    * [Tekton](../../tekton/install-tekton.hbs.md)
 * [Tanzu Cartographer CLI Plugin](../../install-tanzu-cli.hbs.md)
 
 ## <a id="supply-chain-scan-2.0"></a> Create Supply Chain with SCST - Scan 2.0 and Component
@@ -61,8 +66,8 @@ component [page](./setup-supply-chain-component.hbs.md#customize-scan-component)
 
   Where:
 
-  * `SCANNING-COMPONENT-NAME` is the name of the [custom scanning component](./setup-supply-chain-component.hbs.md#customize-scan-component).
-  * `SCANNER` is the name of the scanner from the [custom scanning component](./setup-supply-chain-component.hbs.md#customize-scan-component).
+  * `SCANNING-COMPONENT-NAME` is the name of the [Customized Scanning Component](./setup-supply-chain-component.hbs.md#customize-scan-component).
+  * `SCANNER` is the name of the scanner from the [Customized Scanning Component](./setup-supply-chain-component.hbs.md#customize-scan-component).
 
 **Note**: For more details about how to construct a Supply Chain using the Tanzu CLI, see [Construct a Supply Chain using the CLI](../../supply-chain/platform-engineering/how-to/supply-chain-authoring/construct-with-cli.hbs.md)
 

--- a/scst-scan/tanzu-supply-chain/create-supply-chain-workload.hbs.md
+++ b/scst-scan/tanzu-supply-chain/create-supply-chain-workload.hbs.md
@@ -5,7 +5,8 @@ workload, and how to verify the scanning performed in a workload.
 
 ## <a id="create-and-apply-workload"></a> Create and apply workload
 
-This sections covers how to create a workload from an existing [supply chain](./create-supply-chain-with-app-scanning.hbs.md).
+This sections covers how to create a workload from an existing [supply chain created in the previous page](./create-supply-chain-with-app-scanning.hbs.md) that was created using SCST - Scan 2.0 and with
+either the Trivy Supply Chain Component or Customized Scanning Component.
 
 1. Use the Tanzu Cartographer plug-in to create a workload from a specific supply chain:
 
@@ -35,7 +36,7 @@ This sections covers how to create a workload from an existing [supply chain](./
     Here the user can create a supply chain workload from the:
 
     - [Trivy Supply Chain](./create-supply-chain-with-app-scanning.hbs.md#create-supply-chain-with-scst---scan-20-and-trivy-supply-chain-component)
-    - [Supply Chain with Custom Scanner Component](./create-supply-chain-with-app-scanning.hbs.md#create-supply-chain-with-scst---scan-20-and-custom-scanning-component)
+    - [Supply Chain with Customized Scanning Component](./create-supply-chain-with-app-scanning.hbs.md#create-supply-chain-with-scst---scan-20-and-custom-scanning-component)
 
     This renders a sample workload YAML that you can configure and put in a `workload.yaml`.
 

--- a/scst-scan/tanzu-supply-chain/scan-2-0-with-tanzu-supply-chain-overview.hbs.md
+++ b/scst-scan/tanzu-supply-chain/scan-2-0-with-tanzu-supply-chain-overview.hbs.md
@@ -11,6 +11,7 @@ Application Platform executes a scan on a container image for a container
 image scan solution.
 
 To run an `ImageVulnerabilityScan` in a [Tanzu Supply Chain](../../supply-chain/about.hbs.md):
+
 * [Author Supply Chains and Components](../../supply-chain/platform-engineering/how-to/about.hbs.md)
 * [Create a Workload](../../supply-chain/development/how-to/about.hbs.md)
 

--- a/scst-scan/tanzu-supply-chain/setup-supply-chain-component.hbs.md
+++ b/scst-scan/tanzu-supply-chain/setup-supply-chain-component.hbs.md
@@ -100,7 +100,7 @@ This section describes how to create a custom Scanning Supply Chain Component th
     kubectl apply -f pipeline.yaml
     ```
 
-> **Note** If you create your own component, it requires the following label so that it can be observed by supplychain:
+> **Note** If you create your own component, it requires the following label so that it can be observed by Tanzu Supply Chain:
 
   ```console
   labels:


### PR DESCRIPTION
Summary:
* Specify "Customized Scanning Component" rather than all the other variations to reduce confusion.
* This docs PR is meant to address the comments/suggestions made in this [PR](https://github.com/pivotal/docs-tap/pull/3292#issuecomment-1952942201).
* Right now the list of prerequisites [here](https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Application-Platform/1.8/tap/scst-scan-tanzu-supply-chain-create-supply-chain-with-app-scanning.html) are not separate in sections like and according to the [docs-tap readme](https://github.com/pivotal/docs-tap?tab=readme-ov-file#troubleshooting-markdown) the solution is to add a blank line after the stem sentence and before the first item in the list:
```
supplychain:
    supplychain
    supplychain catalog
    .....
```

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
