### PR TITLE
Fixed typo in  integrate-lsp.hbs.md

### DIFF
--- a/cli-plugins/apps/how-to-guides/integrate-lsp.hbs.md
+++ b/cli-plugins/apps/how-to-guides/integrate-lsp.hbs.md
@@ -13,7 +13,7 @@ To check the installation and health of Local Source Proxy and determine if fail
 the Local Source Proxy or the upstream registry, run:
 
 ```console
-tanzu apps local-source-proxy health`
+tanzu apps local-source-proxy health
 ```
 
 This returns an overview of the health of the Local Source Proxy. This information is obtained


### PR DESCRIPTION

Fixing typo on the end of the `tanzu apps local-source-proxy health` command.

Without the `  at the end it executes successfully:
````
$ tanzu apps local-source-proxy health
user_has_permission: true
reachable: true
upstream_authenticated: true
overall_health: true
message: All health checks passed
````


# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
This typo exists on all existing versions of the documentation.
VMware Tanzu Application Platform 1.9
VMware Tanzu Application Platform 1.8
VMware Tanzu Application Platform 1.7
VMware Tanzu Application Platform 1.6
