### PR TITLE
docs(Supply Chain UI): :memo: Updating the Known Issues for the TDP -…

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -146,7 +146,7 @@ enable TUF:
 
 #### <a id='1-9-0-ssc-ui-ki'></a> v1.9.0 Known issues: Supply Chain UI
 
-- When accessing the supply chain tab in the Tanzu Developer Portal, users might encounter an error related to data.packaging.carvel.dev. This issue arises even for supply chains that do not generate Carvel packages, indicating an unexpected configuration requirement. The error message displayed is related to permission issues and JSON parsing errors, specifically mentioning that the user "system:serviceaccount:tap-gui:tap-gui-viewer" cannot list resource "packages" in the API group "data.packaging.carvel.dev" at the cluster scope. Additionally, an unexpected non-whitespace character is reported after JSON at position 4.
+- When accessing the supply chain tab in the Tanzu Developer Portal, users might encounter an error related to data.packaging.carvel.dev. The error message displayed is related to permission issues and JSON parsing errors, specifically mentioning that the user "system:serviceaccount:tap-gui:tap-gui-viewer" cannot list resource "packages" in the API group "data.packaging.carvel.dev" at the cluster scope. Additionally, an unexpected non-whitespace character is reported after JSON at position 4.
 
 Workaround: A temporary solution involves applying an RBAC configuration that includes permissions (get, watch, list) for the resources within the data.packaging.carvel.dev API group. This configuration mitigates the issue but it is highlighted that such a requirement should not be mandated for supply chains not generating Carvel packages.
 

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -150,11 +150,15 @@ enable TUF:
 
 Workaround: A temporary solution involves applying an RBAC configuration that includes permissions (get, watch, list) for the resources within the data.packaging.carvel.dev API group. This configuration mitigates the issue but it is highlighted that such a requirement should not be mandated for supply chains not generating Carvel packages.
 
-The error goes away after below rbac config is applied:
+Configuring RBAC to allow access to the Carvel package resource eliminates the error message:
 
+```
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 - apiGroups: [data.packaging.carvel.dev]
   resources: [packages]
   verbs: ['get', 'watch', 'list']
+```
 
 ---
 

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -144,6 +144,18 @@ enable TUF:
 
 - SCST - Store returns an expired certificate error message when a CA certificate expires before the app certificate. For more information, see [CA Cert expires](scst-store/troubleshooting.hbs.md#ca-cert-expires).
 
+#### <a id='1-9-0-ssc-ui-ki'></a> v1.9.0 Known issues: Supply Chain UI
+
+- When accessing the supply chain tab in the Tanzu Developer Portal, users might encounter an error related to data.packaging.carvel.dev. This issue arises even for supply chains that do not generate Carvel packages, indicating an unexpected configuration requirement. The error message displayed is related to permission issues and JSON parsing errors, specifically mentioning that the user "system:serviceaccount:tap-gui:tap-gui-viewer" cannot list resource "packages" in the API group "data.packaging.carvel.dev" at the cluster scope. Additionally, an unexpected non-whitespace character is reported after JSON at position 4.
+
+Workaround: A temporary solution involves applying an RBAC configuration that includes permissions (get, watch, list) for the resources within the data.packaging.carvel.dev API group. This configuration mitigates the issue but it is highlighted that such a requirement should not be mandated for supply chains not generating Carvel packages.
+
+The error goes away after below rbac config is applied:
+
+- apiGroups: [data.packaging.carvel.dev]
+  resources: [packages]
+  verbs: ['get', 'watch', 'list']
+
 ---
 
 ### <a id='1-9-0-components'></a> v1.9.0 Component versions


### PR DESCRIPTION
… Supply Chain Plugin

This commit introduces documentation updates to address a known issue where the TAP GUI's Supply Chain visualization improperly expects configuration for data.packaging.carvel.dev for supply chains that do not generate Carvel packages. This behavior led to an error when choosing specific workloads within the Supply Chain tab of the TAP GUI. The updated documentation provides clarity on the error's nature and outlines a workaround involving RBAC configuration adjustments.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
