### PR TITLE
Fix security context workaround

### DIFF
--- a/scst-scan/troubleshoot-scan.hbs.md
+++ b/scst-scan/troubleshoot-scan.hbs.md
@@ -583,10 +583,10 @@ Provide default values for the `Capabilities` or `SeccompProfile` field:
 
 ```yaml
 securityContext:
-  allowPrivilegeEscalation: true
+  allowPrivilegeEscalation: false
   capabilities: {}
-  privileged: true
-  runAsNonRoot: false
+  privileged: false
+  runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault
 ```
@@ -595,7 +595,7 @@ securityContext:
 
 **Symptom:**
 
-SCST - Scan 1.0 fails with the error `secrets 'store-ca-cert' not found` during deployment by using Tanzu Mission Control with a non-default issuer. 
+SCST - Scan 1.0 fails with the error `secrets 'store-ca-cert' not found` during deployment by using Tanzu Mission Control with a non-default issuer.
 
 **Solution:**
 


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

The fix targets all branches in release 1.7.x

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
