### PR TITLE
Add AWS RMQ Secret Key Name known issue

### DIFF
--- a/aws-services/how-to-guides/index.hbs.md
+++ b/aws-services/how-to-guides/index.hbs.md
@@ -5,3 +5,4 @@ This section contains how-to guides for AWS Services.
 In this section:
 
 - [Configure AWS Service Endpoint](configure-aws-service-endpoint.hbs.md)
+- [Troubleshoot AWS Services](troubleshooting.hbs.md)

--- a/aws-services/how-to-guides/troubleshooting.hbs.md
+++ b/aws-services/how-to-guides/troubleshooting.hbs.md
@@ -1,0 +1,46 @@
+# Troubleshoot AWS Services
+
+This topic explains how you troubleshoot issues related to AWS Services on Tanzu Application Platform
+(commonly known as TAP).
+
+## <a id="private-reg"></a> Secret key name for Amazon MQ (RabbitMQ) claims do not match corresponding name used in Spring Cloud Bindings library
+
+**Symptom:**
+
+If you create a claim for Amazon MQ (RabbitMQ), the resulting binding Secret will contain a key named `endpoint`. This does
+not match the key name expected by the [Spring Cloud Bindings](https://github.com/spring-cloud/spring-cloud-bindings)
+library, which uses `addresses`. As such, when binding spring-based workloads to the Amazon MQ (RabbitMQ) service, the
+connection will not be established automatically.
+
+**Cause:**
+
+This is due to a misconfiguration in the `Composition` for the Amazon MQ (RabbitMQ) service.
+
+**Solution:**
+
+Until such time that the key name is updated in the `Composition`, you can apply the following workaround.
+
+1. Pause reconciliation of the aws-services PackageInstall, for example:
+
+```console
+kubectl patch packageinstall/aws-services -n tap-install -p '{"spec":{"paused": true}}' --type=merge
+```
+
+2. Manually edit the Amazon MQ (RabbitMQ) CompositionResourceDefinition and Composition to change the key name, for example:
+
+```console
+kubectl edit xrd xrabbitmqbrokers.aws.queue.tanzu.vmware.com
+# replace "endpoint" with "addresses"
+kubectl edit composition xrabbitmqbrokers.aws.queue.tanzu.vmware.com
+# replace "endpoint" with "addresses"
+```
+
+3. Create a new class claim for the Amazon MQ (RabbitMQ) service, for example:
+
+```
+tanzu service class-claim create <NAME> --class rabbitmq-managed-aws
+```
+
+Note that these changes will not have any effect on any existing claims for the Amazon MQ (RabbitMQ) service.
+Also note that upgrading to a newer version of Tanzu Application Platform may overwrite these temporary workarounds, however
+any existing service instances should continue to function as expected.

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -785,6 +785,14 @@ while installing through Tanzu Mission Control.
   ImageVulnerabilityScan results. There is an error on duplicate submission of identical
   ImageVulnerabilityScans you can ignore if the previous submission was successful.
 
+#### <a id='1-8-0-aws-services-ki'></a> v1.8.0 Known issues: AWS Services
+
+- When creating claims for the Amazon MQ (RabbitMQ), one of the key names in the resulting binding Secret
+  is `endpoint`, which does not match the name of the key expected by the [Spring Cloud Bindings](https://github.com/spring-cloud/spring-cloud-bindings)
+  library, which uses `addresses`. As such, when binding spring-based workloads to the Amazon MQ (RabbitMQ)
+  service, the connection will not be established automatically.
+  For a workaround, see [Troubleshoot AWS Services](aws-services/how-to-guides/troubleshooting.hbs.md).
+
 #### <a id='1-8-0-bitnami-services-ki'></a> v1.8.0 Known issues: Bitnami Services
 
 - If you try to configure private registry integration for the Bitnami services

--- a/toc.hbs.md
+++ b/toc.hbs.md
@@ -309,6 +309,7 @@
             - [Package values](aws-services/reference/package-values.hbs.md)
             - [Supported services](aws-services/reference/supported-services.hbs.md)
             - [Supported topologies](aws-services/reference/supported-topologies.hbs.md)
+            - [Troubleshoot AWS Services](aws-services/how-to-guides/troubleshooting.hbs.md)
             - [Version matrix](aws-services/reference/version-matrix.hbs.md)
         - [Uninstall AWS Services](aws-services/uninstall-aws-services.hbs.md)
     - [Bitnami Services](bitnami-services/about.hbs.md)


### PR DESCRIPTION
## About

Adds a known issue for the AWS Services Package in TAP 1.8 / 1.8.1. We plan to resolve this known issue in TAP 1.8.2 / 1.9+.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)? 1.8.1
