### PR TITLE
Remove extra section to identify configurator image

### DIFF
--- a/tap-gui/configurator/building.hbs.md
+++ b/tap-gui/configurator/building.hbs.md
@@ -90,13 +90,6 @@ To prepare your Configurator configuration file:
    base64 -i tpb-config.yaml
    ```
 
-## <a id="prep-ident-image"></a> Identify your Configurator foundation image
-
-To build a customized Tanzu Developer Portal, you must identify the image that contains the
-foundation that is ready to pass through the supplychain. Depending on how you installed things, this
-could either be on `registry.tanzu.vmware.com` or on the local image registry (`imgpkg`) that you
-moved the installation packages to.
-
 ## <a id="prep-ident-image"></a> Identify your Configurator image
 
 To build a customized Tanzu Developer Portal, you must identify the Configurator image to pass


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
1.6 (I see this in 1-6-8 and 1-6-9 branches)

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
