### PR TITLE
Update prerequisites.hbs.md

### DIFF
--- a/prerequisites.hbs.md
+++ b/prerequisites.hbs.md
@@ -110,7 +110,7 @@ providers:
     - GKE clusters that are set up in zonal mode might detect Kubernetes API errors when the GKE
     control plane is resized after traffic increases. Users can mitigate this by creating a
     regional cluster with three control-plane nodes right from the start.
-- Red Hat OpenShift Container Platform v4.13, v4.14 and v4.15
+- Red Hat OpenShift Container Platform v4.13 and v4.14.
     - vSphere
     - Baremetal
 - Tanzu Kubernetes Grid (commonly called TKG) with Standalone Management Cluster. For more information, see the [Tanzu Kubernetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html).


### PR DESCRIPTION
removing OpenShift 4.15 as its not GA from ReHat yet. Will add it back whenever its GA.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)? 1.8.0 only.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches

Please make the corresponding changes in below as well:
https://github.com/pivotal/docs-tap/blob/main/k8s-matrix.hbs.md

