### PR TITLE
Add namespace read permissions to k8s-reader role

### DIFF
--- a/tap-gui/cluster-view-setup.hbs.md
+++ b/tap-gui/cluster-view-setup.hbs.md
@@ -61,7 +61,13 @@ To set up a Service Account to view resources on a cluster:
       name: k8s-reader
     rules:
     - apiGroups: ['']
-      resources: ['pods', 'pods/log', 'services', 'configmaps', 'limitranges']
+      resources:
+      - pods
+      - pods/log
+      - services
+      - configmaps
+      - limitranges
+      - namespaces
       verbs: ['get', 'watch', 'list']
     - apiGroups: ['metrics.k8s.io']
       resources: ['pods']


### PR DESCRIPTION
- Since TAP 1.8.0 the developer portal queries clusters for namespaces
- The role we tell customers to create lacks namespace permissions. This commit adds it.
- This change should be applied to the docs going back to v1.8.0

[TME-2630]

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)? 
v1.8

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
