### PR TITLE
Minor fix in namespace provisioner docs

### DIFF
--- a/namespace-provisioner/use-case3.hbs.md
+++ b/namespace-provisioner/use-case3.hbs.md
@@ -264,7 +264,7 @@ To configure the service account to work with private Git repositories, follow t
         name: git
         annotations:
           tekton.dev/git-0: #@ data.values.imported.git.host
-      type: kubernetes.io/basic-auth
+      type: kubernetes.io/ssh-auth
       stringData:
         identity: #@ data.values.imported.git.identity
         identity.pub: #@ data.values.imported.git.identity_pub


### PR DESCRIPTION
Fix the code example for SSH git auth to create the correct secret type. The example as previously written failed to reconcile, because basic auth secrets require a username and password.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
This fix should apply to any branch that includes the ssh-auth secret.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
