### PR TITLE
make amr-observer size example compatible with actual size recommended

### DIFF
--- a/scalability.hbs.md
+++ b/scalability.hbs.md
@@ -231,10 +231,10 @@ Edit `values.yaml` to scale resource limits:
 ```console
 amr:
   observer:
-    app_limit_cpu: 500m
-    app_limit_memory: 1Gi
-    app_req_cpu: 100m
-    app_req_memory: 256Mi
+    app_limit_cpu: 1000m
+    app_limit_memory: 3Gi
+    app_req_cpu: 200m
+    app_req_memory: 2Gi
 ```
 
 ### kpack-controller in build service


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

Cherry-pick not needed as this is not seen earlier.