### PR TITLE
remove --ignore-engines from tap-gui docs

### DIFF
--- a/tap-gui/configurator/create-plug-in-wrapper.hbs.md
+++ b/tap-gui/configurator/create-plug-in-wrapper.hbs.md
@@ -114,12 +114,10 @@ To remove unnecessary dependencies you must:
 1. Install the dependencies by running:
 
    ```console
-   yarn install --ignore-engines
+   yarn install
    ```
 
-   This command installs `backstage-cli` and a few other dependencies. The `--ignore-engines` flag
-   is needed because a transitive dependency is expecting Node v18, but this Tanzu Developer Portal
-   version currently only supports Node v16.
+   This command installs `backstage-cli` and a few other dependencies.
 
 ## <a id="tech-insights-frntnd-plgn"></a> Create the Tech Insights front-end Tanzu Developer Portal plug-in
 


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
1.8

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
