### PR TITLE
Affinity Assistant was removed in 1.8

### DIFF
--- a/scst-scan/app-scanning-troubleshooting.hbs.md
+++ b/scst-scan/app-scanning-troubleshooting.hbs.md
@@ -203,7 +203,7 @@ To resolve this issue, you can debug within the scan-task pod by following the i
 
 ### <a id="scanning-restricted-pss"></a> Scanning in a cluster with restricted Kubernetes Pod Security Standards
 
-As part of compliance with the restricted profile for Kubernetes Pod Security Standards, you must set the `securityContext` of containers and initContainers. This applies to the `prepare` initContainers and affinity assistant pods created by Tekton. When a pod does not meet pod Security Standards, it is not created and vulnerability scanning cannot proceed. For more information, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
+As part of compliance with the restricted profile for Kubernetes Pod Security Standards, you must set the `securityContext` of containers and initContainers.  When a pod does not meet pod Security Standards, it is not created and vulnerability scanning cannot proceed. For more information, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
 
 You might see an error message similar to the following when describing the TaskRun:
 
@@ -219,10 +219,9 @@ To resolve this issue:
     tekton_pipelines:
         feature_flags:
             set_security_context: "true"
-            disable_affinity_assistant: "true"
     ```
 
-    Setting the `securityContext` resolves the `prepare` initContainer violation. Deactivating affinity assistant pods is a workaround for the affinity assistant violation as Tekton does not have a way to update the `securityContext` in those pods.
+    Setting the `securityContext` resolves the `prepare` initContainer violation.
 
 1. Update your Tanzu Application Platform installation by running:
 
@@ -231,7 +230,5 @@ To resolve this issue:
    ```
 
     Where `TAP-VERSION` is the version of Tanzu Application Platform installed.
-
-  >**Note** Tekton [affinity assistant](https://tekton.dev/vault/pipelines-main/affinityassistants/) is a feature that can schedule all TaskRun pods within a PipelineRun that share a Workspace on the same node. If deactivated, VMware recommends using an affinity-aware CSI storage class. For more information, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/volumes/#csi).
 
 1. Re-run the scan.

--- a/scst-scan/install-app-scanning.hbs.md
+++ b/scst-scan/install-app-scanning.hbs.md
@@ -34,17 +34,6 @@ When you install SCST - Scan 2.0, you can configure the following optional prope
 
 >**Note** If the StorageClass you select does not have a node limit but uses the node storage, such as hostpath, the nodes must have large enough disks. For example, if a scan creates a 2Gi volume on a hostpath type storage class, `2Gi * number of AMR images` indicates how much storage this cluster needs overall. `2Gi * number of AMR images / number of nodes` indicates how much storage each node needs.
 
-You must deactivate the Tekton Affinity Assistant to reduce the number of pod scheduling issues when using SCST - Scan v2.
-To achieve this, add the following to your `tap-values.yaml`:
-
-```yaml
-tekton_pipelines:
-  feature_flags:
-    disable_affinity_assistant: "true"
-```
-
-In vSphere with Tanzu (TKGs) v1.26 and later, enabling the Affinity Assistant feature on clusters where the Kubernetes Pod Security Admission restricts Pod Security Standards by default, might cause a deadlock, where the affinity pod cannot be scheduled, thereby hindering the scanning process.
-
 ## <a id="install-scst-app-scanning"></a> Install
 
 To install SCST - Scan 2.0:


### PR DESCRIPTION
A few references to affinity assistance were missed in docs.  Cleaning up those references.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

1.8

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
