### PR TITLE
Updated known issue for appliveview for 1.7.x

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -257,6 +257,10 @@ The following issues, listed by component and area, are resolved in this release
 
 This release has the following known issues, listed by component and area.
 
+#### <a id='1-7-5-alv-ki'></a> v1.7.5 Known issues: Appliveview
+
+- Appliveview on `run profile` fails to reconcile when a non default cluster issuer is used while installing via TMC.
+
 #### <a id='1-7-5-COMPONENT-NAME-ki'></a> v1.7.5 Known issues: COMPONENT-NAME
 
 - Known issue description with link to workaround.


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

This should be part of the 1.7.x line

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
