### PR TITLE
Revert deprecate scan 1 0

### DIFF
--- a/getting-started/add-test-and-security.hbs.md
+++ b/getting-started/add-test-and-security.hbs.md
@@ -168,6 +168,11 @@ the workload must be updated to point at your Tekton pipeline.
 
 ## <a id="install-OOTB-test-scan"></a>Install OOTB Supply Chain with Testing and Scanning
 
+<<<<<<< HEAD
+=======
+> **Note** These steps are for Scan 1.0.  Scan 1.0 has been deprecated as of the TAP 1.9 release.  Scan 1.0 will remain the default in the [test and scan supply chain](../getting-started/add-test-and-security.hbs.md#add-testing-and-scanning-to-your-application) in the TAP 1.9 release but it is recommended to opt-in to Scan 2.0 as Scan 1.0 will be replaced as the default and removed in a future version.  For more information about Scan 1.0 versus Scan 2.0, see the [scan overview page](./overview.hbs.md)
+
+>>>>>>> parent of 9f75374ce (Deprecate Scan 1.0)
 To install OOTB Supply Chain with Testing and Scanning, you must install the Scan Controller
 and the Grype scanner.
 

--- a/getting-started/add-test-and-security.hbs.md
+++ b/getting-started/add-test-and-security.hbs.md
@@ -168,11 +168,6 @@ the workload must be updated to point at your Tekton pipeline.
 
 ## <a id="install-OOTB-test-scan"></a>Install OOTB Supply Chain with Testing and Scanning
 
-<<<<<<< HEAD
-=======
-> **Note** These steps are for Scan 1.0.  Scan 1.0 has been deprecated as of the TAP 1.9 release.  Scan 1.0 will remain the default in the [test and scan supply chain](../getting-started/add-test-and-security.hbs.md#add-testing-and-scanning-to-your-application) in the TAP 1.9 release but it is recommended to opt-in to Scan 2.0 as Scan 1.0 will be replaced as the default and removed in a future version.  For more information about Scan 1.0 versus Scan 2.0, see the [scan overview page](./overview.hbs.md)
-
->>>>>>> parent of 9f75374ce (Deprecate Scan 1.0)
 To install OOTB Supply Chain with Testing and Scanning, you must install the Scan Controller
 and the Grype scanner.
 

--- a/getting-started/add-test-and-security.hbs.md
+++ b/getting-started/add-test-and-security.hbs.md
@@ -168,11 +168,6 @@ the workload must be updated to point at your Tekton pipeline.
 
 ## <a id="install-OOTB-test-scan"></a>Install OOTB Supply Chain with Testing and Scanning
 
-> **Note** These steps are for SCST - Scan 1.0. SCST - Scan 1.0 is deprecated in Tanzu Application
-Platform v1.9 and later. Tanzu Application Platform v1.9 documentation continues to describe Scan 1.0
-procedures, however VMware recommends using SCST - Scan 2.0 as SCST - Scan 1.0 will be removed 
-in a future version and SCST - Scan 2.0 will be the default.  For more information, see [SCST - Scan versions](../scst-scan/overview.hbs.md#scst-scan-feat).
-
 To install OOTB Supply Chain with Testing and Scanning, you must install the Scan Controller
 and the Grype scanner.
 

--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -319,7 +319,3 @@ Deprecated features remain on this list until they are retired from Tanzu Applic
 ### <a id='fluxcd-sc-deprecations'></a> FluxCD Source Controller deprecations
 
 - In Tanzu Application Platform v1.9.0, FluxCD Source Controller updates the `GitRepository` API from `v1beta2` to `v1`.  The controller accepts resources with API versions `v1beta1` and `v1beta2`, saving them as `v1`.
-
-### <a id='1-9-0-scst-scan-bc'></a> Supply Chain Security Tools - Scan 1.0 deprecation
-
-- In Tanzu Application Platform v1.9.0, SCST - Scan 1.0 is deprecated in favor of SCST - Scan 2.0.  In Tanzu Application Platform v1.9.0, SCST - Scan 1.0 is still the documented default for online installation. SCST - Scan 2.0 will be the default in v1.10 and will be removed in a future release. For more information, see [SCST - Scan versions](./overview.hbs.md).

--- a/scst-scan/integrate-app-scanning.hbs.md
+++ b/scst-scan/integrate-app-scanning.hbs.md
@@ -1,4 +1,4 @@
-# Enable SCST - Scan 2.0 for default Test and Scan supply chains
+# Enable App Scanning for default Test and Scan supply chains
 
 This topic tells you how to enable Supply Chain Security Tools (SCST) - Scan 2.0
 and an included container image scanner for Out of the Box Supply Chain with Testing and Scanning.

--- a/scst-scan/integrate-app-scanning.hbs.md
+++ b/scst-scan/integrate-app-scanning.hbs.md
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
 # Enable SCST - Scan 2.0 for default Test and Scan supply chains
-=======
-# Enable App Scanning for default Test and Scan supply chains
->>>>>>> parent of 09944abb6 (Deprecate Scan 1.0)
 
 This topic tells you how to enable Supply Chain Security Tools (SCST) - Scan 2.0
 and an included container image scanner for Out of the Box Supply Chain with Testing and Scanning.

--- a/scst-scan/integrate-app-scanning.hbs.md
+++ b/scst-scan/integrate-app-scanning.hbs.md
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 # Enable SCST - Scan 2.0 for default Test and Scan supply chains
+=======
+# Enable App Scanning for default Test and Scan supply chains
+>>>>>>> parent of 09944abb6 (Deprecate Scan 1.0)
 
 This topic tells you how to enable Supply Chain Security Tools (SCST) - Scan 2.0
 and an included container image scanner for Out of the Box Supply Chain with Testing and Scanning.

--- a/scst-scan/results.hbs.md
+++ b/scst-scan/results.hbs.md
@@ -1,12 +1,6 @@
 # View scan status conditions for Supply Chain Security Tools - Scan
 
-This topic explains how you can view scan status conditions for Supply Chain Security Tools - Scan.
-
-> **Note** This topic uses SCST - Scan 1.0. SCST - Scan 1.0 is deprecated in
-Tanzu Application Platform v1.9 and later. In Tanzu Application Platform v1.9, SCST - Scan 1.0 is
-still the default in Supply Chain with Testing. For more information, see [Add testing and scanning to your application](../getting-started/add-test-and-security.hbs.md#add-testing-and-scanning-to-your-application).
-VMware recommends using SCST - Scan 2.0 as SCST - Scan 1.0 will be removed in a future version and
-SCST - Scan 2.0 will be the default. For more information, see [SCST - Scan versions](./overview.hbs.md).
+This topic explains how you can view scan status conditions for Supply Chain Security Tools - Scan. 
 
 ## <a id='view-scan-stat'></a>Viewing scan status
 

--- a/scst-scan/scan-1-0.hbs.md
+++ b/scst-scan/scan-1-0.hbs.md
@@ -2,12 +2,6 @@
 
 This topic gives you an overview of use cases, features, and CVEs for Supply Chain Security Tools (SCST) - Scan 1.0
 
-> **Note** SCST - Scan 1.0 is deprecated in
-Tanzu Application Platform v1.9 and later. In Tanzu Application Platform v1.9, SCST - Scan 1.0 is
-still the default in Supply Chain with Testing. For more information, see [Add testing and scanning to your application](../getting-started/add-test-and-security.hbs.md#add-testing-and-scanning-to-your-application).
-VMware recommends using SCST - Scan 2.0 as SCST - Scan 1.0 will be removed in a future version and
-SCST - Scan 2.0 will be the default. For more information, see [SCST - Scan versions](./overview.hbs.md), and [Enable SCST - Scan 2.0 for default Test and Scan supply chains](./integrate-app-scanning.hbs.md).
-
 ## <a id="overview"></a>Overview
 
 With Supply Chain Security Tools - Scan, you can build and deploy 

--- a/scst-scan/scan-types.hbs.md
+++ b/scst-scan/scan-types.hbs.md
@@ -6,12 +6,6 @@ chain supports the source and container image scan types.
 
 ## <a id="source-scan"></a> Source scan
 
-> **Note** Source scanning is a capability of SCST - Scan 1.0. SCST - Scan 1.0 is deprecated in
-Tanzu Application Platform v1.9 and later. In Tanzu Application Platform v1.9, SCST - Scan 1.0 is
-still the default in Supply Chain with Testing. For more information, see [Add testing and scanning to your application](../getting-started/add-test-and-security.hbs.md#add-testing-and-scanning-to-your-application).
-VMware recommends using SCST - Scan 2.0 as SCST - Scan 1.0 will be removed in a future version and
-SCST - Scan 2.0 will be the default. For more information, see [SCST - Scan versions](./overview.hbs.md).
-
 The source scan step in the test and scan supply chain performs a Software
 Composition Analysis (SCA) scan to inspect the open source dependencies of an
 application for vulnerabilities. You perform this by inspecting the file that


### PR DESCRIPTION
We found bugs that are going to prevent us from deprecating Scan 1.0.   Reverting the announcements.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
