### PR TITLE
Update release-notes.hbs.md for TAP via TMC for K8s 1.26 only.

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -733,6 +733,10 @@ Developer Portal might be inaccurate.
   for their Carvel Package. This overlay incorrectly replaces all Convention provided environment variables, instead of merging in developer provided environment variables.
   Work around this by supplying all environment variables, both Convention provided and user provided, to the Carvel Package. This issue will be fixed in the next patch.
 
+#### <a id='1-8-0-tap'></a> v1.8.0 Known issues: Tanzu Application Platform
+
+- Tanzu Application Platform 1.8.0 installation via TMC is not supported for K8s 1.26.
+  
 ---
 
 ### <a id='1-8-0-components'></a> v1.8.0 Component versions


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)? No. Specific to 1.8.0 only.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
