### PR TITLE
Appliveview known issue has been updated for 1.8.1

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -279,7 +279,12 @@ The following issues, listed by component and area, are resolved in this release
  
 ### <a id='1-8-1-known-issues'></a> v1.8.1 Known issues 
  
-This release has the following known issues, listed by component and area. 
+This release has the following known issues, listed by component and area.
+
+#### <a id='1-8-1-alv-ki'></a> v1.8.1 Known issues: Appliveview
+
+- Appliveview on run profile fails to reconcile when a non default cluster issuer is used while installing via TMC
+
  
 #### <a id='1-8-1-COMPONENT-NAME-ki'></a> v1.8.1 Known issues: COMPONENT-NAME
  


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

This should be part of the 1.8.x line


It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
