### PR TITLE
Call out that triage is alpha in TDP

### DIFF
--- a/tap-gui/plugins/scc-tap-gui.hbs.md
+++ b/tap-gui/plugins/scc-tap-gui.hbs.md
@@ -188,7 +188,11 @@ source code or image, including vulnerabilities from past scans.
 > **Image Scan** stage for image ABC, the log4j CVE issue appears and is associated with the
 > `log4shell` package.
 
-### <a id="triage-vul"></a> Triage vulnerabilities
+### <a id="triage-vul"></a> Triage vulnerabilities (alpha)
+
+> **Important** The capability to triage scan results in TAP GUI is in the alpha stage, which
+> means that it is still in early development and is subject to change at any point. You might
+> encounter unexpected behavior from it.
 
 This feature enables you to store analysis data for each of the vulnerabilities found in the scan.
 


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

1.7,1.8

We missed calling out in one area in 1.7 that Triage is alpha.  It's called out in store and in the cli, but not in the UI.  Adding the alpha disclaimer in the UI docs.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
