### PR TITLE
Adds http-proxy to the TDP TOC

### DIFF
--- a/toc.hbs.md
+++ b/toc.hbs.md
@@ -753,6 +753,7 @@
          - [Configure by using an existing certificate](tap-gui/tls/enable-tls-existing-cert.hbs.md)
          - [Configure by using a self-signed certificate](tap-gui/tls/enable-self-signed-cert.hbs.md)
          - [Configure by using cert-manager and ClusterIssuer](tap-gui/tls/cert-mngr-ext-clusterissuer.hbs.md)
+      - [Configure a Corporate HTTP Proxy](tap-gui/http-proxy.hbs.md)
       - [Upgrade Tanzu Developer Portal](tap-gui/upgrades.hbs.md)
       - [Troubleshoot Tanzu Developer Portal](tap-gui/troubleshooting.hbs.md)
     - [Tanzu Developer Tools for IntelliJ](intellij-extension/about.hbs.md)


### PR DESCRIPTION
This is also the thing that defines the side nav right? Really I want this to show up in the side nav so that folks can discover the doc.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
just this one, this is a new feature with 1.9

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
