### PR TITLE
[TANZUSC-6352] Add release note for known issue around image_scanning_cli.image

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -163,6 +163,21 @@ enable TUF:
     tuf_enabled: true
   ```
 
+#### <a id='1-9-0-scst-scan-ki'></a> v1.9.0 Known issues: Supply Chain Security Tools - Scan
+
+- When using Supply Chain Security Tools (SCST) - Scan 2.0 with a ClusterImageTemplate, the value for
+  the scanning image is overwritten with an incorrect default value from
+  `ootb_supply_chain_testing_scanning.image_scanner_cli` in the `tap-values.yaml` file.
+  You can prevent this by setting the value in your `tap-values.yaml` file to the correct image.
+  For example, for the Trivy image packaged with Tanzu Application Platform:
+
+    ```yaml
+    ootb_supply_chain_testing_scanning:
+      image_scanner_template_name: image-vulnerability-scan-trivy
+      image_scanning_cli:
+        image: registry.tanzu.vmware.com/tanzu-application-platform/tap-packages@sha256:675673a6d495d6f6a688497b754cee304960d9ad56e194cf4f4ea6ab53ca71d6
+    ```
+
 #### <a id='1-9-0-scst-store-ki'></a> v1.9.0 Known issues: Supply Chain Security Tools - Store
 
 - SCST - Store returns an expired certificate error message when a CA certificate expires before the app certificate. For more information, see [CA Cert expires](scst-store/troubleshooting.hbs.md#ca-cert-expires).


### PR DESCRIPTION
Summary:
* Add release note to provide workaround for the known issue of workload failing at the image scanning step when `image_scanner_template_name: image-vulnerability-scan-trivy` is specified without `image_scanning_cli.image`

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
1.8.2

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
