### PR TITLE
Update prerequisites.hbs.md with OpenShift 4.15 is GAed now.

### DIFF
--- a/prerequisites.hbs.md
+++ b/prerequisites.hbs.md
@@ -110,7 +110,7 @@ providers:
     - GKE clusters that are set up in zonal mode might detect Kubernetes API errors when the GKE
     control plane is resized after traffic increases. Users can mitigate this by creating a
     regional cluster with three control-plane nodes right from the start.
-- Red Hat OpenShift Container Platform v4.13 and v4.14.
+- Red Hat OpenShift Container Platform v4.13, v4.14 and v4.15.
     - vSphere
     - Baremetal
 - Tanzu Kubernetes Grid (commonly called TKG) with Standalone Management Cluster. For more information, see the [Tanzu Kubernetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html).


### PR DESCRIPTION
OpenShift 4.15 is GAed now. TAP 1.8.0 had not claimed the support yet RedHat had not GAed at TAP 1.8.0 GA time, but since OpenShift 4.15 is GAed now, we will add the support.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)? 1.8.x and 1.9.x docs.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches

please update https://github.com/pivotal/docs-tap/blob/main/k8s-matrix.hbs.md as well with the same.