### PR TITLE
Update steps to identify configurator image with newer imgpkg

### DIFF
--- a/tap-gui/configurator/building.hbs.md
+++ b/tap-gui/configurator/building.hbs.md
@@ -108,23 +108,53 @@ through the supply chain. Depending on your choices during installation, this is
 `registry.tanzu.vmware.com` or the local image registry (`imgpkg`) that you moved the installation
 packages to.
 
-1. Using the `imgpkg` tool, retrieve the image location by running:
+Using imgpkg version 0.39.0 or lower
+:
 
-   ```console
-   imgpkg describe -b $(kubectl get -n tap-install $(kubectl get package -n tap-install \
-   --field-selector spec.refName=tpb.tanzu.vmware.com -o name) -o \
-   jsonpath="{.spec.template.spec.fetch[0].imgpkgBundle.image}") -o yaml --tty=true | grep -A 1 \
-   "kbld.carvel.dev/id:[[:blank:]]*[^[:blank:]]*configurator" | grep "image:" | sed 's/[[:blank:]]*image:[[:blank:]]*//g'
-   ```
+  1. Using the `imgpkg` tool, retrieve the image location by running:
 
-   Output similar to the following appears:
+    ```console
+    imgpkg describe -b $(kubectl get -n tap-install $(kubectl get package -n tap-install \
+    --field-selector spec.refName=tpb.tanzu.vmware.com -o name) -o \
+    jsonpath="{.spec.template.spec.fetch[0].imgpkgBundle.image}") -o yaml --tty=true | grep -A 1 \
+    "kbld.carvel.dev/id:[[:blank:]]*[^[:blank:]]*configurator" | grep "image:" | sed 's/[[:blank:]]*image:[[:blank:]]*//g'
+    ```
 
-   ```console
-   IMAGE-REGISTRY/tap-packages@sha256:bea2f5bec5c5102e2a69a4c5047fae3d51f29741911cf5bb588893aa4e03ca27
-   ```
+    Output similar to the following appears:
 
-2. Record this value to later use it in place of the `TDP-IMAGE-LOCATION` placeholder in the
-   workload definition.
+    ```console
+    IMAGE-REGISTRY/tap-packages@sha256:bea2f5bec5c5102e2a69a4c5047fae3d51f29741911cf5bb588893aa4e03ca27
+    ```
+
+  2. Record this value to later use it in place of the `TDP-IMAGE-LOCATION` placeholder in the
+    workload definition.
+
+Using imgpkg version 0.40.0 or higher
+:
+
+  1. Using the `imgpkg` tool, download the bundle by running:
+
+    ```console
+    imgpkg pull -b $(kubectl get -n tap-install $(kubectl get package -n tap-install \
+    --field-selector spec.refName=tpb.tanzu.vmware.com -o name) -o \
+    jsonpath="{.spec.template.spec.fetch[0].imgpkgBundle.image}") -o bundle
+    ```
+
+  2. Retrieve the image location by running:
+
+    ```console
+    cat bundle/.imgpkg/images.yml | grep -A 1 "kbld.carvel.dev/id:[[:blank:]]*[^[:blank:]]*configurator" | \
+    grep "image:" | sed 's/[[:blank:]]*image:[[:blank:]]*//g'
+    ```
+
+    Output similar to the following appears:
+
+    ```console
+    IMAGE-REGISTRY/tap-packages@sha256:bea2f5bec5c5102e2a69a4c5047fae3d51f29741911cf5bb588893aa4e03ca27
+    ```
+
+  3. Record this value to later use it in place of the `TDP-IMAGE-LOCATION` placeholder in the
+    workload definition.
 
 ## <a id="build"></a> Build your customized portal
 


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
1.6, 1.7, 1.8

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches

# Note
Please double check the markdown, I tried to make tabs similar to [Build your customized portal](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.7/tap/tap-gui-configurator-building.html#build-your-customized-portal-3)