### PR TITLE
Update git-auth.hbs.md to fix typo on ssh-keygen command

### DIFF
--- a/scc/git-auth.hbs.md
+++ b/scc/git-auth.hbs.md
@@ -140,7 +140,7 @@ create the Kubernetes secret as follows:
 1. Generate a new SSH keypair: `identity` and `identity.pub`.
 
     ```console
-    ssh-keygen -t ecdsa -b 512 -C "" -f "identity" -N ""
+    ssh-keygen -t ecdsa -b 521 -C "" -f "identity" -N ""
     ```
 
 1. Go to your Git provider and add the `identity.pub` as a deployment key for


### PR DESCRIPTION

Theres a typo in the docs this will lead to the following error executing the command:
```
➜  ~ ssh-keygen -t ecdsa -b 512 -C "" -f "identity" -N ""
Invalid ECDSA key length: valid lengths are 256, 384 or 521 bits
```
Update git-auth.hbs.md to fix typo on ssh-keygen command
then it works:
```
➜  ~ ssh-keygen -t ecdsa -b 521 -C "" -f "identity" -N ""
Generating public/private ecdsa key pair.
Your identification has been saved in identity
Your public key has been saved in identity.pub
The key fingerprint is:
```

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
Version 1.6 and 1.7 have those typos.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
