### PR TITLE
Add missing apigroups to 1.6 cluster view setup docs

### DIFF
--- a/tap-gui/cluster-view-setup.hbs.md
+++ b/tap-gui/cluster-view-setup.hbs.md
@@ -152,6 +152,12 @@ To set up a Service Account to view resources on a cluster:
       resources:
       - resourceinspectiongrants
       verbs: ['get', 'watch', 'list', 'create']
+    - apiGroups: ['apiextensions.k8s.io']
+      resources: ['customresourcedefinitions']
+      verbs: ['get', 'watch', 'list']
+    - apiGroups: [data.packaging.carvel.dev]
+      resources: [packages]
+      verbs: ['get', 'watch', 'list']
     ```
 
     This YAML content creates `Namespace`, `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding`.


### PR DESCRIPTION
# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
1.6 (I guess that's 1-6-8 and 1-6-9)

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
