### PR TITLE
Remove tanzunet links for IDE plugin installation

### DIFF
--- a/intellij-extension/install.hbs.md
+++ b/intellij-extension/install.hbs.md
@@ -21,7 +21,6 @@ Before installing the extension, you must have:
 The VMware Tanzu Developer Tools for IntelliJ extension is available from:
 
 - [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/21823-tanzu-developer-tools) or
-- [VMware Tanzu Network](https://network.tanzu.vmware.com/products/tanzu-application-platform/).
 
 JetBrains Marketplace
 : To install from JetBrains Marketplace:

--- a/partials/vscode-extension/_install.hbs.md
+++ b/partials/vscode-extension/_install.hbs.md
@@ -20,7 +20,6 @@ Docker Desktop and local Kubernetes are not prerequisites for using Tanzu Develo
 VMware Tanzu Developer Tools for VS Code is available from:
 
 - [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=vmware.tanzu-dev-tools)
-- [VMware Tanzu Network](https://network.tanzu.vmware.com/products/tanzu-application-platform).
 
 Visual Studio Marketplace
 : To install Visual Studio Marketplace:


### PR DESCRIPTION
- now only available via respective marketplaces

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

TAP 1.8->TAP 1.5