### PR TITLE
appsso: fix client credentials grant example

### DIFF
--- a/app-sso/concepts/grant-types.hbs.md
+++ b/app-sso/concepts/grant-types.hbs.md
@@ -70,7 +70,9 @@ spec:
 6. Request token
 
    ```shell
-   curl -X POST <AUTH-DOMAIN>/oauth2/token?grant_type=client_credentials -v -u "YOUR_CLIENT_ID:DECODED_CLIENT_SECRET"
+   curl -X POST <AUTH-DOMAIN>/oauth2/token \
+     -d "grant_type=client_credentials" \
+     -u "YOUR_CLIENT_ID:DECODED_CLIENT_SECRET"
    ```
 
 ### Authorization Code Grant Type


### PR DESCRIPTION
Target: TAP 1.9
Backport to 1.8 and 1.7
