### PR TITLE
Update release-notes.hbs.md adding N-2 upgrade support

### DIFF
--- a/release-notes.hbs.md
+++ b/release-notes.hbs.md
@@ -87,6 +87,11 @@ This release includes the following changes, listed by component and area.
   - Added graphs to display changes in Lead Time and Deployment Frequency metrics over time
   - Performance improvements
 
+#### <a id='1-9-0-tap-upgrade'></a> v1.9.0 Features: N-2 upgrade to TAP 1.9.x
+
+- TAP supports N-2 upgrades starting with 1.9.0, i.e, one can upgrade from TAP 1.7.x -> 1.9.x and TAP 1.8.x -> 1.9.x.
+
+
 ---
 
 ### <a id='1-9-0-breaking-changes'></a> v1.9.0 Breaking changes


### PR DESCRIPTION
Update release-notes.hbs.md adding N-2 upgrade support

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
Only into 1.9.x and above.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
